### PR TITLE
Add three-level Ctrl+C signal handling for sessions

### DIFF
--- a/cli/src/strawpot/agents/interactive.py
+++ b/cli/src/strawpot/agents/interactive.py
@@ -175,6 +175,14 @@ class InteractiveWrapperRuntime:
         )
         _tmux(["kill-session", "-t", session])
 
+    def interrupt(self, handle: AgentHandle) -> bool:
+        """Forward Ctrl+C to the tmux pane."""
+        session = handle.metadata.get(
+            "session", _session_name(handle.agent_id)
+        )
+        _tmux(["send-keys", "-t", session, "C-c"])
+        return True
+
     def attach(self, handle: AgentHandle) -> None:
         """Attach the user's terminal to the tmux session.
 
@@ -293,6 +301,10 @@ class DirectWrapperRuntime:
         proc = self._procs.get(handle.agent_id)
         if proc is not None:
             proc.terminate()
+
+    def interrupt(self, handle: AgentHandle) -> bool:
+        """No-op — the agent already received SIGINT from the OS."""
+        return False
 
     def attach(self, handle: AgentHandle) -> None:
         """Wait for the process to complete.

--- a/cli/src/strawpot/agents/protocol.py
+++ b/cli/src/strawpot/agents/protocol.py
@@ -78,3 +78,16 @@ class AgentRuntime(Protocol):
     def kill(self, handle: AgentHandle) -> None:
         """Forcefully terminate the agent process."""
         ...
+
+    def interrupt(self, handle: AgentHandle) -> bool:
+        """Send a soft interrupt to cancel the agent's current task.
+
+        Returns ``True`` if the interrupt was explicitly forwarded to the
+        agent (e.g. via ``tmux send-keys``).  Returns ``False`` if the
+        agent already received the signal from the OS (direct mode) or
+        does not support interrupt (non-interactive).
+
+        The session layer uses the return value to decide whether to
+        stay at the interrupt level or escalate directly to shutdown.
+        """
+        ...

--- a/cli/src/strawpot/agents/wrapper.py
+++ b/cli/src/strawpot/agents/wrapper.py
@@ -255,3 +255,7 @@ class WrapperRuntime:
                 pass  # already exited
             except PermissionError:
                 pass  # Windows: race with process exit or access denied
+
+    def interrupt(self, handle: AgentHandle) -> bool:
+        """No-op — non-interactive agents do not support interrupt."""
+        return False

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -3,9 +3,12 @@
 import json
 import logging
 import os
+import signal
 import shutil
 import subprocess
+import sys
 import threading
+import time
 import uuid
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -243,6 +246,9 @@ class Session:
         self._agent_info: dict[str, dict] = {}
         self._session_file: str | None = None
         self._session_data: dict = {}
+        self._shutting_down: bool = False
+        self._interrupted: bool = False
+        self._last_sigint_time: float = 0.0
 
     # ------------------------------------------------------------------
     # Public interface
@@ -316,10 +322,15 @@ class Session:
             # 6. Write session state file
             self._write_session_file()
 
-            # 7. Attach — blocks until orchestrator exits
+            # 7. Install signal handler before blocking attach
+            original_sigint = signal.getsignal(signal.SIGINT)
+            signal.signal(signal.SIGINT, self._handle_sigint)
+
+            # 8. Attach — blocks until orchestrator exits
             self.runtime.attach(handle)
 
         finally:
+            signal.signal(signal.SIGINT, original_sigint)
             self.stop()
 
     def stop(self) -> None:
@@ -363,6 +374,70 @@ class Session:
 
         # 5. Remove session directory (includes session.json, agent workspaces, staged roles)
         self._remove_session_dir()
+
+    # ------------------------------------------------------------------
+    # Signal handling
+    # ------------------------------------------------------------------
+
+    _SIGINT_ESCALATION_WINDOW = 2.0
+
+    def _handle_sigint(self, signum, frame) -> None:
+        """Handle SIGINT (Ctrl+C) during session — three escalation levels.
+
+        1. **First press — Interrupt**: Forward interrupt to the agent
+           (cancel current task), keep the session alive.  If the runtime
+           reports that the agent already received SIGINT (direct mode),
+           escalate immediately to shutdown.
+        2. **Second press (within ~2 s) — Shutdown**: Kill the orchestrator
+           to unblock ``runtime.attach()`` so cleanup runs via ``finally``.
+        3. **Third press (during shutdown) — Force quit**: ``os._exit(1)``.
+        """
+        now = time.monotonic()
+
+        # Level 3: already shutting down → force quit
+        if self._shutting_down:
+            sys.stderr.write("\nForce quit.\n")
+            os._exit(1)
+
+        # Level 2: second Ctrl+C within window → shutdown
+        if (
+            self._interrupted
+            and (now - self._last_sigint_time) < self._SIGINT_ESCALATION_WINDOW
+        ):
+            self._shutdown_orchestrator()
+            return
+
+        # Level 1: first Ctrl+C (or re-interrupt after window expired)
+        self._interrupted = True
+        self._last_sigint_time = now
+
+        forwarded = False
+        if self._orchestrator_handle:
+            try:
+                forwarded = self.runtime.interrupt(self._orchestrator_handle)
+            except Exception:
+                pass
+
+        if forwarded:
+            # Interactive (tmux): interrupt was forwarded, wait for second Ctrl+C
+            sys.stderr.write(
+                "\nInterrupting agent... press Ctrl+C again within 2s to shut down.\n"
+            )
+        else:
+            # Direct mode: agent already got SIGINT, escalate to shutdown
+            self._shutdown_orchestrator()
+
+    def _shutdown_orchestrator(self) -> None:
+        """Kill the orchestrator and mark session as shutting down."""
+        self._shutting_down = True
+        sys.stderr.write(
+            "\nShutting down... press Ctrl+C again to force quit.\n"
+        )
+        if self._orchestrator_handle:
+            try:
+                self.runtime.kill(self._orchestrator_handle)
+            except Exception:
+                pass
 
     # ------------------------------------------------------------------
     # Merge strategies

--- a/cli/tests/test_agents_interactive.py
+++ b/cli/tests/test_agents_interactive.py
@@ -708,3 +708,55 @@ def test_direct_attach_unknown_noop():
         agent_id="unknown", runtime_name="claude-code", pid=None, metadata={},
     )
     runtime.attach(handle)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# interrupt
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_tmux
+def test_interrupt_sends_tmux_ctrl_c(monkeypatch):
+    """interrupt() sends Ctrl+C to the tmux session via send-keys."""
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _mock_completed()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    runtime = InteractiveWrapperRuntime(_make_inner())
+    handle = AgentHandle(
+        agent_id="int01",
+        runtime_name="claude-code",
+        pid=None,
+        metadata={"session": "strawpot-int00001"},
+    )
+    result = runtime.interrupt(handle)
+
+    assert result is True
+    assert any(
+        cmd[:2] == ["tmux", "send-keys"]
+        and "strawpot-int00001" in cmd
+        and "C-c" in cmd
+        for cmd in calls
+    )
+
+
+def test_direct_interrupt_is_noop():
+    """interrupt() is a no-op in direct mode (OS already sent SIGINT)."""
+    inner = _make_inner()
+    runtime = DirectWrapperRuntime(inner)
+
+    proc = MagicMock()
+    runtime._procs["d001"] = proc
+
+    handle = AgentHandle(
+        agent_id="d001", runtime_name="claude-code", pid=42, metadata={},
+    )
+    result = runtime.interrupt(handle)
+
+    assert result is False
+    # Verify no signals were sent to the process
+    proc.send_signal.assert_not_called()

--- a/cli/tests/test_agents_protocol.py
+++ b/cli/tests/test_agents_protocol.py
@@ -50,6 +50,9 @@ def test_agent_runtime_protocol():
         def kill(self, handle):
             pass
 
+        def interrupt(self, handle):
+            pass
+
     assert isinstance(FakeRuntime(), AgentRuntime)
 
 

--- a/cli/tests/test_session.py
+++ b/cli/tests/test_session.py
@@ -806,3 +806,215 @@ class TestRecoverStaleSessions:
 
         assert result == ["run_fail"]
         assert not os.path.exists(session_dir)
+
+
+# ---------------------------------------------------------------------------
+# Signal handling
+# ---------------------------------------------------------------------------
+
+
+class TestSignalHandling:
+    """Tests for three-level Ctrl+C handling.
+
+    By default ``_mock_runtime().interrupt()`` returns a truthy MagicMock,
+    simulating interactive (tmux) mode where the interrupt is forwarded.
+    Tests for direct mode explicitly set ``interrupt.return_value = False``.
+    """
+
+    # -- Interactive (tmux) mode: interrupt forwarded --
+
+    def test_interactive_first_sigint_sets_interrupted(self, tmp_path):
+        """First SIGINT sets _interrupted flag but NOT _shutting_down (tmux)."""
+        runtime = _mock_runtime()
+        session = _make_session(tmp_path, runtime=runtime)
+        session._orchestrator_handle = runtime.spawn.return_value
+
+        with patch("strawpot.session.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            session._handle_sigint(None, None)
+
+        assert session._interrupted is True
+        assert session._shutting_down is False
+
+    def test_interactive_first_sigint_forwards_interrupt(self, tmp_path):
+        """First SIGINT calls runtime.interrupt() — NOT kill() (tmux)."""
+        runtime = _mock_runtime()
+        session = _make_session(tmp_path, runtime=runtime)
+        handle = runtime.spawn.return_value
+        session._orchestrator_handle = handle
+
+        with patch("strawpot.session.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            session._handle_sigint(None, None)
+
+        runtime.interrupt.assert_called_once_with(handle)
+        runtime.kill.assert_not_called()
+
+    def test_interactive_second_sigint_within_window_shuts_down(self, tmp_path):
+        """Second SIGINT within 2s kills orchestrator (tmux)."""
+        runtime = _mock_runtime()
+        session = _make_session(tmp_path, runtime=runtime)
+        handle = runtime.spawn.return_value
+        session._orchestrator_handle = handle
+
+        with patch("strawpot.session.time") as mock_time:
+            mock_time.monotonic.side_effect = [100.0, 101.0]
+            session._handle_sigint(None, None)  # Level 1: interrupt
+            session._handle_sigint(None, None)  # Level 2: shutdown
+
+        assert session._shutting_down is True
+        runtime.kill.assert_called_once_with(handle)
+
+    def test_interactive_second_sigint_outside_window_reinterrupts(self, tmp_path):
+        """Second SIGINT after 2s resets to Level 1 (tmux)."""
+        runtime = _mock_runtime()
+        session = _make_session(tmp_path, runtime=runtime)
+        handle = runtime.spawn.return_value
+        session._orchestrator_handle = handle
+
+        with patch("strawpot.session.time") as mock_time:
+            mock_time.monotonic.side_effect = [100.0, 103.0]
+            session._handle_sigint(None, None)
+            session._handle_sigint(None, None)
+
+        assert session._interrupted is True
+        assert session._shutting_down is False
+        assert runtime.interrupt.call_count == 2
+        runtime.kill.assert_not_called()
+
+    def test_interactive_full_three_levels(self, tmp_path):
+        """Full sequence: interrupt → shutdown → force quit (tmux)."""
+        runtime = _mock_runtime()
+        session = _make_session(tmp_path, runtime=runtime)
+        session._orchestrator_handle = runtime.spawn.return_value
+
+        with patch("strawpot.session.time") as mock_time:
+            mock_time.monotonic.side_effect = [100.0, 101.0]
+            session._handle_sigint(None, None)   # Level 1: interrupt
+            session._handle_sigint(None, None)   # Level 2: shutdown
+
+        assert session._shutting_down is True
+
+        with patch("os._exit") as mock_exit:
+            session._handle_sigint(None, None)   # Level 3: force quit
+
+        mock_exit.assert_called_once_with(1)
+
+    # -- Direct mode: interrupt not forwarded, escalate immediately --
+
+    def test_direct_first_sigint_escalates_to_shutdown(self, tmp_path):
+        """First SIGINT in direct mode skips interrupt and shuts down."""
+        runtime = _mock_runtime()
+        runtime.interrupt.return_value = False
+        session = _make_session(tmp_path, runtime=runtime)
+        handle = runtime.spawn.return_value
+        session._orchestrator_handle = handle
+
+        with patch("strawpot.session.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            session._handle_sigint(None, None)
+
+        assert session._shutting_down is True
+        runtime.kill.assert_called_once_with(handle)
+
+    def test_direct_second_sigint_force_quits(self, tmp_path):
+        """Second SIGINT in direct mode force-quits (only two levels)."""
+        runtime = _mock_runtime()
+        runtime.interrupt.return_value = False
+        session = _make_session(tmp_path, runtime=runtime)
+        session._orchestrator_handle = runtime.spawn.return_value
+
+        with patch("strawpot.session.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            session._handle_sigint(None, None)   # Level 1 → shutdown
+
+        with patch("os._exit") as mock_exit:
+            session._handle_sigint(None, None)   # Level 2 → force quit
+
+        mock_exit.assert_called_once_with(1)
+
+    # -- Common behavior (both modes) --
+
+    def test_first_sigint_no_orchestrator(self, tmp_path):
+        """First SIGINT with no orchestrator handle does not crash."""
+        session = _make_session(tmp_path)
+        session._orchestrator_handle = None
+
+        with patch("strawpot.session.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            session._handle_sigint(None, None)
+
+        assert session._interrupted is True
+        # No handle → interrupt not called → forwarded=False → shutdown
+        assert session._shutting_down is True
+
+    def test_first_sigint_interrupt_failure_escalates(self, tmp_path):
+        """If runtime.interrupt() raises, escalate to shutdown."""
+        runtime = _mock_runtime()
+        runtime.interrupt.side_effect = RuntimeError("tmux not found")
+        session = _make_session(tmp_path, runtime=runtime)
+        session._orchestrator_handle = runtime.spawn.return_value
+
+        with patch("strawpot.session.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            session._handle_sigint(None, None)
+
+        # Exception → forwarded stays False → shutdown
+        assert session._shutting_down is True
+
+    def test_force_quit_during_shutdown(self, tmp_path):
+        """SIGINT during shutdown calls os._exit(1)."""
+        session = _make_session(tmp_path)
+        session._shutting_down = True
+
+        with patch("os._exit") as mock_exit:
+            session._handle_sigint(None, None)
+
+        mock_exit.assert_called_once_with(1)
+
+    def test_shutdown_kill_failure_still_sets_flag(self, tmp_path):
+        """If runtime.kill() fails during shutdown, _shutting_down is still set."""
+        runtime = _mock_runtime()
+        runtime.kill.side_effect = RuntimeError("tmux error")
+        session = _make_session(tmp_path, runtime=runtime)
+        session._orchestrator_handle = runtime.spawn.return_value
+
+        with patch("strawpot.session.time") as mock_time:
+            mock_time.monotonic.side_effect = [100.0, 101.0]
+            session._handle_sigint(None, None)  # Level 1
+            session._handle_sigint(None, None)  # Level 2 (kill fails)
+
+        assert session._shutting_down is True
+
+    @patch("strawpot.session.DenDenServer")
+    def test_handler_installed_and_restored(self, mock_server_cls, tmp_path):
+        """Signal handler is installed before attach and restored after stop."""
+        import signal
+
+        isolator = _mock_isolator()
+        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
+        runtime = _mock_runtime()
+        session = _make_session(
+            tmp_path, isolator=isolator, runtime=runtime
+        )
+
+        original = signal.getsignal(signal.SIGINT)
+        session.start(str(tmp_path))
+        restored = signal.getsignal(signal.SIGINT)
+
+        assert restored is original
+
+    @patch("strawpot.session.DenDenServer")
+    def test_stop_runs_after_shutdown(self, mock_server_cls, tmp_path):
+        """stop() runs via finally block after shutdown kills orchestrator."""
+        isolator = _mock_isolator()
+        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
+        runtime = _mock_runtime()
+        session = _make_session(
+            tmp_path, isolator=isolator, runtime=runtime
+        )
+
+        with patch.object(session, "stop") as mock_stop:
+            session.start(str(tmp_path))
+
+        mock_stop.assert_called_once()


### PR DESCRIPTION
## Summary
- Add `interrupt()` method to `AgentRuntime` protocol with `bool` return value indicating whether the interrupt was forwarded to the agent
- Implement three-level Ctrl+C escalation in `Session._handle_sigint()`:
  - **Tmux mode**: interrupt (forward Ctrl+C) → shutdown (kill orchestrator) → force quit
  - **Direct mode**: shutdown (agent already got SIGINT from OS) → force quit
- Extract `_shutdown_orchestrator()` helper to reduce duplication in signal handler

## Test plan
- [x] 13 signal handling tests covering both interactive and direct mode behavior
- [x] 2 interrupt tests for tmux send-keys and direct no-op
- [x] Protocol test updated for new `interrupt()` method
- [x] All 280 tests pass (`pytest cli/tests/ -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)