### PR TITLE
Add noninteractive mode with --task option

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -56,7 +56,8 @@ def cli():
 )
 @click.option("--host", default=None, help="Denden server host.")
 @click.option("--port", default=None, type=int, help="Denden server port.")
-def start(role, runtime, isolation, merge_strategy, pull, host, port):
+@click.option("--task", default=None, help="Run noninteractively with a task string.")
+def start(role, runtime, isolation, merge_strategy, pull, host, port, task):
     """Start an orchestration session.
 
     Runs in the foreground — creates an isolated environment (if configured),
@@ -111,7 +112,9 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port):
 
     # 3. Build runtimes (session_dir set later by Session.start())
     wrapper = WrapperRuntime(spec)
-    if shutil.which("tmux"):
+    if task:
+        rt = DirectWrapperRuntime(wrapper)
+    elif shutil.which("tmux"):
         rt = InteractiveWrapperRuntime(wrapper)
     else:
         rt = DirectWrapperRuntime(wrapper)
@@ -141,6 +144,7 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port):
         isolator=isolator,
         resolve_role=_resolve_role,
         resolve_role_dirs=_resolve_role_dirs,
+        task=task or "",
     )
     session.start(working_dir)
 

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -228,11 +228,13 @@ class Session:
         *,
         resolve_role: Callable[..., dict],
         resolve_role_dirs: Callable[[str], str | None],
+        task: str = "",
     ) -> None:
         self.config = config
         self.wrapper = wrapper
         self.runtime = runtime
         self.isolator = isolator
+        self.task = task
         self._resolve_role = resolve_role
         self._resolve_role_dirs = resolve_role_dirs
 
@@ -308,7 +310,7 @@ class Session:
                 memory_prompt="",
                 skills_dir=skills_dir,
                 roles_dirs=[roles_dir],
-                task="",
+                task=self.task,
                 env=env,
             )
             self._orchestrator_handle = handle
@@ -326,8 +328,13 @@ class Session:
             original_sigint = signal.getsignal(signal.SIGINT)
             signal.signal(signal.SIGINT, self._handle_sigint)
 
-            # 8. Attach — blocks until orchestrator exits
-            self.runtime.attach(handle)
+            # 8. Block until orchestrator exits
+            if self.task:
+                result = self.runtime.wait(handle)
+                if result.exit_code != 0:
+                    sys.exit(result.exit_code)
+            else:
+                self.runtime.attach(handle)
 
         finally:
             signal.signal(signal.SIGINT, original_sigint)

--- a/cli/tests/test_session.py
+++ b/cli/tests/test_session.py
@@ -1018,3 +1018,122 @@ class TestSignalHandling:
             session.start(str(tmp_path))
 
         mock_stop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Noninteractive mode (--task)
+# ---------------------------------------------------------------------------
+
+
+class TestNoninteractiveMode:
+    @patch("strawpot.session.DenDenServer")
+    def test_spawn_receives_task(self, mock_server_cls, tmp_path):
+        """spawn() receives the task string when --task is given."""
+        isolator = _mock_isolator()
+        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
+        runtime = _mock_runtime()
+        session = _make_session(
+            tmp_path, isolator=isolator, runtime=runtime, task="fix the bug"
+        )
+
+        session.start(str(tmp_path))
+
+        kw = runtime.spawn.call_args.kwargs
+        assert kw["task"] == "fix the bug"
+
+    @patch("strawpot.session.DenDenServer")
+    def test_wait_called_instead_of_attach(self, mock_server_cls, tmp_path):
+        """Noninteractive mode calls wait() instead of attach()."""
+        isolator = _mock_isolator()
+        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
+        runtime = _mock_runtime()
+        session = _make_session(
+            tmp_path, isolator=isolator, runtime=runtime, task="do something"
+        )
+
+        session.start(str(tmp_path))
+
+        runtime.wait.assert_called_once()
+        runtime.attach.assert_not_called()
+
+    @patch("strawpot.session.DenDenServer")
+    def test_attach_called_when_no_task(self, mock_server_cls, tmp_path):
+        """Interactive mode (no task) calls attach() as before."""
+        isolator = _mock_isolator()
+        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
+        runtime = _mock_runtime()
+        session = _make_session(
+            tmp_path, isolator=isolator, runtime=runtime
+        )
+
+        session.start(str(tmp_path))
+
+        runtime.attach.assert_called_once()
+        runtime.wait.assert_not_called()
+
+    @patch("strawpot.session.DenDenServer")
+    def test_nonzero_exit_code(self, mock_server_cls, tmp_path):
+        """sys.exit() is called with the agent's nonzero exit code."""
+        isolator = _mock_isolator()
+        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
+        runtime = _mock_runtime()
+        runtime.wait.return_value = AgentResult(
+            summary="Failed", exit_code=1
+        )
+        session = _make_session(
+            tmp_path, isolator=isolator, runtime=runtime, task="fail"
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            session.start(str(tmp_path))
+
+        assert exc_info.value.code == 1
+
+    @patch("strawpot.session.DenDenServer")
+    def test_zero_exit_code_no_sys_exit(self, mock_server_cls, tmp_path):
+        """No sys.exit() on success (exit code 0)."""
+        isolator = _mock_isolator()
+        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
+        runtime = _mock_runtime()
+        runtime.wait.return_value = AgentResult(
+            summary="Done", exit_code=0
+        )
+        session = _make_session(
+            tmp_path, isolator=isolator, runtime=runtime, task="succeed"
+        )
+
+        # Should not raise SystemExit
+        session.start(str(tmp_path))
+
+    @patch("strawpot.session.DenDenServer")
+    def test_signal_handler_still_installed(self, mock_server_cls, tmp_path):
+        """Signal handler is installed and restored in noninteractive mode."""
+        import signal
+
+        isolator = _mock_isolator()
+        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
+        runtime = _mock_runtime()
+        session = _make_session(
+            tmp_path, isolator=isolator, runtime=runtime, task="a task"
+        )
+
+        original = signal.getsignal(signal.SIGINT)
+        session.start(str(tmp_path))
+        restored = signal.getsignal(signal.SIGINT)
+
+        assert restored is original
+
+    @patch("strawpot.session.DenDenServer")
+    def test_stop_runs_after_task_completes(self, mock_server_cls, tmp_path):
+        """stop() runs via finally block after task completion."""
+        isolator = _mock_isolator()
+        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
+        runtime = _mock_runtime()
+        session = _make_session(
+            tmp_path, isolator=isolator, runtime=runtime, task="a task"
+        )
+
+        with patch.object(session, "stop") as mock_stop:
+            session.start(str(tmp_path))
+
+        mock_stop.assert_called_once()


### PR DESCRIPTION
## Summary
- Add `--task` option to `strawpot start` for noninteractive execution
- When `--task` is given, uses `DirectWrapperRuntime` (no tmux) so agent output streams to the terminal in real time
- `Session.start()` calls `runtime.wait()` instead of `runtime.attach()` and propagates the agent's exit code via `sys.exit()`

## Test plan
- [x] 7 noninteractive mode tests covering task passthrough, wait vs attach branching, exit code propagation, signal handler, and cleanup
- [x] All 287 tests pass (`pytest cli/tests/ -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)