### PR TITLE
Add delegation retry policy for output format validation

### DIFF
--- a/cli/src/strawpot/config.py
+++ b/cli/src/strawpot/config.py
@@ -30,6 +30,7 @@ class StrawPotConfig:
     max_depth: int = 3
     permission_mode: str = "default"
     agent_timeout: int | None = None
+    max_delegate_retries: int = 0
     agents: dict[str, dict] = field(default_factory=dict)
     merge_strategy: str = "auto"
     pull_before_session: str = "prompt"
@@ -68,6 +69,8 @@ def _apply(config: StrawPotConfig, data: dict) -> None:
         config.max_depth = policy["max_depth"]
     if "agent_timeout" in policy:
         config.agent_timeout = policy["agent_timeout"]
+    if "max_delegate_retries" in policy:
+        config.max_delegate_retries = policy["max_delegate_retries"]
 
     agents = data.get("agents", {})
     for name, agent_data in agents.items():

--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -1,5 +1,7 @@
 """Delegate handler — policy check, resolve, build prompt, spawn, wait."""
 
+import json
+import logging
 import os
 import shutil
 import uuid
@@ -10,6 +12,8 @@ from pathlib import Path
 from strawpot.agents.protocol import AgentHandle, AgentResult, AgentRuntime
 from strawpot.config import StrawPotConfig
 from strawpot.context import build_prompt, parse_frontmatter, read_role_description
+
+logger = logging.getLogger(__name__)
 
 
 class DelegationError(Exception):
@@ -34,6 +38,7 @@ class DelegateRequest:
     parent_role: str
     run_id: str
     depth: int
+    return_format: str = "TEXT"
 
 
 @dataclass
@@ -57,6 +62,23 @@ def _check_policy(
         raise PolicyDenied("DENY_ROLE_NOT_ALLOWED")
     if request.depth + 1 > config.max_depth:
         raise PolicyDenied("DENY_DEPTH_LIMIT")
+
+
+def _validate_output(output: str, return_format: str) -> str | None:
+    """Validate agent output against the requested format.
+
+    Returns None if valid, or an error message string if not.
+    """
+    if return_format.strip().upper() != "JSON":
+        return None
+    stripped = output.strip()
+    if not stripped:
+        return "Output is empty; expected valid JSON."
+    try:
+        json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        return f"Output is not valid JSON: {exc}"
+    return None
 
 
 def _symlink(src: str, dst: str) -> None:
@@ -339,59 +361,112 @@ def handle_delegate(
     # 5. Stage role (session-level, idempotent)
     skills_dir, roles_dir = stage_role(session_dir, resolved)
 
-    # 6. Create agent workspace
-    agent_id = f"agent_{uuid.uuid4().hex[:12]}"
-    workspace = create_agent_workspace(session_dir, agent_id)
+    # 6-9. Spawn/wait loop with retry on format validation failure
+    max_attempts = 1 + config.max_delegate_retries
+    task_text = request.task_text
+    result: AgentResult | None = None
 
-    # 6b. Link requester role into session-level per-agent dir
-    roles_dirs = [roles_dir]
-    requester_role_dir = resolve_role_dirs(request.parent_role)
-    if requester_role_dir is not None:
-        req_roles_dir = os.path.join(
-            session_dir, "requester_roles", agent_id
-        )
-        req_dest = os.path.join(req_roles_dir, request.parent_role)
-        if not os.path.exists(req_dest):
-            os.makedirs(req_roles_dir, exist_ok=True)
-            _symlink(requester_role_dir, req_dest)
-        roles_dirs.append(req_roles_dir)
+    for attempt in range(max_attempts):
+        # 6. Create agent workspace (fresh per attempt)
+        agent_id = f"agent_{uuid.uuid4().hex[:12]}"
+        workspace = create_agent_workspace(session_dir, agent_id)
 
-    # 7. Spawn
-    env = {
-        "DENDEN_ADDR": config.denden_addr,
-        "DENDEN_AGENT_ID": agent_id,
-        "DENDEN_PARENT_AGENT_ID": request.parent_agent_id,
-        "DENDEN_RUN_ID": request.run_id,
-        "PERMISSION_MODE": "auto",
-    }
+        # 6b. Link requester role into session-level per-agent dir
+        roles_dirs = [roles_dir]
+        requester_role_dir = resolve_role_dirs(request.parent_role)
+        if requester_role_dir is not None:
+            req_roles_dir = os.path.join(
+                session_dir, "requester_roles", agent_id
+            )
+            req_dest = os.path.join(req_roles_dir, request.parent_role)
+            if not os.path.exists(req_dest):
+                os.makedirs(req_roles_dir, exist_ok=True)
+                _symlink(requester_role_dir, req_dest)
+            roles_dirs.append(req_roles_dir)
 
-    handle: AgentHandle = runtime.spawn(
-        agent_id=agent_id,
-        working_dir=working_dir,
-        agent_workspace_dir=workspace,
-        role_prompt=role_prompt,
-        memory_prompt="",
-        skills_dir=skills_dir,
-        roles_dirs=roles_dirs,
-        task=request.task_text,
-        env=env,
-    )
+        # 7. Spawn
+        env = {
+            "DENDEN_ADDR": config.denden_addr,
+            "DENDEN_AGENT_ID": agent_id,
+            "DENDEN_PARENT_AGENT_ID": request.parent_agent_id,
+            "DENDEN_RUN_ID": request.run_id,
+            "PERMISSION_MODE": "auto",
+        }
 
-    # 8. Wait
-    result: AgentResult = runtime.wait(
-        handle, timeout=config.agent_timeout
-    )
-
-    # 8b. Handle timeout — kill agent if still alive
-    if config.agent_timeout is not None and runtime.is_alive(handle):
-        runtime.kill(handle)
-        return DelegateResult(
-            summary=f"Agent timed out after {config.agent_timeout}s",
-            output=result.output,
-            exit_code=1,
+        handle: AgentHandle = runtime.spawn(
+            agent_id=agent_id,
+            working_dir=working_dir,
+            agent_workspace_dir=workspace,
+            role_prompt=role_prompt,
+            memory_prompt="",
+            skills_dir=skills_dir,
+            roles_dirs=roles_dirs,
+            task=task_text,
+            env=env,
         )
 
-    # 9. Return
+        # 8. Wait
+        result = runtime.wait(handle, timeout=config.agent_timeout)
+
+        # 8b. Handle timeout — no retry on timeout
+        if config.agent_timeout is not None and runtime.is_alive(handle):
+            runtime.kill(handle)
+            return DelegateResult(
+                summary=f"Agent timed out after {config.agent_timeout}s",
+                output=result.output,
+                exit_code=1,
+            )
+
+        # 8c. No retry on non-zero exit
+        if result.exit_code != 0:
+            return DelegateResult(
+                summary=result.summary,
+                output=result.output,
+                exit_code=result.exit_code,
+            )
+
+        # 8d. Validate output format
+        validation_error = _validate_output(
+            result.output, request.return_format
+        )
+        if validation_error is None:
+            return DelegateResult(
+                summary=result.summary,
+                output=result.output,
+                exit_code=result.exit_code,
+            )
+
+        # 8e. Validation failed — retry or give up
+        if attempt == max_attempts - 1:
+            logger.warning(
+                "Delegation to %s failed format validation after %d "
+                "attempt(s): %s",
+                request.role_slug,
+                max_attempts,
+                validation_error,
+            )
+            return DelegateResult(
+                summary=result.summary,
+                output=result.output,
+                exit_code=result.exit_code,
+            )
+
+        logger.info(
+            "Retrying delegation to %s (attempt %d/%d): %s",
+            request.role_slug,
+            attempt + 2,
+            max_attempts,
+            validation_error,
+        )
+        task_text = (
+            f"{request.task_text}\n\n"
+            f"[RETRY: Your previous output was not valid JSON. "
+            f"{validation_error} "
+            f"Please output valid JSON only.]"
+        )
+
+    # Defensive: should never reach here
+    assert result is not None
     return DelegateResult(
         summary=result.summary,
         output=result.output,

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -539,6 +539,9 @@ class Session:
         payload = request.delegate
         trace = request.trace
 
+        fmt = payload.task.return_format
+        return_format = "JSON" if fmt == denden_pb2.JSON else "TEXT"
+
         delegate_req = DelegateRequest(
             role_slug=payload.delegate_to,
             task_text=payload.task.text,
@@ -546,6 +549,7 @@ class Session:
             parent_role=self._agent_role(trace.agent_instance_id),
             run_id=trace.run_id,
             depth=self._agent_depth(trace.agent_instance_id),
+            return_format=return_format,
         )
 
         try:

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -15,6 +15,7 @@ def test_defaults():
     assert config.max_depth == 3
     assert config.permission_mode == "default"
     assert config.agent_timeout is None
+    assert config.max_delegate_retries == 0
     assert config.agents == {}
     assert config.merge_strategy == "auto"
     assert config.pull_before_session == "prompt"
@@ -88,6 +89,7 @@ def test_load_config_full(tmp_path, monkeypatch):
         'allowed_roles = ["implementer", "reviewer"]\n'
         "max_depth = 5\n"
         "agent_timeout = 300\n"
+        "max_delegate_retries = 2\n"
         "\n"
         "[session]\n"
         'merge_strategy = "pr"\n'
@@ -107,6 +109,7 @@ def test_load_config_full(tmp_path, monkeypatch):
     assert config.max_depth == 5
     assert config.permission_mode == "plan"
     assert config.agent_timeout == 300
+    assert config.max_delegate_retries == 2
     assert config.agents == {"claude_code": {"model": "claude-sonnet-4-6"}}
     assert config.merge_strategy == "pr"
     assert config.pull_before_session == "auto"

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -16,6 +16,7 @@ from strawpot.delegation import (
     _collect_transitive_skills,
     _parse_role_deps,
     _parse_skill_deps,
+    _validate_output,
     create_agent_workspace,
     handle_delegate,
     stage_role,
@@ -107,6 +108,7 @@ def _make_request(**overrides):
         "parent_role": "orchestrator",
         "run_id": "run_abc",
         "depth": 0,
+        "return_format": "TEXT",
     }
     defaults.update(overrides)
     return DelegateRequest(**defaults)
@@ -171,6 +173,46 @@ class TestCheckPolicy:
         config = _make_config(max_depth=1)
         request = _make_request(depth=0)
         _check_policy(request, config)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Output format validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateOutput:
+    def test_text_format_always_passes(self):
+        """TEXT format never fails validation."""
+        assert _validate_output("anything", "TEXT") is None
+        assert _validate_output("", "TEXT") is None
+        assert _validate_output("{not json", "TEXT") is None
+
+    def test_json_valid(self):
+        """Valid JSON passes validation."""
+        assert _validate_output('{"key": "value"}', "JSON") is None
+        assert _validate_output("[1, 2, 3]", "JSON") is None
+        assert _validate_output('"just a string"', "JSON") is None
+
+    def test_json_valid_with_whitespace(self):
+        """Leading/trailing whitespace is tolerated."""
+        assert _validate_output('  {"key": 1}  \n', "JSON") is None
+
+    def test_json_empty_output(self):
+        """Empty output fails JSON validation."""
+        error = _validate_output("", "JSON")
+        assert error is not None
+        assert "empty" in error.lower()
+
+    def test_json_invalid(self):
+        """Invalid JSON returns an error message."""
+        error = _validate_output("not json at all", "JSON")
+        assert error is not None
+        assert "not valid JSON" in error
+
+    def test_json_partial(self):
+        """Partial JSON fails validation."""
+        error = _validate_output('{"key": ', "JSON")
+        assert error is not None
 
 
 # ---------------------------------------------------------------------------
@@ -924,6 +966,222 @@ class TestSpawnAndWait:
         )
 
         runtime.kill.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Retry policy
+# ---------------------------------------------------------------------------
+
+
+class TestRetryPolicy:
+    """Tests for delegation retry on format validation failure."""
+
+    def _resolved(self, tmp_path):
+        base = str(tmp_path / "registry")
+        role_path = _write_role(base, "implementer", "Implement.")
+        return {
+            "slug": "implementer",
+            "kind": "role",
+            "version": "1.0",
+            "path": role_path,
+            "source": "local",
+            "dependencies": [],
+        }
+
+    def test_no_retry_when_text_format(self, tmp_path):
+        """TEXT format: no retry even if max_delegate_retries > 0."""
+        runtime = _mock_runtime(output="not json")
+        result = handle_delegate(
+            request=_make_request(return_format="TEXT"),
+            config=_make_config(max_delegate_retries=3),
+            runtime=runtime,
+            working_dir=str(tmp_path / "work"),
+            session_dir=str(tmp_path / "session"),
+            resolve_role=lambda slug, kind="role": self._resolved(tmp_path),
+            resolve_role_dirs=lambda s: None,
+        )
+        runtime.spawn.assert_called_once()
+        assert result.output == "not json"
+
+    def test_no_retry_when_retries_zero(self, tmp_path):
+        """Default config (retries=0): never retries."""
+        runtime = _mock_runtime(output="not json")
+        result = handle_delegate(
+            request=_make_request(return_format="JSON"),
+            config=_make_config(max_delegate_retries=0),
+            runtime=runtime,
+            working_dir=str(tmp_path / "work"),
+            session_dir=str(tmp_path / "session"),
+            resolve_role=lambda slug, kind="role": self._resolved(tmp_path),
+            resolve_role_dirs=lambda s: None,
+        )
+        runtime.spawn.assert_called_once()
+        assert result.output == "not json"
+
+    def test_retry_on_invalid_json(self, tmp_path):
+        """JSON format with retries=1: retries once on invalid output."""
+        runtime = MagicMock()
+        runtime.name = "mock_runtime"
+        runtime.spawn.return_value = AgentHandle(
+            agent_id="agent_test", runtime_name="mock_runtime", pid=999
+        )
+        runtime.wait.side_effect = [
+            AgentResult(summary="Done", output="not json", exit_code=0),
+            AgentResult(summary="Done", output='{"ok": true}', exit_code=0),
+        ]
+        runtime.is_alive.return_value = False
+
+        result = handle_delegate(
+            request=_make_request(return_format="JSON"),
+            config=_make_config(max_delegate_retries=1),
+            runtime=runtime,
+            working_dir=str(tmp_path / "work"),
+            session_dir=str(tmp_path / "session"),
+            resolve_role=lambda slug, kind="role": self._resolved(tmp_path),
+            resolve_role_dirs=lambda s: None,
+        )
+        assert runtime.spawn.call_count == 2
+        assert result.output == '{"ok": true}'
+
+    def test_retry_hint_in_task_text(self, tmp_path):
+        """On retry, task text includes [RETRY: ...] hint."""
+        runtime = MagicMock()
+        runtime.name = "mock_runtime"
+        runtime.spawn.return_value = AgentHandle(
+            agent_id="agent_test", runtime_name="mock_runtime", pid=999
+        )
+        runtime.wait.side_effect = [
+            AgentResult(summary="Done", output="bad", exit_code=0),
+            AgentResult(summary="Done", output='"ok"', exit_code=0),
+        ]
+        runtime.is_alive.return_value = False
+
+        handle_delegate(
+            request=_make_request(
+                return_format="JSON", task_text="Do something"
+            ),
+            config=_make_config(max_delegate_retries=1),
+            runtime=runtime,
+            working_dir=str(tmp_path / "work"),
+            session_dir=str(tmp_path / "session"),
+            resolve_role=lambda slug, kind="role": self._resolved(tmp_path),
+            resolve_role_dirs=lambda s: None,
+        )
+        second_call = runtime.spawn.call_args_list[1]
+        task = second_call.kwargs["task"]
+        assert "Do something" in task
+        assert "[RETRY:" in task
+        assert "valid JSON" in task
+
+    def test_retry_exhaustion(self, tmp_path):
+        """All retries fail: returns last attempt's result."""
+        runtime = MagicMock()
+        runtime.name = "mock_runtime"
+        runtime.spawn.return_value = AgentHandle(
+            agent_id="agent_test", runtime_name="mock_runtime", pid=999
+        )
+        runtime.wait.side_effect = [
+            AgentResult(summary="Done", output="bad1", exit_code=0),
+            AgentResult(summary="Done", output="bad2", exit_code=0),
+            AgentResult(summary="Done", output="bad3", exit_code=0),
+        ]
+        runtime.is_alive.return_value = False
+
+        result = handle_delegate(
+            request=_make_request(return_format="JSON"),
+            config=_make_config(max_delegate_retries=2),
+            runtime=runtime,
+            working_dir=str(tmp_path / "work"),
+            session_dir=str(tmp_path / "session"),
+            resolve_role=lambda slug, kind="role": self._resolved(tmp_path),
+            resolve_role_dirs=lambda s: None,
+        )
+        assert runtime.spawn.call_count == 3
+        assert result.output == "bad3"
+
+    def test_fresh_agent_id_per_retry(self, tmp_path):
+        """Each retry gets a unique agent_id."""
+        runtime = MagicMock()
+        runtime.name = "mock_runtime"
+        runtime.spawn.return_value = AgentHandle(
+            agent_id="agent_test", runtime_name="mock_runtime", pid=999
+        )
+        runtime.wait.side_effect = [
+            AgentResult(summary="Done", output="bad", exit_code=0),
+            AgentResult(summary="Done", output='"ok"', exit_code=0),
+        ]
+        runtime.is_alive.return_value = False
+
+        handle_delegate(
+            request=_make_request(return_format="JSON"),
+            config=_make_config(max_delegate_retries=1),
+            runtime=runtime,
+            working_dir=str(tmp_path / "work"),
+            session_dir=str(tmp_path / "session"),
+            resolve_role=lambda slug, kind="role": self._resolved(tmp_path),
+            resolve_role_dirs=lambda s: None,
+        )
+        ids = [c.kwargs["agent_id"] for c in runtime.spawn.call_args_list]
+        assert len(ids) == 2
+        assert ids[0] != ids[1]
+
+    def test_no_retry_on_timeout(self, tmp_path):
+        """Timeout during attempt: returns immediately, no retry."""
+        runtime = MagicMock()
+        runtime.name = "mock_runtime"
+        runtime.spawn.return_value = AgentHandle(
+            agent_id="agent_test", runtime_name="mock_runtime", pid=999
+        )
+        runtime.wait.return_value = AgentResult(
+            summary="Done", output="partial", exit_code=0
+        )
+        runtime.is_alive.return_value = True
+
+        result = handle_delegate(
+            request=_make_request(return_format="JSON"),
+            config=_make_config(max_delegate_retries=3, agent_timeout=60),
+            runtime=runtime,
+            working_dir=str(tmp_path / "work"),
+            session_dir=str(tmp_path / "session"),
+            resolve_role=lambda slug, kind="role": self._resolved(tmp_path),
+            resolve_role_dirs=lambda s: None,
+        )
+        runtime.spawn.assert_called_once()
+        runtime.kill.assert_called_once()
+        assert result.exit_code == 1
+        assert "timed out" in result.summary
+
+    def test_no_retry_on_nonzero_exit(self, tmp_path):
+        """Non-zero exit: returns immediately, no retry."""
+        runtime = _mock_runtime(summary="Crashed", output="error", exit_code=1)
+        runtime.is_alive.return_value = False
+
+        result = handle_delegate(
+            request=_make_request(return_format="JSON"),
+            config=_make_config(max_delegate_retries=3),
+            runtime=runtime,
+            working_dir=str(tmp_path / "work"),
+            session_dir=str(tmp_path / "session"),
+            resolve_role=lambda slug, kind="role": self._resolved(tmp_path),
+            resolve_role_dirs=lambda s: None,
+        )
+        runtime.spawn.assert_called_once()
+        assert result.exit_code == 1
+
+    def test_valid_json_first_attempt_no_retry(self, tmp_path):
+        """Valid JSON on first attempt: returns immediately."""
+        runtime = _mock_runtime(output='{"result": 42}')
+        result = handle_delegate(
+            request=_make_request(return_format="JSON"),
+            config=_make_config(max_delegate_retries=3),
+            runtime=runtime,
+            working_dir=str(tmp_path / "work"),
+            session_dir=str(tmp_path / "session"),
+            resolve_role=lambda slug, kind="role": self._resolved(tmp_path),
+            resolve_role_dirs=lambda s: None,
+        )
+        runtime.spawn.assert_called_once()
+        assert result.output == '{"result": 42}'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `max_delegate_retries` config field under `[policy]` (default `0` = off)
- When `return_format=JSON`, validates sub-agent output is valid JSON after each attempt
- On validation failure, retries with a `[RETRY: ...]` hint appended to the task text
- No retry on timeout or non-zero exit — only format validation failures trigger retries
- Extracts `Task.return_format` from the denden proto in `session.py` and passes it through

## Test plan
- [x] 6 new `TestValidateOutput` tests (TEXT always passes, valid/invalid/empty JSON, whitespace tolerance)
- [x] 9 new `TestRetryPolicy` tests (no retry for TEXT, retries=0, retry on invalid JSON, hint text, exhaustion, fresh agent_id, no retry on timeout/non-zero exit, valid first attempt)
- [x] 2 updated config tests (default value, TOML loading)
- [x] All 69 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)