### PR TITLE
Add denden port auto-resolution with OS-assigned fallback

### DIFF
--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -308,6 +308,7 @@ def handle_delegate(
     session_dir: str,
     resolve_role: Callable[..., dict],
     resolve_role_dirs: Callable[[str], str | None],
+    denden_addr: str | None = None,
 ) -> DelegateResult:
     """Handle a delegation request end-to-end.
 
@@ -332,6 +333,8 @@ def handle_delegate(
             Signature: (slug, kind="role") -> dict.
         resolve_role_dirs: Callable that maps a role slug to its directory
             path (or None if not resolvable). Used to build delegatable roles.
+        denden_addr: Actual bound denden address. If provided, takes
+            precedence over ``config.denden_addr``.
 
     Returns:
         DelegateResult with summary and output from the sub-agent.
@@ -386,7 +389,7 @@ def handle_delegate(
 
         # 7. Spawn
         env = {
-            "DENDEN_ADDR": config.denden_addr,
+            "DENDEN_ADDR": denden_addr or config.denden_addr,
             "DENDEN_AGENT_ID": agent_id,
             "DENDEN_PARENT_AGENT_ID": request.parent_agent_id,
             "DENDEN_RUN_ID": request.run_id,

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -6,7 +6,6 @@ import os
 import signal
 import subprocess
 import sys
-import threading
 import time
 import uuid
 from collections.abc import Callable
@@ -242,7 +241,7 @@ class Session:
         self._env: IsolatedEnv | None = None
         self._working_dir: str | None = None
         self._server: DenDenServer | None = None
-        self._server_thread: threading.Thread | None = None
+        self._denden_addr: str | None = None
         self._orchestrator_handle: AgentHandle | None = None
         self._agents: dict[str, AgentHandle] = {}
         self._agent_info: dict[str, dict] = {}
@@ -298,7 +297,7 @@ class Session:
             # 5. Spawn orchestrator (interactive mode)
             env = {
                 "PERMISSION_MODE": self.config.permission_mode,
-                "DENDEN_ADDR": self.config.denden_addr,
+                "DENDEN_ADDR": self._denden_addr,
                 "DENDEN_AGENT_ID": agent_id,
                 "DENDEN_RUN_ID": self._run_id,
             }
@@ -510,21 +509,36 @@ class Session:
     # ------------------------------------------------------------------
 
     def _start_denden_server(self) -> None:
-        """Create and start the denden gRPC server in a daemon thread."""
+        """Create and start the denden gRPC server.
+
+        Tries the configured address first.  If binding fails (port in
+        use), falls back to port 0 (OS-assigned free port).  The actual
+        bound address is stored in ``self._denden_addr``.
+        """
         self._server = DenDenServer(addr=self.config.denden_addr)
         self._server.on_delegate(self._handle_delegate)
         self._server.on_ask_user(self._handle_ask_user)
 
-        self._server_thread = threading.Thread(
-            target=self._server.run, daemon=True
-        )
-        self._server_thread.start()
+        try:
+            self._server.start()
+        except RuntimeError:
+            host = self.config.denden_addr.rsplit(":", 1)[0]
+            logger.info(
+                "Port %s in use, falling back to OS-assigned port",
+                self.config.denden_addr,
+            )
+            self._server = DenDenServer(addr=f"{host}:0")
+            self._server.on_delegate(self._handle_delegate)
+            self._server.on_ask_user(self._handle_ask_user)
+            self._server.start()
+
+        self._denden_addr = self._server.bound_addr
 
     def _stop_denden_server(self) -> None:
         """Stop the denden gRPC server."""
-        if self._server and self._server._server:
+        if self._server is not None:
             try:
-                self._server._server.stop(grace=5)
+                self._server.stop(grace=5)
             except Exception:
                 logger.debug("Failed to stop denden server", exc_info=True)
 
@@ -561,6 +575,7 @@ class Session:
                 session_dir=self._session_dir(),
                 resolve_role=self._resolve_role,
                 resolve_role_dirs=self._resolve_role_dirs,
+                denden_addr=self._denden_addr,
             )
             return ok_response(
                 request.request_id,
@@ -631,7 +646,7 @@ class Session:
             "working_dir": self._working_dir,
             "isolation": self.config.isolation,
             "runtime": self.config.runtime,
-            "denden_addr": self.config.denden_addr,
+            "denden_addr": self._denden_addr,
             "started_at": datetime.now(timezone.utc).isoformat(),
             "pid": os.getpid(),
             "agents": {},

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -712,6 +712,57 @@ class TestSpawnAndWait:
         assert kw["env"]["PERMISSION_MODE"] == "auto"
         assert "DENDEN_AGENT_ID" in kw["env"]
 
+    def test_denden_addr_override(self, tmp_path):
+        """When denden_addr is provided, it overrides config.denden_addr."""
+        base = str(tmp_path / "registry")
+        role_path = _write_role(base, "implementer", "Implement.")
+        resolved = {
+            "slug": "implementer",
+            "kind": "role",
+            "version": "1.0",
+            "path": role_path,
+            "source": "local",
+            "dependencies": [],
+        }
+        runtime = _mock_runtime()
+        handle_delegate(
+            request=_make_request(),
+            config=_make_config(denden_addr="127.0.0.1:9999"),
+            runtime=runtime,
+            working_dir=str(tmp_path / "work"),
+            session_dir=str(tmp_path / "session"),
+            resolve_role=lambda slug, kind="role": resolved,
+            resolve_role_dirs=lambda s: None,
+            denden_addr="127.0.0.1:55555",
+        )
+        kw = runtime.spawn.call_args.kwargs
+        assert kw["env"]["DENDEN_ADDR"] == "127.0.0.1:55555"
+
+    def test_denden_addr_falls_back_to_config(self, tmp_path):
+        """When denden_addr is not provided, config.denden_addr is used."""
+        base = str(tmp_path / "registry")
+        role_path = _write_role(base, "implementer", "Implement.")
+        resolved = {
+            "slug": "implementer",
+            "kind": "role",
+            "version": "1.0",
+            "path": role_path,
+            "source": "local",
+            "dependencies": [],
+        }
+        runtime = _mock_runtime()
+        handle_delegate(
+            request=_make_request(),
+            config=_make_config(denden_addr="127.0.0.1:9999"),
+            runtime=runtime,
+            working_dir=str(tmp_path / "work"),
+            session_dir=str(tmp_path / "session"),
+            resolve_role=lambda slug, kind="role": resolved,
+            resolve_role_dirs=lambda s: None,
+        )
+        kw = runtime.spawn.call_args.kwargs
+        assert kw["env"]["DENDEN_ADDR"] == "127.0.0.1:9999"
+
     def test_requester_role_dir_included(self, tmp_path):
         """Requester role is symlinked into session-level requester_roles dir."""
         base = str(tmp_path / "registry")

--- a/cli/tests/test_session.py
+++ b/cli/tests/test_session.py
@@ -160,6 +160,7 @@ class TestStartFlow:
     @patch("strawpot.session.DenDenServer")
     def test_creates_isolation_env(self, mock_server_cls, tmp_path):
         """start() calls isolator.create with correct args."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         session = _make_session(tmp_path, isolator=isolator)
@@ -173,7 +174,8 @@ class TestStartFlow:
 
     @patch("strawpot.session.DenDenServer")
     def test_starts_denden_server(self, mock_server_cls, tmp_path):
-        """start() creates and starts a DenDenServer."""
+        """start() creates and starts a DenDenServer via start() (non-blocking)."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         session = _make_session(tmp_path, isolator=isolator)
@@ -184,10 +186,12 @@ class TestStartFlow:
         server_instance = mock_server_cls.return_value
         server_instance.on_delegate.assert_called_once()
         server_instance.on_ask_user.assert_called_once()
+        server_instance.start.assert_called_once()
 
     @patch("strawpot.session.DenDenServer")
     def test_spawns_orchestrator(self, mock_server_cls, tmp_path):
         """start() spawns the orchestrator with interactive mode (task='')."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         runtime = _mock_runtime()
@@ -208,6 +212,7 @@ class TestStartFlow:
     @patch("strawpot.session.DenDenServer")
     def test_writes_session_file(self, mock_server_cls, tmp_path):
         """start() writes session state JSON file."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         session = _make_session(tmp_path, isolator=isolator)
@@ -222,6 +227,7 @@ class TestStartFlow:
     @patch("strawpot.session.DenDenServer")
     def test_attaches_to_orchestrator(self, mock_server_cls, tmp_path):
         """start() calls runtime.attach() which blocks."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         runtime = _mock_runtime()
@@ -233,6 +239,53 @@ class TestStartFlow:
 
         runtime.attach.assert_called_once()
 
+    @patch("strawpot.session.DenDenServer")
+    def test_port_fallback_on_bind_failure(self, mock_server_cls, tmp_path):
+        """If start() raises RuntimeError (port taken), retry with port 0."""
+        first_server = MagicMock()
+        first_server.start.side_effect = RuntimeError("failed to bind")
+        second_server = MagicMock()
+        second_server.bound_addr = "127.0.0.1:54321"
+        mock_server_cls.side_effect = [first_server, second_server]
+
+        isolator = _mock_isolator()
+        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
+        session = _make_session(tmp_path, isolator=isolator)
+
+        session.start(str(tmp_path))
+
+        assert mock_server_cls.call_count == 2
+        # Second call should use port 0
+        second_call_kwargs = mock_server_cls.call_args_list[1]
+        assert second_call_kwargs == ({"addr": "127.0.0.1:0"},)
+        assert session._denden_addr == "127.0.0.1:54321"
+
+    @patch("strawpot.session.DenDenServer")
+    def test_actual_addr_in_orchestrator_env(self, mock_server_cls, tmp_path):
+        """Orchestrator env receives actual bound addr, not config addr."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:54321"
+        isolator = _mock_isolator()
+        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
+        runtime = _mock_runtime()
+        session = _make_session(tmp_path, isolator=isolator, runtime=runtime)
+
+        session.start(str(tmp_path))
+
+        kw = runtime.spawn.call_args.kwargs
+        assert kw["env"]["DENDEN_ADDR"] == "127.0.0.1:54321"
+
+    @patch("strawpot.session.DenDenServer")
+    def test_actual_addr_in_session_file(self, mock_server_cls, tmp_path):
+        """Session file stores actual bound addr, not config addr."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:54321"
+        isolator = _mock_isolator()
+        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
+        session = _make_session(tmp_path, isolator=isolator)
+
+        session.start(str(tmp_path))
+
+        assert session._session_data["denden_addr"] == "127.0.0.1:54321"
+
 
 # ---------------------------------------------------------------------------
 # Stop / cleanup
@@ -242,21 +295,21 @@ class TestStartFlow:
 class TestStop:
     @patch("strawpot.session.DenDenServer")
     def test_stops_denden_server(self, mock_server_cls, tmp_path):
-        """stop() stops the denden gRPC server."""
+        """stop() stops the denden gRPC server via public stop() method."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         session = _make_session(tmp_path, isolator=isolator)
 
         session.start(str(tmp_path))
 
-        # The server's internal _server.stop should have been called
         server_instance = mock_server_cls.return_value
-        if server_instance._server:
-            server_instance._server.stop.assert_called()
+        server_instance.stop.assert_called_once_with(grace=5)
 
     @patch("strawpot.session.DenDenServer")
     def test_calls_isolator_cleanup(self, mock_server_cls, tmp_path):
         """stop() calls isolator.cleanup()."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         session = _make_session(tmp_path, isolator=isolator)
@@ -268,6 +321,7 @@ class TestStop:
     @patch("strawpot.session.DenDenServer")
     def test_removes_session_dir(self, mock_server_cls, tmp_path):
         """stop() removes the entire session directory."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         session = _make_session(tmp_path, isolator=isolator)
@@ -427,6 +481,7 @@ class TestHandleDelegate:
         session._env = IsolatedEnv(path=str(tmp_path))
         session._working_dir = str(tmp_path)
         session._run_id = "run_test"
+        session._denden_addr = "127.0.0.1:9700"
         session._register_agent(
             "agent_orch", role="orchestrator", parent_id=None
         )
@@ -436,6 +491,33 @@ class TestHandleDelegate:
         mock_handle.assert_called_once()
         mock_ok.assert_called_once()
         assert result == "ok"
+
+    @patch("strawpot.session.handle_delegate")
+    @patch("strawpot.session.ok_response")
+    def test_passes_denden_addr_to_handle_delegate(
+        self, mock_ok, mock_handle, tmp_path
+    ):
+        """_handle_delegate passes actual denden_addr to handle_delegate()."""
+        from strawpot.delegation import DelegateResult
+
+        mock_handle.return_value = DelegateResult(
+            summary="Done", output="ok", exit_code=0
+        )
+        mock_ok.return_value = "ok"
+
+        session = _make_session(tmp_path)
+        session._env = IsolatedEnv(path=str(tmp_path))
+        session._working_dir = str(tmp_path)
+        session._run_id = "run_test"
+        session._denden_addr = "127.0.0.1:54321"
+        session._register_agent(
+            "agent_orch", role="orchestrator", parent_id=None
+        )
+
+        session._handle_delegate(self._make_denden_request())
+
+        call_kwargs = mock_handle.call_args.kwargs
+        assert call_kwargs["denden_addr"] == "127.0.0.1:54321"
 
     @patch("strawpot.session.handle_delegate")
     @patch("strawpot.session.denied_response")
@@ -448,6 +530,7 @@ class TestHandleDelegate:
         session._env = IsolatedEnv(path=str(tmp_path))
         session._working_dir = str(tmp_path)
         session._run_id = "run_test"
+        session._denden_addr = "127.0.0.1:9700"
         session._register_agent(
             "agent_orch", role="orchestrator", parent_id=None
         )
@@ -470,6 +553,7 @@ class TestHandleDelegate:
         session._env = IsolatedEnv(path=str(tmp_path))
         session._working_dir = str(tmp_path)
         session._run_id = "run_test"
+        session._denden_addr = "127.0.0.1:9700"
         session._register_agent(
             "agent_orch", role="orchestrator", parent_id=None
         )
@@ -991,6 +1075,7 @@ class TestSignalHandling:
         """Signal handler is installed before attach and restored after stop."""
         import signal
 
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         runtime = _mock_runtime()
@@ -1007,6 +1092,7 @@ class TestSignalHandling:
     @patch("strawpot.session.DenDenServer")
     def test_stop_runs_after_shutdown(self, mock_server_cls, tmp_path):
         """stop() runs via finally block after shutdown kills orchestrator."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         runtime = _mock_runtime()
@@ -1029,6 +1115,7 @@ class TestNoninteractiveMode:
     @patch("strawpot.session.DenDenServer")
     def test_spawn_receives_task(self, mock_server_cls, tmp_path):
         """spawn() receives the task string when --task is given."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         runtime = _mock_runtime()
@@ -1044,6 +1131,7 @@ class TestNoninteractiveMode:
     @patch("strawpot.session.DenDenServer")
     def test_wait_called_instead_of_attach(self, mock_server_cls, tmp_path):
         """Noninteractive mode calls wait() instead of attach()."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         runtime = _mock_runtime()
@@ -1059,6 +1147,7 @@ class TestNoninteractiveMode:
     @patch("strawpot.session.DenDenServer")
     def test_attach_called_when_no_task(self, mock_server_cls, tmp_path):
         """Interactive mode (no task) calls attach() as before."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         runtime = _mock_runtime()
@@ -1074,6 +1163,7 @@ class TestNoninteractiveMode:
     @patch("strawpot.session.DenDenServer")
     def test_nonzero_exit_code(self, mock_server_cls, tmp_path):
         """sys.exit() is called with the agent's nonzero exit code."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         runtime = _mock_runtime()
@@ -1092,6 +1182,7 @@ class TestNoninteractiveMode:
     @patch("strawpot.session.DenDenServer")
     def test_zero_exit_code_no_sys_exit(self, mock_server_cls, tmp_path):
         """No sys.exit() on success (exit code 0)."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         runtime = _mock_runtime()
@@ -1110,6 +1201,7 @@ class TestNoninteractiveMode:
         """Signal handler is installed and restored in noninteractive mode."""
         import signal
 
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         runtime = _mock_runtime()
@@ -1126,6 +1218,7 @@ class TestNoninteractiveMode:
     @patch("strawpot.session.DenDenServer")
     def test_stop_runs_after_task_completes(self, mock_server_cls, tmp_path):
         """stop() runs via finally block after task completion."""
+        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
         isolator = _mock_isolator()
         isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
         runtime = _mock_runtime()


### PR DESCRIPTION
## Summary
- If the configured denden port is taken, retry with port 0 (OS-assigned free port)
- Propagate actual bound address to orchestrator env, session file, and delegated sub-agents via new `denden_addr` parameter on `handle_delegate()`
- Replace daemon thread with non-blocking `DenDenServer.start()` API and use public `stop()` method instead of private `._server`
- Remove unused `threading` import

## Test plan
- [x] Port fallback test: first `start()` raises RuntimeError, second succeeds with port 0
- [x] Actual addr propagates to orchestrator env (`DENDEN_ADDR`)
- [x] Actual addr stored in session file
- [x] `denden_addr` parameter overrides `config.denden_addr` in delegation
- [x] `denden_addr` falls back to config when not provided
- [x] `_handle_delegate` passes `denden_addr` to `handle_delegate()`
- [x] All 312 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)