### PR TITLE
Align memory protocol with DESIGN.md

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1516,13 +1516,13 @@ building the agent's prompt.
 
 ```
 Inputs:
-  worktree_id
-  agent_instance_id
-  parent_agent_instance_id    (optional)
+  session_id
+  agent_id
+  parent_agent_id             (optional)
   role
-  behavior_ref                (Agent.md / ROLE.md path)
-  task_text
-  budget                      (token budget hint)
+  behavior_ref                (loaded role description text)
+  task
+  budget                      (token budget hint, optional)
 
 Outputs:
   context_cards               (typed: PM/SM/STM/RM)
@@ -1546,15 +1546,16 @@ StrawPot calls the memory provider to record what happened.
 
 ```
 Inputs:
-  worktree_id
-  agent_instance_id
-  parent_agent_instance_id    (optional)
+  session_id
+  agent_id
+  parent_agent_id             (optional)
   role
-  task_text
-  assistant_output
-  tool_trace                  (strongly recommended)
-  artifacts                   (commit hash, patch refs, test reports)
+  behavior_ref                (loaded role description text)
+  task
   status                      (success/failure/timeout)
+  output                      (assistant output text)
+  tool_trace                  (tool call trace text, optional)
+  artifacts                   (commit hash, patch refs, etc., optional)
 
 Outputs (mandatory receipt):
   em_event_ids                (appended event IDs or count)
@@ -1571,21 +1572,19 @@ Outputs (mandatory receipt):
 
 ### Memory Provider Protocol
 
-Same pattern as agent wrappers — a CLI that implements a contract:
+Memory providers are Python modules loaded directly into the strawpot
+process (unlike agent wrappers which are CLI subprocesses). Each provider
+implements the `MemoryProvider` protocol defined in
+`strawpot.memory.protocol`:
 
-```
-<provider> get  --worktree-id ID --agent-id ID --role SLUG \
-                --behavior-ref FILE --task TEXT --budget N \
-                [--parent-agent-id ID]
-  → stdout JSON: {"context_cards": [...], "control_signals": {...},
-                   "context_hash": "...", "sources_used": [...]}
-
-<provider> dump --worktree-id ID --agent-id ID --role SLUG \
-                --task TEXT --status STATUS \
-                --output FILE --tool-trace FILE \
-                [--parent-agent-id ID] [--artifacts JSON]
-  → stdout JSON: {"em_event_ids": [...], "stm_updates": [...],
-                   "sm_rm_proposals": [...], "deferred": [...]}
+```python
+class MemoryProvider(Protocol):
+    name: str
+    def get(self, *, session_id, agent_id, role, behavior_ref,
+            task, budget=None, parent_agent_id=None) -> GetResult: ...
+    def dump(self, *, session_id, agent_id, role, behavior_ref,
+             task, status, output, tool_trace="",
+             parent_agent_id=None, artifacts=None) -> DumpReceipt: ...
 ```
 
 ### Memory Manifest (`MEMORY.md`)
@@ -1640,9 +1639,9 @@ Every event in the append-only event log:
 
 ```json
 {
-  "worktree_id": "run_abc123",
-  "agent_instance_id": "agent_xyz",
-  "parent_agent_instance_id": null,
+  "session_id": "run_abc123",
+  "agent_id": "agent_xyz",
+  "parent_agent_id": null,
   "role": "implementer",
   "event_type": "AGENT_RESULT",
   "payload": {},

--- a/cli/src/strawpot/memory/protocol.py
+++ b/cli/src/strawpot/memory/protocol.py
@@ -50,7 +50,7 @@ class DumpReceipt:
     em_event_ids: list[str] = field(default_factory=list)
     stm_updates: list[str] = field(default_factory=list)
     sm_rm_proposals: list[str] = field(default_factory=list)
-    deferred: list[str] = field(default_factory=list)
+    deferred_items: list[str] = field(default_factory=list)
 
 
 @runtime_checkable

--- a/cli/tests/test_memory_protocol.py
+++ b/cli/tests/test_memory_protocol.py
@@ -98,7 +98,7 @@ def test_dump_receipt_defaults():
     assert receipt.em_event_ids == []
     assert receipt.stm_updates == []
     assert receipt.sm_rm_proposals == []
-    assert receipt.deferred == []
+    assert receipt.deferred_items == []
 
 
 def test_dump_receipt_with_values():
@@ -106,12 +106,22 @@ def test_dump_receipt_with_values():
         em_event_ids=["ev1", "ev2"],
         stm_updates=["scratch:updated"],
         sm_rm_proposals=["add convention X"],
-        deferred=["review needed"],
+        deferred_items=["review needed"],
     )
     assert receipt.em_event_ids == ["ev1", "ev2"]
     assert receipt.stm_updates == ["scratch:updated"]
     assert receipt.sm_rm_proposals == ["add convention X"]
-    assert receipt.deferred == ["review needed"]
+    assert receipt.deferred_items == ["review needed"]
+
+
+# -- Mutable default isolation -------------------------------------------------
+
+
+def test_mutable_defaults_not_shared():
+    a = DumpReceipt()
+    b = DumpReceipt()
+    a.em_event_ids.append("x")
+    assert b.em_event_ids == []
 
 
 # -- MemoryProvider protocol ---------------------------------------------------


### PR DESCRIPTION
## Summary
- Rename `deferred` → `deferred_items` in `DumpReceipt` to match DESIGN.md
- Update DESIGN.md memory section to reflect implementation decisions:
  - `worktree_id` → `session_id`, `agent_instance_id` → `agent_id`
  - Memory providers are Python modules (not CLI subprocesses)
  - `behavior_ref` is loaded role description text
  - `budget` is optional
  - `behavior_ref` added to `dump` inputs
- Add mutable default isolation test for `DumpReceipt`

## Test plan
- [x] 13 tests in `test_memory_protocol.py` pass
- [ ] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)