### PR TITLE
Integrate memory.get/dump into delegation flow (#19, #20)

### DIFF
--- a/cli/src/strawpot/config.py
+++ b/cli/src/strawpot/config.py
@@ -32,6 +32,8 @@ class StrawPotConfig:
     agent_timeout: int | None = None
     max_delegate_retries: int = 0
     agents: dict[str, dict] = field(default_factory=dict)
+    memory: str | None = None
+    memory_config: dict[str, str] = field(default_factory=dict)
     merge_strategy: str = "auto"
     pull_before_session: str = "prompt"
     pr_command: str = _DEFAULT_PR_COMMAND
@@ -75,6 +77,12 @@ def _apply(config: StrawPotConfig, data: dict) -> None:
     agents = data.get("agents", {})
     for name, agent_data in agents.items():
         config.agents.setdefault(name, {}).update(agent_data)
+
+    if "memory" in data:
+        config.memory = data["memory"]
+    memory_cfg = data.get("memory_config", {})
+    for key, value in memory_cfg.items():
+        config.memory_config[key] = value
 
     session = data.get("session", {})
     if "merge_strategy" in session:

--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from strawpot.agents.protocol import AgentHandle, AgentResult, AgentRuntime
 from strawpot.config import StrawPotConfig
 from strawpot.context import build_prompt, parse_frontmatter, read_role_description
+from strawpot.memory.protocol import GetResult, MemoryProvider
 
 logger = logging.getLogger(__name__)
 
@@ -295,6 +296,26 @@ def _build_delegatable_roles(
 
 
 # ---------------------------------------------------------------------------
+# Memory helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_memory_prompt(get_result: GetResult) -> str:
+    """Format context cards from a memory.get result into prompt text."""
+    parts = []
+    for card in get_result.context_cards:
+        parts.append(f"[{card.kind.value}] {card.content}")
+    return "\n\n".join(parts)
+
+
+def _agent_status(result: AgentResult, *, timed_out: bool = False) -> str:
+    """Map an agent result to a status string for memory.dump."""
+    if timed_out:
+        return "timeout"
+    return "success" if result.exit_code == 0 else "failure"
+
+
+# ---------------------------------------------------------------------------
 # Delegate handler
 # ---------------------------------------------------------------------------
 
@@ -309,6 +330,7 @@ def handle_delegate(
     resolve_role: Callable[..., dict],
     resolve_role_dirs: Callable[[str], str | None],
     denden_addr: str | None = None,
+    memory_provider: MemoryProvider | None = None,
 ) -> DelegateResult:
     """Handle a delegation request end-to-end.
 
@@ -335,6 +357,8 @@ def handle_delegate(
             path (or None if not resolvable). Used to build delegatable roles.
         denden_addr: Actual bound denden address. If provided, takes
             precedence over ``config.denden_addr``.
+        memory_provider: Optional memory provider. When set, ``get()``
+            is called before spawn and ``dump()`` after wait.
 
     Returns:
         DelegateResult with summary and output from the sub-agent.
@@ -387,7 +411,21 @@ def handle_delegate(
                 _symlink(requester_role_dir, req_dest)
             roles_dirs.append(req_roles_dir)
 
-        # 7. Spawn
+        # 7a. Memory get — retrieve context before spawn
+        memory_prompt = ""
+        if memory_provider is not None:
+            get_result = memory_provider.get(
+                session_id=request.run_id,
+                agent_id=agent_id,
+                role=request.role_slug,
+                behavior_ref=role_prompt,
+                task=task_text,
+                parent_agent_id=request.parent_agent_id,
+            )
+            if get_result.context_cards:
+                memory_prompt = _format_memory_prompt(get_result)
+
+        # 7b. Spawn
         env = {
             "DENDEN_ADDR": denden_addr or config.denden_addr,
             "DENDEN_AGENT_ID": agent_id,
@@ -401,7 +439,7 @@ def handle_delegate(
             working_dir=working_dir,
             agent_workspace_dir=workspace,
             role_prompt=role_prompt,
-            memory_prompt="",
+            memory_prompt=memory_prompt,
             skills_dir=skills_dir,
             roles_dirs=roles_dirs,
             task=task_text,
@@ -411,8 +449,24 @@ def handle_delegate(
         # 8. Wait
         result = runtime.wait(handle, timeout=config.agent_timeout)
 
+        # 8a. Memory dump — record result after wait
+        timed_out = (
+            config.agent_timeout is not None and runtime.is_alive(handle)
+        )
+        if memory_provider is not None:
+            memory_provider.dump(
+                session_id=request.run_id,
+                agent_id=agent_id,
+                role=request.role_slug,
+                behavior_ref=role_prompt,
+                task=task_text,
+                status=_agent_status(result, timed_out=timed_out),
+                output=result.output,
+                parent_agent_id=request.parent_agent_id,
+            )
+
         # 8b. Handle timeout — no retry on timeout
-        if config.agent_timeout is not None and runtime.is_alive(handle):
+        if timed_out:
             runtime.kill(handle)
             return DelegateResult(
                 summary=f"Agent timed out after {config.agent_timeout}s",

--- a/cli/src/strawpot/memory/registry.py
+++ b/cli/src/strawpot/memory/registry.py
@@ -1,5 +1,6 @@
 """Memory registry — discover MEMORY.md manifests and resolve to MemorySpec."""
 
+import importlib.util
 import os
 import shutil
 from dataclasses import dataclass, field
@@ -9,6 +10,7 @@ import yaml
 
 from strawpot.agents.registry import ValidationResult, _current_os
 from strawpot.config import get_strawpot_home
+from strawpot.memory.protocol import MemoryProvider
 
 
 @dataclass
@@ -138,6 +140,46 @@ def resolve_memory(
         config=config,
         env_schema=env_schema,
         tools=tools,
+    )
+
+
+def load_provider(spec: MemorySpec) -> MemoryProvider:
+    """Dynamically load a memory provider from a MemorySpec.
+
+    Imports the script file, scans for a class that satisfies
+    ``MemoryProvider``, and returns an instance.
+
+    Args:
+        spec: A resolved MemorySpec with an absolute script path.
+
+    Returns:
+        An instance of the first class found that satisfies MemoryProvider.
+
+    Raises:
+        ValueError: If no MemoryProvider implementation is found in the script.
+    """
+    mod_spec = importlib.util.spec_from_file_location(
+        "_memory_provider", spec.script
+    )
+    mod = importlib.util.module_from_spec(mod_spec)  # type: ignore[arg-type]
+    mod_spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+    for attr_name in dir(mod):
+        attr = getattr(mod, attr_name)
+        if (
+            isinstance(attr, type)
+            and attr is not MemoryProvider
+            and issubclass(attr, object)
+        ):
+            try:
+                instance = attr()
+            except TypeError:
+                continue
+            if isinstance(instance, MemoryProvider):
+                return instance
+
+    raise ValueError(
+        f"No MemoryProvider implementation found in {spec.script}"
     )
 
 

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -26,10 +26,13 @@ from strawpot.context import build_prompt
 from strawpot.delegation import (
     DelegateRequest,
     PolicyDenied,
+    _format_memory_prompt,
     create_agent_workspace,
     handle_delegate,
     stage_role,
 )
+from strawpot.memory.protocol import MemoryProvider
+from strawpot.memory.registry import MemorySpec, load_provider, resolve_memory
 from strawpot.isolation.protocol import IsolatedEnv, Isolator, NoneIsolator
 from strawpot.isolation.worktree import WorktreeIsolator
 
@@ -247,6 +250,7 @@ class Session:
         self._agent_info: dict[str, dict] = {}
         self._session_file: str | None = None
         self._session_data: dict = {}
+        self._memory_provider: MemoryProvider | None = None
         self._shutting_down: bool = False
         self._interrupted: bool = False
         self._last_sigint_time: float = 0.0
@@ -276,6 +280,15 @@ class Session:
                 session_id=self._run_id, base_dir=working_dir
             )
 
+            # 1b. Resolve memory provider (if configured)
+            if self.config.memory:
+                spec = resolve_memory(
+                    self.config.memory,
+                    working_dir,
+                    self.config.memory_config,
+                )
+                self._memory_provider = load_provider(spec)
+
             # 2. Start denden server in background
             self._start_denden_server()
 
@@ -294,7 +307,20 @@ class Session:
                 self._session_dir(), agent_id
             )
 
-            # 5. Spawn orchestrator (interactive mode)
+            # 5a. Memory get for orchestrator
+            memory_prompt = ""
+            if self._memory_provider is not None:
+                get_result = self._memory_provider.get(
+                    session_id=self._run_id,
+                    agent_id=agent_id,
+                    role=self.config.orchestrator_role,
+                    behavior_ref=role_prompt,
+                    task=self.task,
+                )
+                if get_result.context_cards:
+                    memory_prompt = _format_memory_prompt(get_result)
+
+            # 5b. Spawn orchestrator (interactive mode)
             env = {
                 "PERMISSION_MODE": self.config.permission_mode,
                 "DENDEN_ADDR": self._denden_addr,
@@ -307,7 +333,7 @@ class Session:
                 working_dir=self._env.path,
                 agent_workspace_dir=workspace,
                 role_prompt=role_prompt,
-                memory_prompt="",
+                memory_prompt=memory_prompt,
                 skills_dir=skills_dir,
                 roles_dirs=[roles_dir],
                 task=self.task,
@@ -576,6 +602,7 @@ class Session:
                 resolve_role=self._resolve_role,
                 resolve_role_dirs=self._resolve_role_dirs,
                 denden_addr=self._denden_addr,
+                memory_provider=self._memory_provider,
             )
             return ok_response(
                 request.request_id,

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -17,6 +17,8 @@ def test_defaults():
     assert config.agent_timeout is None
     assert config.max_delegate_retries == 0
     assert config.agents == {}
+    assert config.memory is None
+    assert config.memory_config == {}
     assert config.merge_strategy == "auto"
     assert config.pull_before_session == "prompt"
     assert "gh pr create" in config.pr_command
@@ -77,6 +79,7 @@ def test_load_config_full(tmp_path, monkeypatch):
     (strawpot_dir / "config.toml").write_text(
         'runtime = "codex"\n'
         'isolation = "docker"\n'
+        'memory = "test-provider"\n'
         "\n"
         "[denden]\n"
         'addr = "0.0.0.0:8080"\n'
@@ -96,6 +99,9 @@ def test_load_config_full(tmp_path, monkeypatch):
         'pull_before_session = "auto"\n'
         'pr_command = "glab mr create --source {session_branch} --target {base_branch}"\n'
         "\n"
+        "[memory_config]\n"
+        'storage_dir = "/custom/mem"\n'
+        "\n"
         "[agents.claude_code]\n"
         'model = "claude-sonnet-4-6"\n'
     )
@@ -111,6 +117,8 @@ def test_load_config_full(tmp_path, monkeypatch):
     assert config.agent_timeout == 300
     assert config.max_delegate_retries == 2
     assert config.agents == {"claude_code": {"model": "claude-sonnet-4-6"}}
+    assert config.memory == "test-provider"
+    assert config.memory_config == {"storage_dir": "/custom/mem"}
     assert config.merge_strategy == "pr"
     assert config.pull_before_session == "auto"
     assert config.pr_command == "glab mr create --source {session_branch} --target {base_branch}"
@@ -160,3 +168,30 @@ def test_load_config_agents_merge(tmp_path, monkeypatch):
     assert config.agents == {
         "claude_code": {"model": "claude-sonnet-4-6", "timeout": 300}
     }
+
+
+def test_load_config_memory_merge(tmp_path, monkeypatch):
+    """Memory config from project merges with global per-key."""
+    global_dir = tmp_path / "global"
+    global_dir.mkdir()
+    (global_dir / "config.toml").write_text(
+        'memory = "my-provider"\n'
+        "\n"
+        "[memory_config]\n"
+        'storage_dir = "/global/mem"\n'
+        "em_max_events = 5000\n"
+    )
+    monkeypatch.setenv("STRAWPOT_HOME", str(global_dir))
+
+    project_dir = tmp_path / "project"
+    strawpot_dir = project_dir / ".strawpot"
+    strawpot_dir.mkdir(parents=True)
+    (strawpot_dir / "config.toml").write_text(
+        "[memory_config]\n"
+        'storage_dir = "/project/mem"\n'
+    )
+
+    config = load_config(project_dir)
+    assert config.memory == "my-provider"
+    assert config.memory_config["storage_dir"] == "/project/mem"
+    assert config.memory_config["em_max_events"] == 5000

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -11,15 +11,23 @@ from strawpot.delegation import (
     DelegateRequest,
     DelegateResult,
     PolicyDenied,
+    _agent_status,
     _build_delegatable_roles,
     _check_policy,
     _collect_transitive_skills,
+    _format_memory_prompt,
     _parse_role_deps,
     _parse_skill_deps,
     _validate_output,
     create_agent_workspace,
     handle_delegate,
     stage_role,
+)
+from strawpot.memory.protocol import (
+    ContextCard,
+    DumpReceipt,
+    GetResult,
+    MemoryKind,
 )
 
 
@@ -1355,3 +1363,168 @@ class TestIntegration:
         assert kw["env"]["DENDEN_ADDR"] == "127.0.0.1:9700"
         assert kw["env"]["DENDEN_PARENT_AGENT_ID"] == "agent_orch"
         assert kw["env"]["DENDEN_RUN_ID"] == "run_session"
+
+
+# ---------------------------------------------------------------------------
+# Memory helpers
+# ---------------------------------------------------------------------------
+
+
+class TestFormatMemoryPrompt:
+    def test_empty_cards(self):
+        result = _format_memory_prompt(GetResult())
+        assert result == ""
+
+    def test_single_card(self):
+        get_result = GetResult(
+            context_cards=[ContextCard(kind=MemoryKind.PM, content="Do X")]
+        )
+        result = _format_memory_prompt(get_result)
+        assert result == "[PM] Do X"
+
+    def test_multiple_cards(self):
+        get_result = GetResult(
+            context_cards=[
+                ContextCard(kind=MemoryKind.PM, content="instructions"),
+                ContextCard(kind=MemoryKind.SM, content="fact A"),
+                ContextCard(kind=MemoryKind.STM, content="scratch"),
+            ]
+        )
+        result = _format_memory_prompt(get_result)
+        assert "[PM] instructions" in result
+        assert "[SM] fact A" in result
+        assert "[STM] scratch" in result
+
+
+class TestAgentStatus:
+    def test_success(self):
+        result = AgentResult(summary="ok", output="done", exit_code=0)
+        assert _agent_status(result) == "success"
+
+    def test_failure(self):
+        result = AgentResult(summary="fail", output="err", exit_code=1)
+        assert _agent_status(result) == "failure"
+
+    def test_timeout(self):
+        result = AgentResult(summary="partial", output="...", exit_code=0)
+        assert _agent_status(result, timed_out=True) == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# Memory integration in handle_delegate
+# ---------------------------------------------------------------------------
+
+
+def _mock_memory_provider(context_cards=None):
+    """Create a mock MemoryProvider."""
+    provider = MagicMock()
+    provider.name = "mock-memory"
+    provider.get.return_value = GetResult(
+        context_cards=context_cards or [],
+    )
+    provider.dump.return_value = DumpReceipt()
+    return provider
+
+
+class TestMemoryIntegration:
+    def _run_delegate(self, tmp_path, runtime=None, memory_provider=None,
+                      **config_overrides):
+        """Helper to run handle_delegate with minimal setup."""
+        base = str(tmp_path / "registry")
+        role_path = _write_role(base, "implementer", "Implement things.")
+        resolved = {
+            "slug": "implementer",
+            "kind": "role",
+            "version": "1.0",
+            "path": role_path,
+            "source": "local",
+            "dependencies": [],
+        }
+        if runtime is None:
+            runtime = _mock_runtime()
+        return handle_delegate(
+            request=_make_request(),
+            config=_make_config(**config_overrides),
+            runtime=runtime,
+            working_dir=str(tmp_path / "work"),
+            session_dir=str(tmp_path / "session"),
+            resolve_role=lambda slug, kind="role": resolved,
+            resolve_role_dirs=lambda s: None,
+            memory_provider=memory_provider,
+        )
+
+    def test_no_memory_provider_skips_calls(self, tmp_path):
+        """When memory_provider is None, no memory calls are made."""
+        runtime = _mock_runtime()
+        self._run_delegate(tmp_path, runtime=runtime, memory_provider=None)
+
+        # spawn still called with empty memory_prompt
+        kw = runtime.spawn.call_args.kwargs
+        assert kw["memory_prompt"] == ""
+
+    def test_memory_get_called_before_spawn(self, tmp_path):
+        """memory.get() is called and memory_prompt is populated."""
+        provider = _mock_memory_provider(
+            context_cards=[
+                ContextCard(kind=MemoryKind.PM, content="role instructions"),
+                ContextCard(kind=MemoryKind.SM, content="workspace fact"),
+            ]
+        )
+        runtime = _mock_runtime()
+        self._run_delegate(tmp_path, runtime=runtime, memory_provider=provider)
+
+        # get was called
+        provider.get.assert_called_once()
+        get_kwargs = provider.get.call_args.kwargs
+        assert get_kwargs["role"] == "implementer"
+        assert "Implement things." in get_kwargs["behavior_ref"]
+
+        # memory_prompt in spawn contains formatted cards
+        spawn_kwargs = runtime.spawn.call_args.kwargs
+        assert "[PM] role instructions" in spawn_kwargs["memory_prompt"]
+        assert "[SM] workspace fact" in spawn_kwargs["memory_prompt"]
+
+    def test_memory_get_empty_cards_gives_empty_prompt(self, tmp_path):
+        """When memory.get returns no cards, memory_prompt is empty."""
+        provider = _mock_memory_provider(context_cards=[])
+        runtime = _mock_runtime()
+        self._run_delegate(tmp_path, runtime=runtime, memory_provider=provider)
+
+        spawn_kwargs = runtime.spawn.call_args.kwargs
+        assert spawn_kwargs["memory_prompt"] == ""
+
+    def test_memory_dump_called_after_wait(self, tmp_path):
+        """memory.dump() is called with correct status after success."""
+        provider = _mock_memory_provider()
+        self._run_delegate(tmp_path, memory_provider=provider)
+
+        provider.dump.assert_called_once()
+        dump_kwargs = provider.dump.call_args.kwargs
+        assert dump_kwargs["status"] == "success"
+        assert dump_kwargs["role"] == "implementer"
+        assert dump_kwargs["output"] == "ok"
+
+    def test_memory_dump_on_failure(self, tmp_path):
+        """memory.dump() records failure status on non-zero exit."""
+        provider = _mock_memory_provider()
+        runtime = _mock_runtime(exit_code=1)
+        self._run_delegate(tmp_path, runtime=runtime, memory_provider=provider)
+
+        dump_kwargs = provider.dump.call_args.kwargs
+        assert dump_kwargs["status"] == "failure"
+
+    def test_memory_dump_on_timeout(self, tmp_path):
+        """memory.dump() records timeout status when agent times out."""
+        provider = _mock_memory_provider()
+        runtime = _mock_runtime()
+        runtime.is_alive.return_value = True  # simulate timeout
+
+        self._run_delegate(
+            tmp_path,
+            runtime=runtime,
+            memory_provider=provider,
+            agent_timeout=10,
+        )
+
+        dump_kwargs = provider.dump.call_args.kwargs
+        assert dump_kwargs["status"] == "timeout"

--- a/cli/tests/test_memory_registry.py
+++ b/cli/tests/test_memory_registry.py
@@ -11,6 +11,7 @@ from strawpot.memory.registry import (
     MemorySpec,
     _merge_config,
     _resolve_script,
+    load_provider,
     parse_memory_md,
     resolve_memory,
     validate_memory,
@@ -298,3 +299,54 @@ def test_noop_provider_dump_returns_empty():
     )
     assert receipt.em_event_ids == []
     assert receipt.deferred_items == []
+
+
+# --- load_provider ---
+
+
+def test_load_provider(tmp_path):
+    provider_code = dedent("""\
+        from strawpot.memory.protocol import DumpReceipt, GetResult
+
+        class MyProvider:
+            name = "test"
+
+            def get(self, *, session_id, agent_id, role, behavior_ref,
+                    task, budget=None, parent_agent_id=None):
+                return GetResult()
+
+            def dump(self, *, session_id, agent_id, role, behavior_ref,
+                     task, status, output, tool_trace="",
+                     parent_agent_id=None, artifacts=None):
+                return DumpReceipt()
+    """)
+    script = tmp_path / "provider.py"
+    script.write_text(provider_code)
+    spec = MemorySpec(name="test", version="1.0", script=str(script))
+
+    provider = load_provider(spec)
+    assert isinstance(provider, MemoryProvider)
+    assert provider.name == "test"
+    result = provider.get(
+        session_id="s1", agent_id="a1", role="r",
+        behavior_ref="desc", task="t",
+    )
+    assert result.context_cards == []
+
+
+def test_load_provider_no_class(tmp_path):
+    script = tmp_path / "empty.py"
+    script.write_text("# no provider class\nx = 42\n")
+    spec = MemorySpec(name="bad", version="1.0", script=str(script))
+
+    with pytest.raises(ValueError, match="No MemoryProvider"):
+        load_provider(spec)
+
+
+def test_load_provider_noop(tmp_path, monkeypatch):
+    """load_provider works with the built-in noop provider."""
+    monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "global"))
+    spec = resolve_memory("noop", str(tmp_path))
+    provider = load_provider(spec)
+    assert isinstance(provider, MemoryProvider)
+    assert provider.name == "noop"


### PR DESCRIPTION
## Summary
- Add `memory` and `memory_config` fields to `StrawPotConfig` with TOML loading and per-key merge across global/project scopes
- Add `load_provider()` to memory registry for dynamic provider loading via `importlib`
- Integrate `memory.get()` before spawn and `memory.dump()` after wait in `handle_delegate()`, formatting context cards into `memory_prompt`
- Wire memory provider resolution through `Session` for both orchestrator and delegated agents
- Memory is fully optional — when no provider is configured, the delegation flow is unchanged

## Test plan
- [x] Config tests: defaults include `memory=None` and `memory_config={}`, full config load, per-key merge across scopes
- [x] Registry tests: `load_provider` with valid provider, missing class, and built-in noop
- [x] Delegation tests: memory.get called before spawn with correct args, memory_prompt populated, dump called with success/failure/timeout status, no-provider backward compat
- [x] Full suite: 362 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)