### PR TITLE
Add metadata.strawpot.env support to SKILL.md

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -110,6 +110,26 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task):
         value = click.prompt(f"Enter value for {var}")
         os.environ[var] = value
 
+    # 2b. Validate skill env requirements for orchestrator role
+    try:
+        from strawhub.resolver import resolve as _resolve
+
+        from strawpot.delegation import collect_skill_env, discover_global_skills, validate_skill_env
+
+        resolved = _resolve(config.orchestrator_role, kind="role")
+        global_skills = discover_global_skills(resolved)
+        skill_env = collect_skill_env(resolved, global_skills=global_skills or None)
+        skill_validation = validate_skill_env(skill_env)
+        for var in skill_validation.missing_env:
+            desc = skill_env[var].get("description", "")
+            prompt_text = f"Enter value for {var}"
+            if desc:
+                prompt_text += f" ({desc})"
+            value = click.prompt(prompt_text)
+            os.environ[var] = value
+    except Exception:
+        pass  # Role resolution failures handled by Session.start()
+
     # 3. Build runtimes (session_dir set later by Session.start())
     wrapper = WrapperRuntime(spec)
     if task:

--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -141,6 +141,26 @@ def _parse_skill_deps(skill_path: str) -> list[str]:
     return [spec.split()[0] for spec in deps]
 
 
+def _parse_skill_env(skill_path: str) -> dict[str, dict]:
+    """Parse SKILL.md frontmatter to extract env schema.
+
+    Returns:
+        Dict mapping var name to metadata
+        (e.g. ``{"GITHUB_TOKEN": {"required": True, "description": "..."}}``)
+        or empty dict if no env field.
+    """
+    skill_md = Path(skill_path) / "SKILL.md"
+    if not skill_md.exists():
+        return {}
+    text = skill_md.read_text(encoding="utf-8")
+    parsed = parse_frontmatter(text)
+    fm = parsed.get("frontmatter", {})
+    env = fm.get("metadata", {}).get("strawpot", {}).get("env", {})
+    if not isinstance(env, dict):
+        return {}
+    return env
+
+
 # ---------------------------------------------------------------------------
 # Global skill discovery
 # ---------------------------------------------------------------------------
@@ -208,6 +228,98 @@ def discover_global_skills(
         global_skills.append((slug, desc, str(entry)))
 
     return global_skills
+
+
+# ---------------------------------------------------------------------------
+# Skill env collection and validation
+# ---------------------------------------------------------------------------
+
+
+def _merge_env_entry(target: dict[str, dict], var: str, meta: dict) -> None:
+    """Merge a single env entry into *target*, preferring ``required=True``."""
+    if var not in target:
+        target[var] = dict(meta)
+    elif meta.get("required") and not target[var].get("required"):
+        target[var] = dict(meta)
+
+
+def collect_skill_env(
+    resolved: dict,
+    global_skills: list[tuple[str, str, str]] | None = None,
+) -> dict[str, dict]:
+    """Collect env requirements from all skills in a role's dependency tree.
+
+    Walks the full dependency graph:
+
+    1. The role's own transitive skill dependencies (skill → skill chain).
+    2. Each delegatable role's transitive skill dependencies (recursive).
+    3. Global skills (if ``inherit_global_skills`` is true).
+
+    If the same var appears in multiple skills, ``required: True`` wins.
+
+    Args:
+        resolved: Resolved role dict from ``strawhub.resolver.resolve()``.
+        global_skills: Optional list of ``(slug, description, path)`` tuples.
+
+    Returns:
+        Merged dict mapping var name to metadata.
+    """
+    merged: dict[str, dict] = {}
+    all_deps = resolved.get("dependencies", [])
+
+    # Build lookups
+    role_lookup: dict[str, dict] = {}
+    for dep in all_deps:
+        if dep["kind"] == "role":
+            role_lookup[dep["slug"]] = dep
+
+    visited_roles: set[str] = set()
+
+    def _collect_from_role(role_path: str, role_slug: str) -> None:
+        if role_slug in visited_roles:
+            return
+        visited_roles.add(role_slug)
+
+        skill_slugs, child_role_slugs = _parse_role_deps(role_path)
+        skill_deps = _collect_transitive_skills(skill_slugs, all_deps)
+        for dep in skill_deps:
+            for var, meta in _parse_skill_env(dep["path"]).items():
+                _merge_env_entry(merged, var, meta)
+
+        # Recurse into delegatable roles
+        for child_slug in child_role_slugs:
+            child = role_lookup.get(child_slug)
+            if child is not None:
+                _collect_from_role(child["path"], child_slug)
+
+    # Start from the resolved role itself
+    _collect_from_role(resolved["path"], resolved["slug"])
+
+    if global_skills:
+        for _slug, _desc, gpath in global_skills:
+            for var, meta in _parse_skill_env(gpath).items():
+                _merge_env_entry(merged, var, meta)
+
+    return merged
+
+
+def validate_skill_env(env_schema: dict[str, dict]) -> "ValidationResult":
+    """Validate that required skill env vars are set.
+
+    Args:
+        env_schema: Merged env schema from :func:`collect_skill_env`.
+
+    Returns:
+        :class:`~strawpot.agents.registry.ValidationResult` with any
+        missing required env vars.
+    """
+    from strawpot.agents.registry import ValidationResult
+
+    result = ValidationResult()
+    for var_name, var_meta in env_schema.items():
+        if var_meta.get("required") and var_name not in os.environ:
+            result.missing_env.append(var_name)
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -463,6 +575,17 @@ def handle_delegate(
 
     # 2b. Discover global skills
     global_skills = discover_global_skills(resolved)
+
+    # 2c. Validate skill env requirements (non-interactive)
+    skill_env = collect_skill_env(resolved, global_skills=global_skills or None)
+    skill_validation = validate_skill_env(skill_env)
+    if not skill_validation.ok:
+        missing = ", ".join(skill_validation.missing_env)
+        raise DelegationError(
+            f"Missing required environment variables for role "
+            f"'{request.role_slug}': {missing}. "
+            f"Set these variables before starting the session."
+        )
 
     # 3. Build delegatable roles for the sub-agent
     delegatable = _build_delegatable_roles(

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -10,6 +10,7 @@ from strawpot.config import StrawPotConfig
 from strawpot.delegation import (
     DelegateRequest,
     DelegateResult,
+    DelegationError,
     PolicyDenied,
     _agent_status,
     _build_delegatable_roles,
@@ -17,13 +18,17 @@ from strawpot.delegation import (
     _check_policy,
     _collect_transitive_skills,
     _format_memory_prompt,
+    _merge_env_entry,
     _parse_role_deps,
     _parse_skill_deps,
+    _parse_skill_env,
     _validate_output,
+    collect_skill_env,
     create_agent_workspace,
     discover_global_skills,
     handle_delegate,
     stage_role,
+    validate_skill_env,
 )
 from strawpot.memory.protocol import (
     ContextCard,
@@ -38,7 +43,7 @@ from strawpot.memory.protocol import (
 # ---------------------------------------------------------------------------
 
 
-def _write_skill(base, slug, body="Skill body.", deps=None):
+def _write_skill(base, slug, body="Skill body.", deps=None, env=None):
     """Write a SKILL.md file.
 
     Args:
@@ -46,19 +51,33 @@ def _write_skill(base, slug, body="Skill body.", deps=None):
         slug: Skill slug.
         body: Markdown body.
         deps: Optional list of skill dependency slugs for frontmatter.
+        env: Optional dict of env var schemas
+            (e.g. ``{"TOKEN": {"required": True, "description": "..."}}``)
     """
     d = os.path.join(base, "skills", slug)
     os.makedirs(d, exist_ok=True)
-    if deps:
-        deps_yaml = "\n".join(f"      - {s}" for s in deps)
+    has_strawpot = deps or env
+    if has_strawpot:
+        strawpot_lines = []
+        if deps:
+            strawpot_lines.append("    dependencies:")
+            for s in deps:
+                strawpot_lines.append(f"      - {s}")
+        if env:
+            strawpot_lines.append("    env:")
+            for var_name, var_meta in env.items():
+                strawpot_lines.append(f"      {var_name}:")
+                for k, v in var_meta.items():
+                    val = "true" if v is True else "false" if v is False else v
+                    strawpot_lines.append(f"        {k}: {val}")
+        strawpot_yaml = "\n".join(strawpot_lines)
         fm = (
             f"---\n"
             f"name: {slug}\n"
             f"description: test\n"
             f"metadata:\n"
             f"  strawpot:\n"
-            f"    dependencies:\n"
-            f"{deps_yaml}\n"
+            f"{strawpot_yaml}\n"
             f"---\n"
         )
     else:
@@ -1767,3 +1786,293 @@ class TestStageRoleGlobalSkills:
         # skills dir exists but is empty
         assert os.path.isdir(skills_dir)
         assert os.listdir(skills_dir) == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_skill_env
+# ---------------------------------------------------------------------------
+
+
+class TestParseSkillEnv:
+    def test_reads_env(self, tmp_path):
+        skill_path = _write_skill(
+            str(tmp_path), "my-skill",
+            env={"MY_TOKEN": {"required": True, "description": "API token"}},
+        )
+        result = _parse_skill_env(skill_path)
+        assert "MY_TOKEN" in result
+        assert result["MY_TOKEN"]["required"] is True
+        assert result["MY_TOKEN"]["description"] == "API token"
+
+    def test_empty_when_no_env(self, tmp_path):
+        skill_path = _write_skill(str(tmp_path), "plain-skill")
+        result = _parse_skill_env(skill_path)
+        assert result == {}
+
+    def test_empty_when_no_file(self, tmp_path):
+        result = _parse_skill_env(str(tmp_path / "nonexistent"))
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# _merge_env_entry
+# ---------------------------------------------------------------------------
+
+
+class TestMergeEnvEntry:
+    def test_adds_new_entry(self):
+        target = {}
+        _merge_env_entry(target, "TOKEN", {"required": True, "description": "x"})
+        assert target == {"TOKEN": {"required": True, "description": "x"}}
+
+    def test_required_true_wins(self):
+        target = {"TOKEN": {"required": False, "description": "old"}}
+        _merge_env_entry(target, "TOKEN", {"required": True, "description": "new"})
+        assert target["TOKEN"]["required"] is True
+
+    def test_required_false_does_not_overwrite(self):
+        target = {"TOKEN": {"required": True, "description": "old"}}
+        _merge_env_entry(target, "TOKEN", {"required": False, "description": "new"})
+        assert target["TOKEN"]["required"] is True
+        assert target["TOKEN"]["description"] == "old"
+
+
+# ---------------------------------------------------------------------------
+# collect_skill_env
+# ---------------------------------------------------------------------------
+
+
+class TestCollectSkillEnv:
+    def test_merges_deps_and_global(self, tmp_path):
+        base = str(tmp_path)
+
+        # Skill dep with env
+        skill_a = _write_skill(
+            base, "skill-a",
+            env={"TOKEN_A": {"required": True, "description": "A"}},
+        )
+
+        # Global skill with env
+        global_dir = tmp_path / "global_skills" / "skill-g"
+        global_dir.mkdir(parents=True)
+        (global_dir / "SKILL.md").write_text(
+            "---\nname: skill-g\ndescription: global\n"
+            "metadata:\n  strawpot:\n    env:\n      TOKEN_G:\n"
+            "        required: true\n        description: G\n---\nbody\n"
+        )
+
+        role_path = _write_role(base, "my-role", skill_deps=["skill-a"])
+        resolved = {
+            "slug": "my-role",
+            "kind": "role",
+            "path": role_path,
+            "dependencies": [
+                {"slug": "skill-a", "kind": "skill", "path": skill_a},
+            ],
+        }
+
+        result = collect_skill_env(
+            resolved,
+            global_skills=[("skill-g", "global", str(global_dir))],
+        )
+        assert "TOKEN_A" in result
+        assert "TOKEN_G" in result
+
+    def test_required_wins_across_skills(self, tmp_path):
+        base = str(tmp_path)
+        skill_a = _write_skill(
+            base, "skill-a",
+            env={"SHARED": {"required": False, "description": "optional"}},
+        )
+        skill_b = _write_skill(
+            base, "skill-b",
+            env={"SHARED": {"required": True, "description": "required"}},
+        )
+        role_path = _write_role(
+            base, "my-role", skill_deps=["skill-a", "skill-b"]
+        )
+        resolved = {
+            "slug": "my-role",
+            "kind": "role",
+            "path": role_path,
+            "dependencies": [
+                {"slug": "skill-a", "kind": "skill", "path": skill_a},
+                {"slug": "skill-b", "kind": "skill", "path": skill_b},
+            ],
+        }
+        result = collect_skill_env(resolved)
+        assert result["SHARED"]["required"] is True
+
+    def test_collects_env_from_delegatable_roles(self, tmp_path):
+        """Env from skills of delegatable (child) roles is included."""
+        base = str(tmp_path)
+
+        # Skill owned by the child role
+        child_skill = _write_skill(
+            base, "child-skill",
+            env={"CHILD_TOKEN": {"required": True, "description": "child"}},
+        )
+
+        # Child role that depends on child-skill
+        child_role = _write_role(
+            base, "child-role", skill_deps=["child-skill"],
+        )
+
+        # Parent role delegates to child-role (no direct skill deps)
+        parent_role = _write_role(
+            base, "parent-role", role_deps=["child-role"],
+        )
+
+        resolved = {
+            "slug": "parent-role",
+            "kind": "role",
+            "path": parent_role,
+            "dependencies": [
+                {"slug": "child-skill", "kind": "skill", "path": child_skill},
+                {"slug": "child-role", "kind": "role", "path": child_role},
+            ],
+        }
+
+        result = collect_skill_env(resolved)
+        assert "CHILD_TOKEN" in result
+        assert result["CHILD_TOKEN"]["required"] is True
+
+    def test_collects_env_from_nested_delegatable_roles(self, tmp_path):
+        """Env from skills of deeply nested delegatable roles is collected."""
+        base = str(tmp_path)
+
+        leaf_skill = _write_skill(
+            base, "leaf-skill",
+            env={"LEAF_VAR": {"required": True, "description": "leaf"}},
+        )
+        grandchild_role = _write_role(
+            base, "grandchild", skill_deps=["leaf-skill"],
+        )
+        child_role = _write_role(
+            base, "child", role_deps=["grandchild"],
+        )
+        parent_role = _write_role(
+            base, "parent", role_deps=["child"],
+        )
+
+        resolved = {
+            "slug": "parent",
+            "kind": "role",
+            "path": parent_role,
+            "dependencies": [
+                {"slug": "leaf-skill", "kind": "skill", "path": leaf_skill},
+                {"slug": "grandchild", "kind": "role", "path": grandchild_role},
+                {"slug": "child", "kind": "role", "path": child_role},
+            ],
+        }
+
+        result = collect_skill_env(resolved)
+        assert "LEAF_VAR" in result
+
+    def test_merges_env_across_own_and_delegatable_skills(self, tmp_path):
+        """Env from both the role's own skills and delegatable roles' skills
+        are merged, with required: true winning."""
+        base = str(tmp_path)
+
+        own_skill = _write_skill(
+            base, "own-skill",
+            env={"SHARED": {"required": False, "description": "optional"}},
+        )
+        child_skill = _write_skill(
+            base, "child-skill",
+            env={"SHARED": {"required": True, "description": "required"}},
+        )
+        child_role = _write_role(
+            base, "child-role", skill_deps=["child-skill"],
+        )
+        parent_role = _write_role(
+            base, "parent-role",
+            skill_deps=["own-skill"], role_deps=["child-role"],
+        )
+
+        resolved = {
+            "slug": "parent-role",
+            "kind": "role",
+            "path": parent_role,
+            "dependencies": [
+                {"slug": "own-skill", "kind": "skill", "path": own_skill},
+                {"slug": "child-skill", "kind": "skill", "path": child_skill},
+                {"slug": "child-role", "kind": "role", "path": child_role},
+            ],
+        }
+
+        result = collect_skill_env(resolved)
+        assert result["SHARED"]["required"] is True
+
+
+# ---------------------------------------------------------------------------
+# validate_skill_env
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSkillEnv:
+    def test_missing_required(self, monkeypatch):
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+        schema = {"MISSING_VAR": {"required": True, "description": "x"}}
+        result = validate_skill_env(schema)
+        assert not result.ok
+        assert "MISSING_VAR" in result.missing_env
+
+    def test_all_present(self, monkeypatch):
+        monkeypatch.setenv("PRESENT_VAR", "value")
+        schema = {"PRESENT_VAR": {"required": True, "description": "x"}}
+        result = validate_skill_env(schema)
+        assert result.ok
+
+    def test_optional_not_required(self, monkeypatch):
+        monkeypatch.delenv("OPT_VAR", raising=False)
+        schema = {"OPT_VAR": {"required": False, "description": "x"}}
+        result = validate_skill_env(schema)
+        assert result.ok
+
+
+# ---------------------------------------------------------------------------
+# handle_delegate — skill env validation
+# ---------------------------------------------------------------------------
+
+
+class TestHandleDelegateSkillEnv:
+    def test_fails_on_missing_skill_env(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("REQUIRED_TOKEN", raising=False)
+
+        base = str(tmp_path)
+        skill_path = _write_skill(
+            base, "needs-token",
+            env={"REQUIRED_TOKEN": {"required": True, "description": "token"}},
+        )
+        role_path = _write_role(
+            base, "my-role", skill_deps=["needs-token"]
+        )
+
+        def mock_resolve(slug, kind="role"):
+            return {
+                "slug": slug,
+                "kind": kind,
+                "path": role_path,
+                "source": "local",
+                "dependencies": [
+                    {"slug": "needs-token", "kind": "skill", "path": skill_path},
+                ],
+            }
+
+        request = _make_request(role_slug="my-role")
+        config = StrawPotConfig(allowed_roles=["my-role"])
+
+        runtime = MagicMock()
+        runtime.name = "mock"
+
+        with pytest.raises(DelegationError, match="REQUIRED_TOKEN"):
+            handle_delegate(
+                request=request,
+                config=config,
+                runtime=runtime,
+                working_dir=base,
+                session_dir=str(tmp_path / "session"),
+                resolve_role=mock_resolve,
+                resolve_role_dirs=lambda s: None,
+            )

--- a/docs/strawhub/concepts/skills.mdx
+++ b/docs/strawhub/concepts/skills.mdx
@@ -45,6 +45,7 @@ Step-by-step instructions for the agent...
 |-------|-------------|
 | `metadata.strawpot.dependencies` | List of skill dependencies with optional version constraints |
 | `metadata.strawpot.tools` | System tool requirements with OS-specific install commands |
+| `metadata.strawpot.env` | Required environment variables (prompted at session start) |
 
 ## Dependencies
 
@@ -87,6 +88,24 @@ metadata:
 Supported OS keys: `macos`, `linux`, `windows`.
 
 Use `--skip-tools` during install to opt out, or run `strawhub install-tools` later to re-check.
+
+## Environment Variables
+
+Skills can declare required environment variables. At session start, the CLI checks if each required variable is set and prompts the user interactively for missing ones.
+
+```yaml
+metadata:
+  strawpot:
+    env:
+      GITHUB_TOKEN:
+        required: true
+        description: GitHub API token
+      OPTIONAL_VAR:
+        required: false
+        description: Optional configuration value
+```
+
+Variables set at session start are inherited by all sub-agents. During delegation, missing required variables cause the delegation to fail with a clear error message.
 
 ## Supporting Files
 

--- a/docs/strawhub/publishing/frontmatter.mdx
+++ b/docs/strawhub/publishing/frontmatter.mdx
@@ -25,6 +25,10 @@ metadata:
           macos: brew install gh
           linux: apt install gh
           windows: winget install GitHub.cli
+    env:                                   # Optional: required environment variables
+      GITHUB_TOKEN:
+        required: true
+        description: GitHub API token
 ---
 
 # Skill Title
@@ -40,6 +44,7 @@ Markdown body with instructions for the agent...
 | `description` | Yes | One-line summary |
 | `metadata.strawpot.dependencies` | No | Flat list of skill slugs with optional version constraints |
 | `metadata.strawpot.tools` | No | System tool requirements |
+| `metadata.strawpot.env` | No | Required environment variables (prompted at session start) |
 
 ## Role Frontmatter (`ROLE.md`)
 
@@ -113,6 +118,22 @@ metadata:
 - Install commands run in the user's shell
 - Only the current OS command is executed
 - Supported OS keys: `macos`, `linux`, `windows`
+
+## Environment Variables Schema
+
+```yaml
+metadata:
+  strawpot:
+    env:
+      <VARIABLE_NAME>:
+        required: <boolean>          # Whether the variable must be set
+        description: <string>        # Human-readable description
+```
+
+- At session start, missing required variables are prompted interactively
+- During delegation, missing required variables cause the delegation to fail
+- Variables set at session start are inherited by all sub-agents
+- If the same variable appears in multiple skills, `required: true` takes precedence
 
 ## Key Differences: Skills vs Roles
 


### PR DESCRIPTION
## Summary
- Skills can now declare required environment variables via `metadata.strawpot.env` in SKILL.md frontmatter
- At session start, `collect_skill_env()` walks the full dependency graph (own transitive skills, delegatable roles' skills recursively, global skills) and prompts for all missing required vars upfront
- During delegation, missing required vars trigger a fail-fast `DelegationError` — sub-agents never prompt interactively
- Merge strategy: when the same var appears in multiple skills, `required: true` takes precedence

## Test plan
- [x] 15 new tests across `TestParseSkillEnv`, `TestMergeEnvEntry`, `TestCollectSkillEnv`, `TestValidateSkillEnv`, `TestHandleDelegateSkillEnv`
- [x] Tests cover recursive role delegation env collection (parent → child → grandchild)
- [x] Full suite passes (399 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)