### PR TITLE
Add TODO items for wildcard dependencies and persistent config

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,3 +27,38 @@ Full design for the web-based management interface is pending. Topics to cover:
 - Strawhub browsing / installing
 - Agent configuration and role management
 - Session monitoring and logs
+
+## 5. Support `"*"` wildcard in role dependencies
+
+Add support for `"*"` as a special value in role `dependencies`, meaning "depend on all roles available globally and locally." This wildcard should be ignored by install commands (both `strawhub` CLI and `strawpot` CLI proxy) since it doesn't refer to a specific installable package.
+
+## 6. Persistent user configuration for env, agent params, and default_agent
+
+Currently, SKILL.md `env` values are prompted every session and never saved, AGENT.md `params` are persisted only via `[agents.<name>]` in `config.toml`, and ROLE.md `default_agent` has no user-override mechanism beyond the global `runtime` setting.
+
+Design a unified persistent configuration layer so users can set and reuse these values across sessions, and the Web GUI can read/write them.
+
+### Recommended approach: extend `config.toml`
+
+Reuse the existing `config.toml` (global `~/.strawpot/config.toml` and project-local `.strawpot/config.toml`) with new sections:
+
+```toml
+# Persist env values for skills (avoids re-prompting each session)
+[skills.github_pr.env]
+GITHUB_TOKEN = "ghp_..."
+
+# Override a role's default_agent
+[roles.implementer]
+default_agent = "claude_code"
+
+# Agent params already supported — no changes needed
+[agents.claude_code]
+model = "claude-sonnet-4-6"
+```
+
+### Design considerations
+- **Global vs local layering** — project-local overrides global, matching the existing `config.toml` merge behavior
+- **Env resolution order** — saved value → environment variable → interactive prompt (only prompt if still missing)
+- **Secret handling** — env values may contain secrets; consider whether to store them in plain text, use OS keychain integration, or reference external secret managers
+- **Web GUI integration** — the GUI should be able to list configurable fields (from frontmatter schemas) and read/write the corresponding `config.toml` sections
+- **Validation** — validate saved values against frontmatter-declared types and `required` flags at load time


### PR DESCRIPTION
## Summary
- **Item 5**: Support `"*"` wildcard in role `dependencies` — means "depend on all roles available globally and locally," ignored by install commands (both `strawhub` CLI and `strawpot` CLI proxy)
- **Item 6**: Persistent user configuration for `env` (SKILL.md/AGENT.md), agent `params`, and `default_agent` (ROLE.md) — recommends extending `config.toml` with `[skills.<slug>.env]` and `[roles.<slug>]` sections, reusing the existing global/local layering

## Test plan
- [ ] Review TODO.md for accuracy and completeness
- [ ] Confirm no existing items were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)