### PR TITLE
Rename config.toml to strawpot.toml, move project config to root

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -429,8 +429,8 @@ creating a PR. Users can swap `gh` for `glab`, a custom script, etc.
 
 Loaded from (later overrides earlier):
 1. Built-in defaults
-2. `$STRAWPOT_HOME/config.toml` (global — defaults to `~/.strawpot/`)
-3. `.strawpot/config.toml` (project-level, in CWD)
+2. `$STRAWPOT_HOME/strawpot.toml` (global — defaults to `~/.strawpot/`)
+3. `strawpot.toml` (project-level, in project root)
 4. CLI flags
 
 Environment variables:
@@ -442,7 +442,7 @@ Environment variables:
 ## Config Format
 
 ```toml
-# .strawpot/config.toml
+# strawpot.toml (project root)
 runtime = "claude_code"
 isolation = "none"               # none | worktree | docker
 
@@ -1650,7 +1650,7 @@ Event types: `AGENT_STARTED`, `MEMORY_GET_USED`, `TOOL_CALL`, `TOOL_RESULT`,
 ### Config
 
 ```toml
-# .strawpot/config.toml
+# strawpot.toml (project root)
 memory = "strawpot-memory-local"   # provider name (default: none/disabled)
 
 [memory_config]
@@ -1744,7 +1744,7 @@ a read-only observer that renders existing runtime data.
 ### Features
 
 **Project Management**
-- Register projects (directories with `.strawpot/config.toml`)
+- Register projects (directories with `strawpot.toml`)
 - View project config and installed agents/skills/roles
 - Quick-launch sessions from the GUI
 
@@ -1775,7 +1775,7 @@ The GUI reads existing runtime artifacts — no new data formats needed:
 | Agent output | `.strawpot/sessions/*/agents/*/.log` | Text |
 | Denden status | gRPC connection to running server | Live |
 | Event memory | Memory provider store | Provider-specific |
-| Project config | `.strawpot/config.toml` | TOML |
+| Project config | `strawpot.toml` | TOML |
 
 ### CLI Integration
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ strawpot config
 
 ## Configuration
 
-Global: `$STRAWPOT_HOME/config.toml` (default `~/.strawpot/config.toml`)
-Project: `.strawpot/config.toml`
+Global: `$STRAWPOT_HOME/strawpot.toml` (default `~/.strawpot/strawpot.toml`)
+Project: `strawpot.toml` (project root)
 
 ```toml
 runtime = "claude_code"       # claude_code | codex | openhands

--- a/TODO.md
+++ b/TODO.md
@@ -27,3 +27,38 @@ Full design for the web-based management interface is pending. Topics to cover:
 - Strawhub browsing / installing
 - Agent configuration and role management
 - Session monitoring and logs
+
+## 5. Support `"*"` wildcard in role dependencies
+
+Add support for `"*"` as a special value in role `dependencies`, meaning "depend on all roles available globally and locally." This wildcard should be ignored by install commands (both `strawhub` CLI and `strawpot` CLI proxy) since it doesn't refer to a specific installable package.
+
+## 6. Persistent user configuration for env, agent params, and default_agent
+
+Currently, SKILL.md `env` values are prompted every session and never saved, AGENT.md `params` are persisted only via `[agents.<name>]` in `strawpot.toml`, and ROLE.md `default_agent` has no user-override mechanism beyond the global `runtime` setting.
+
+Design a unified persistent configuration layer so users can set and reuse these values across sessions, and the Web GUI can read/write them.
+
+### Recommended approach: extend `strawpot.toml`
+
+Reuse the existing `strawpot.toml` (global `~/.strawpot/strawpot.toml` and project-level `strawpot.toml` at project root) with new sections:
+
+```toml
+# Persist env values for skills (avoids re-prompting each session)
+[skills.github_pr.env]
+GITHUB_TOKEN = "ghp_..."
+
+# Override a role's default_agent
+[roles.implementer]
+default_agent = "claude_code"
+
+# Agent params already supported — no changes needed
+[agents.claude_code]
+model = "claude-sonnet-4-6"
+```
+
+### Design considerations
+- **Global vs local layering** — project-local overrides global, matching the existing `strawpot.toml` merge behavior
+- **Env resolution order** — saved value → environment variable → interactive prompt (only prompt if still missing)
+- **Secret handling** — env values may contain secrets; consider whether to store them in plain text, use OS keychain integration, or reference external secret managers
+- **Web GUI integration** — the GUI should be able to list configurable fields (from frontmatter schemas) and read/write the corresponding `strawpot.toml` sections
+- **Validation** — validate saved values against frontmatter-declared types and `required` flags at load time

--- a/cli/README.md
+++ b/cli/README.md
@@ -32,8 +32,8 @@ strawpot config
 
 ## Configuration
 
-Global: `$STRAWPOT_HOME/config.toml` (default `~/.strawpot/config.toml`)
-Project: `.strawpot/config.toml`
+Global: `$STRAWPOT_HOME/strawpot.toml` (default `~/.strawpot/strawpot.toml`)
+Project: `strawpot.toml` (project root)
 
 ```toml
 runtime = "claude_code"       # claude_code | codex | openhands

--- a/cli/src/strawpot/agents/registry.py
+++ b/cli/src/strawpot/agents/registry.py
@@ -150,7 +150,7 @@ def resolve_agent(
     Args:
         name: Agent name (e.g. ``"claude_code"``).
         project_dir: Project root directory.
-        user_config: Per-agent config from ``[agents.<name>]`` in config.toml.
+        user_config: Per-agent config from ``[agents.<name>]`` in strawpot.toml.
 
     Returns:
         Resolved AgentSpec.

--- a/cli/src/strawpot/config.py
+++ b/cli/src/strawpot/config.py
@@ -96,18 +96,18 @@ def _apply(config: StrawPotConfig, data: dict) -> None:
 def load_config(project_dir: Path | None = None) -> StrawPotConfig:
     """Load config merging: defaults < global < project-level.
 
-    Global: $STRAWPOT_HOME/config.toml (default ~/.strawpot/config.toml)
-    Project: <project_dir>/.strawpot/config.toml
+    Global: $STRAWPOT_HOME/strawpot.toml (default ~/.strawpot/strawpot.toml)
+    Project: <project_dir>/strawpot.toml
     """
     config = StrawPotConfig()
 
     # Global config
-    global_path = get_strawpot_home() / "config.toml"
+    global_path = get_strawpot_home() / "strawpot.toml"
     _apply(config, _read_toml(global_path))
 
     # Project config
     if project_dir:
-        project_path = project_dir / ".strawpot" / "config.toml"
+        project_path = project_dir / "strawpot.toml"
         _apply(config, _read_toml(project_path))
 
     return config

--- a/cli/src/strawpot/memory/registry.py
+++ b/cli/src/strawpot/memory/registry.py
@@ -95,7 +95,7 @@ def resolve_memory(
     Args:
         name: Memory provider name (e.g. ``"strawpot-memory-local"``).
         project_dir: Project root directory.
-        user_config: Per-provider config from ``[memory_config]`` in config.toml.
+        user_config: Per-provider config from ``[memory_config]`` in strawpot.toml.
 
     Returns:
         Resolved MemorySpec.

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -43,7 +43,7 @@ def test_load_config_no_files(tmp_path):
 def test_load_config_global(tmp_path, monkeypatch):
     global_dir = tmp_path / "global"
     global_dir.mkdir()
-    (global_dir / "config.toml").write_text(
+    (global_dir / "strawpot.toml").write_text(
         '[agents.claude_code]\nmodel = "claude-opus-4-6"\n'
     )
     monkeypatch.setenv("STRAWPOT_HOME", str(global_dir))
@@ -57,14 +57,13 @@ def test_load_config_project_overrides_global(tmp_path, monkeypatch):
     # Global config
     global_dir = tmp_path / "global"
     global_dir.mkdir()
-    (global_dir / "config.toml").write_text('runtime = "codex"\n')
+    (global_dir / "strawpot.toml").write_text('runtime = "codex"\n')
     monkeypatch.setenv("STRAWPOT_HOME", str(global_dir))
 
     # Project config
     project_dir = tmp_path / "project"
-    strawpot_dir = project_dir / ".strawpot"
-    strawpot_dir.mkdir(parents=True)
-    (strawpot_dir / "config.toml").write_text('runtime = "openhands"\n')
+    project_dir.mkdir(parents=True)
+    (project_dir / "strawpot.toml").write_text('runtime = "openhands"\n')
 
     config = load_config(project_dir)
     assert config.runtime == "openhands"
@@ -74,9 +73,8 @@ def test_load_config_full(tmp_path, monkeypatch):
     monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "nonexistent"))
 
     project_dir = tmp_path / "project"
-    strawpot_dir = project_dir / ".strawpot"
-    strawpot_dir.mkdir(parents=True)
-    (strawpot_dir / "config.toml").write_text(
+    project_dir.mkdir(parents=True)
+    (project_dir / "strawpot.toml").write_text(
         'runtime = "codex"\n'
         'isolation = "docker"\n'
         'memory = "test-provider"\n'
@@ -128,7 +126,7 @@ def test_load_config_session_override(tmp_path, monkeypatch):
     """Project [session] overrides global [session] per-key."""
     global_dir = tmp_path / "global"
     global_dir.mkdir()
-    (global_dir / "config.toml").write_text(
+    (global_dir / "strawpot.toml").write_text(
         "[session]\n"
         'merge_strategy = "local"\n'
         'pull_before_session = "never"\n'
@@ -136,9 +134,8 @@ def test_load_config_session_override(tmp_path, monkeypatch):
     monkeypatch.setenv("STRAWPOT_HOME", str(global_dir))
 
     project_dir = tmp_path / "project"
-    strawpot_dir = project_dir / ".strawpot"
-    strawpot_dir.mkdir(parents=True)
-    (strawpot_dir / "config.toml").write_text(
+    project_dir.mkdir(parents=True)
+    (project_dir / "strawpot.toml").write_text(
         "[session]\n"
         'merge_strategy = "pr"\n'
     )
@@ -152,15 +149,14 @@ def test_load_config_agents_merge(tmp_path, monkeypatch):
     """Agent config from project overrides global per-key, not wholesale."""
     global_dir = tmp_path / "global"
     global_dir.mkdir()
-    (global_dir / "config.toml").write_text(
+    (global_dir / "strawpot.toml").write_text(
         '[agents.claude_code]\nmodel = "claude-opus-4-6"\ntimeout = 300\n'
     )
     monkeypatch.setenv("STRAWPOT_HOME", str(global_dir))
 
     project_dir = tmp_path / "project"
-    strawpot_dir = project_dir / ".strawpot"
-    strawpot_dir.mkdir(parents=True)
-    (strawpot_dir / "config.toml").write_text(
+    project_dir.mkdir(parents=True)
+    (project_dir / "strawpot.toml").write_text(
         '[agents.claude_code]\nmodel = "claude-sonnet-4-6"\n'
     )
 
@@ -174,7 +170,7 @@ def test_load_config_memory_merge(tmp_path, monkeypatch):
     """Memory config from project merges with global per-key."""
     global_dir = tmp_path / "global"
     global_dir.mkdir()
-    (global_dir / "config.toml").write_text(
+    (global_dir / "strawpot.toml").write_text(
         'memory = "my-provider"\n'
         "\n"
         "[memory_config]\n"
@@ -184,9 +180,8 @@ def test_load_config_memory_merge(tmp_path, monkeypatch):
     monkeypatch.setenv("STRAWPOT_HOME", str(global_dir))
 
     project_dir = tmp_path / "project"
-    strawpot_dir = project_dir / ".strawpot"
-    strawpot_dir.mkdir(parents=True)
-    (strawpot_dir / "config.toml").write_text(
+    project_dir.mkdir(parents=True)
+    (project_dir / "strawpot.toml").write_text(
         "[memory_config]\n"
         'storage_dir = "/project/mem"\n'
     )

--- a/docs/agents/claude-code.mdx
+++ b/docs/agents/claude-code.mdx
@@ -16,7 +16,7 @@ Claude Code is the default agent runtime in StrawPot. It ships as a built-in age
 ## Configuration
 
 ```toml
-# .strawpot/config.toml
+# strawpot.toml (project root)
 runtime = "claude_code"
 
 [agents.claude_code]

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -10,14 +10,14 @@ StrawPot uses TOML configuration files with a layered hierarchy.
 Settings are merged in order (later overrides earlier):
 
 1. **Built-in defaults** — Sensible defaults for all options
-2. **Global config** — `~/.strawpot/config.toml` (or `$STRAWPOT_HOME/config.toml`)
-3. **Project config** — `.strawpot/config.toml` (in project root)
+2. **Global config** — `~/.strawpot/strawpot.toml` (or `$STRAWPOT_HOME/strawpot.toml`)
+3. **Project config** — `strawpot.toml` (in project root)
 4. **CLI flags** — Override everything
 
 ## Full Reference
 
 ```toml
-# .strawpot/config.toml
+# strawpot.toml (project root)
 
 # Agent runtime to use for the orchestrator
 # Options: claude_code, codex, openhands, or any custom agent name
@@ -96,8 +96,8 @@ Agent-specific environment variables (e.g. `ANTHROPIC_API_KEY`) are declared in 
 
 | Scope | Path |
 |-------|------|
-| Global | `~/.strawpot/config.toml` |
-| Project | `.strawpot/config.toml` |
+| Global | `~/.strawpot/strawpot.toml` |
+| Project | `strawpot.toml` |
 
 The global config applies to all projects. The project config is specific to the repository it lives in. CLI flags override both.
 

--- a/docs/concepts/isolation.mdx
+++ b/docs/concepts/isolation.mdx
@@ -16,7 +16,7 @@ StrawPot creates one isolated environment per session. All agents in a session â
 Set the strategy in your config or via CLI flag:
 
 ```toml
-# .strawpot/config.toml
+# strawpot.toml (project root)
 isolation = "worktree"
 ```
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -33,7 +33,7 @@ strawpot start
 ```
 
 This will:
-1. Load configuration from `.strawpot/config.toml` (if present) and `~/.strawpot/config.toml`
+1. Load configuration from `strawpot.toml` (if present) and `~/.strawpot/strawpot.toml`
 2. Resolve the agent runtime (default: Claude Code)
 3. Start a Denden gRPC server on `127.0.0.1:9700`
 4. Spawn the orchestrator agent in your terminal
@@ -74,7 +74,7 @@ strawpot search "code review"
 Create a project-level config file:
 
 ```toml
-# .strawpot/config.toml
+# strawpot.toml (project root)
 runtime = "claude_code"
 isolation = "worktree"
 

--- a/docs/strawhub/concepts/agents.mdx
+++ b/docs/strawhub/concepts/agents.mdx
@@ -152,7 +152,7 @@ metadata:
 ```
 
 ```toml
-# .strawpot/config.toml
+# strawpot.toml (project root)
 [agents.my_agent]
 model = "gpt-4o"
 temperature = "0.2"

--- a/docs/strawhub/publishing/frontmatter.mdx
+++ b/docs/strawhub/publishing/frontmatter.mdx
@@ -171,7 +171,7 @@ metadata:
         description: <string>       # Human-readable description
 ```
 
-- Defaults from `AGENT.md` are merged with user config from `[agents.<name>]` in `config.toml`
+- Defaults from `AGENT.md` are merged with user config from `[agents.<name>]` in `strawpot.toml`
 - User values take precedence over defaults
 - The merged config is passed to the agent binary as the `--config` JSON string
 


### PR DESCRIPTION
## Summary
- Rename `config.toml` → `strawpot.toml` to avoid generic naming conflicts
- Move project-level config from `.strawpot/strawpot.toml` to `strawpot.toml` at project root, sharing the same file as strawhub's dependency manifest (sections don't overlap)
- Global config remains at `~/.strawpot/strawpot.toml`
- Updated across 14 files: implementation, tests (all 10 pass), and documentation
- TODO items #5 and #6 updated with new naming

## Test plan
- [x] All 10 config tests pass
- [x] No remaining `.strawpot/config.toml` or `.strawpot/strawpot.toml` project-level references
- [ ] Verify strawhub dependency sections and strawpot config sections coexist in the same `strawpot.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)