### PR TITLE
Add two-tier session tracing

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -58,9 +58,10 @@ src/strawpot/
   isolation/
     protocol.py            # Isolator protocol, IsolatedEnv
     worktree.py            # WorktreeIsolator
+  trace.py                 # Session tracing — JSONL events + content-addressed artifacts
 ```
 
-13 source files. No agent-specific code in the core — agents are installed
+14 source files. No agent-specific code in the core — agents are installed
 via StrawHub (e.g. `strawhub install agent strawpot_claude_code --global`).
 
 ---
@@ -404,6 +405,7 @@ class StrawPotConfig:
     merge_strategy: str = "auto"       # auto | local | pr
     pull_before_session: str = "prompt" # auto | always | never | prompt
     pr_command: str = "gh pr create --base {base_branch} --head {session_branch}"
+    trace: bool = True                 # emit JSONL trace events per session
 ```
 
 `agents` holds agent-specific config keyed by agent name. These are extras
@@ -430,6 +432,9 @@ creating a worktree or docker session:
 - `never` — skip, use current HEAD
 - `prompt` — ask the user each time (default)
 
+`trace` enables the two-tier tracing system (JSONL events + content-addressed
+artifacts). Default on. Disable with `[trace] enabled = false` in config.
+
 `pr_command` is the command template for creating PRs. Supports `{base_branch}`
 and `{session_branch}` placeholders. Set to empty string to push without
 creating a PR. Users can swap `gh` for `glab`, a custom script, etc.
@@ -443,6 +448,69 @@ Loaded from (later overrides earlier):
 Environment variables:
 - `STRAWPOT_HOME` — global config/data directory (default: `~/.strawpot/`).
   Also used by `strawhub` CLI for skill/role install paths.
+
+### Tracer (`trace.py`)
+
+Two-tier tracing: a lightweight JSONL event stream for metadata + span tree,
+and a content-addressed artifact store for large payloads (context prompts,
+agent output, memory cards).
+
+```python
+@dataclass
+class TraceEvent:
+    ts: str                          # ISO 8601 UTC
+    event: str                       # event name
+    trace_id: str                    # = run_id (session-scoped)
+    span_id: str                     # uuid hex[:12]
+    parent_span: str | None = None   # parent span for tree reconstruction
+    data: dict = field(default_factory=dict)
+
+class Tracer:
+    def __init__(self, session_dir: str, trace_id: str) -> None:
+        # Creates <session_dir>/trace.jsonl and <session_dir>/artifacts/
+        ...
+
+    def store_artifact(self, content: str) -> str | None:
+        # Writes to artifacts/<sha256[:12]>, deduplicates, returns ref
+        # Returns None for empty content
+        ...
+
+    def emit(self, event, span_id, parent_span=None, **data) -> None:
+        # Appends one JSONL line. Wrapped in try/except — never crashes the session.
+        ...
+```
+
+Convenience methods (each calls `emit` + `store_artifact` as needed):
+
+| Method | Returns | Stores artifact |
+|--------|---------|-----------------|
+| `session_start(run_id, role, runtime, isolation)` | span_id | — |
+| `session_end(span_id, merge_strategy, duration_ms)` | — | — |
+| `delegate_start(role, parent_span, context)` | span_id | context → `context_ref` |
+| `delegate_end(span_id, exit_code, summary, duration_ms)` | — | — |
+| `delegate_denied(role, parent_span, reason)` | — | — |
+| `memory_get(span_id, provider, cards, card_count)` | — | cards JSON → `cards_ref` |
+| `memory_dump(span_id, provider, entries, entry_count)` | — | entries → `entries_ref` |
+| `agent_spawn(span_id, agent_id, runtime, pid)` | — | — |
+| `agent_end(span_id, exit_code, output, duration_ms)` | — | output → `output_ref` |
+
+Session output layout:
+
+```
+.strawpot/sessions/<run_id>/
+  session.json
+  trace.jsonl          ← JSONL event stream (metadata + artifact refs)
+  artifacts/           ← content-addressed store for large payloads
+    a1b2c3d4e5f6       ← sha256[:12] filename, plain text content
+    ...
+```
+
+The span tree enables call-tree reconstruction:
+- `session_start` is the root span (no parent)
+- `delegate_start` sets `parent_span` to the requesting agent's span
+- `agent_spawn`, `memory_get`, `memory_dump`, `agent_end` inherit the
+  delegation span_id
+- Nested delegations form a tree: session → delegate A→B → delegate B→C
 
 ---
 
@@ -486,6 +554,11 @@ GITHUB_TOKEN = "ghp_..."
 # Role overrides — override ROLE.md frontmatter settings.
 [roles.implementer]
 default_agent = "claude_code"
+
+# Tracing — JSONL events + content-addressed artifacts per session.
+# Default: enabled. Set to false to disable.
+[trace]
+enabled = true
 ```
 
 ---
@@ -511,6 +584,7 @@ default_agent = "claude_code"
 6. session = Session(config, wrapper, runtime, isolator)
 7. session.start():
    a. run_id = "run_" + uuid4()
+      → if config.trace: create Tracer(session_dir, run_id), emit session_start
    b. Create isolated env (or use CWD directly):
       env = isolator.create(session_id=run_id, base_dir=working_dir)
       → isolation=none:     env.path = working_dir (no-op)
@@ -566,8 +640,8 @@ Denden server dispatches to `Session._handle_delegate`:
 ```
 1. Extract: role_slug, task_text, parent_agent_id, run_id from request
 2. Policy check:
-   - role_slug in allowed_roles?  → DENY_ROLE_NOT_ALLOWED
-   - depth > max_depth?           → DENY_DEPTH_LIMIT
+   - role_slug in allowed_roles?  → DENY_ROLE_NOT_ALLOWED (+ trace: delegate_denied)
+   - depth > max_depth?           → DENY_DEPTH_LIMIT (+ trace: delegate_denied)
 3. Resolve:
    resolved = strawhub.resolver.resolve(role_slug, kind="role")
    → {slug, version, path, dependencies: [{slug, kind, path}, ...]}
@@ -595,6 +669,7 @@ Denden server dispatches to `Session._handle_delegate`:
    workspace = create_agent_workspace(session_dir, agent_id)
    → per-agent scratch directory at session_dir/agents/<agent_id>/ (clean — no pre-placed files)
 6. Spawn in session worktree (shared — no new worktree):
+   → trace: delegate_start (stores context as artifact)
    handle = runtime.spawn(
      agent_id=agent_id, working_dir=self.env.path,
      agent_workspace_dir=workspace,
@@ -606,12 +681,16 @@ Denden server dispatches to `Session._handle_delegate`:
           DENDEN_PARENT_AGENT_ID, DENDEN_RUN_ID}
    )
    → WrapperRuntime calls wrapper CLI with standard protocol args
+   → trace: agent_spawn
 7. Wait:
    result = runtime.wait(handle, timeout=config.agent_timeout)
    (blocks — sequential DAG, one sub-agent at a time)
+   → trace: agent_end (stores output as artifact)
    → on timeout: runtime.kill(handle), return error response
      "Agent timed out after {timeout}s" to parent
+   → trace: memory_dump (if memory provider configured)
 8. Return:
+   → trace: delegate_end (exit_code, summary, duration_ms)
    ok_response(request_id, delegate_result=DelegateResult(summary=result.summary))
 ```
 

--- a/cli/src/strawpot/config.py
+++ b/cli/src/strawpot/config.py
@@ -39,6 +39,7 @@ class StrawPotConfig:
     merge_strategy: str = "auto"
     pull_before_session: str = "prompt"
     pr_command: str = _DEFAULT_PR_COMMAND
+    trace: bool = True
 
 
 def _read_toml(path: Path) -> dict:
@@ -103,6 +104,10 @@ def _apply(config: StrawPotConfig, data: dict) -> None:
         config.pull_before_session = session["pull_before_session"]
     if "pr_command" in session:
         config.pr_command = session["pr_command"]
+
+    trace_section = data.get("trace", {})
+    if "enabled" in trace_section:
+        config.trace = trace_section["enabled"]
 
 
 def load_config(project_dir: Path | None = None) -> StrawPotConfig:

--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -1,13 +1,20 @@
 """Delegate handler — policy check, resolve, build prompt, spawn, wait."""
 
+from __future__ import annotations
+
 import json
 import logging
 import os
 import shutil
+import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from strawpot.trace import Tracer
 
 from strawpot.agents.protocol import AgentHandle, AgentResult, AgentRuntime
 from strawpot.agents.registry import resolve_agent
@@ -626,6 +633,24 @@ def _agent_status(result: AgentResult, *, timed_out: bool = False) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _emit_delegate_end(
+    tracer: Tracer | None,
+    span_id: str | None,
+    exit_code: int,
+    summary: str,
+    start_time: float,
+) -> None:
+    """Emit delegate_end if tracer is active."""
+    if tracer is not None and span_id is not None:
+        duration_ms = int((time.monotonic() - start_time) * 1000)
+        tracer.delegate_end(
+            span_id=span_id,
+            exit_code=exit_code,
+            summary=summary,
+            duration_ms=duration_ms,
+        )
+
+
 def handle_delegate(
     *,
     request: DelegateRequest,
@@ -637,6 +662,9 @@ def handle_delegate(
     resolve_role_dirs: Callable[[str], str | None],
     denden_addr: str | None = None,
     memory_provider: MemoryProvider | None = None,
+    tracer: Tracer | None = None,
+    parent_span: str | None = None,
+    agent_spans: dict[str, str] | None = None,
 ) -> DelegateResult:
     """Handle a delegation request end-to-end.
 
@@ -665,6 +693,11 @@ def handle_delegate(
             precedence over ``config.denden_addr``.
         memory_provider: Optional memory provider. When set, ``get()``
             is called before spawn and ``dump()`` after wait.
+        tracer: Optional session tracer for JSONL event emission.
+        parent_span: Parent span ID for delegation tree reconstruction.
+        agent_spans: Shared dict mapping agent_id to its delegation
+            span_id.  Populated here so sub-delegations from the
+            spawned agent can look up the correct parent span.
 
     Returns:
         DelegateResult with summary and output from the sub-agent.
@@ -674,6 +707,16 @@ def handle_delegate(
     """
     # 1. Policy check
     _check_policy(request, config)
+
+    # 1b. Start delegation trace span
+    delegate_span_id: str | None = None
+    delegate_start_time = time.monotonic()
+    if tracer is not None:
+        delegate_span_id = tracer.delegate_start(
+            role=request.role_slug,
+            parent_span=parent_span,
+            context=request.task_text,
+        )
 
     # 2. Resolve role + skills
     resolved = resolve_role(request.role_slug, kind="role")
@@ -775,6 +818,13 @@ def handle_delegate(
             )
             if get_result.context_cards:
                 memory_prompt = _format_memory_prompt(get_result)
+            if tracer is not None and delegate_span_id is not None:
+                tracer.memory_get(
+                    span_id=delegate_span_id,
+                    provider=memory_provider.name,
+                    cards=get_result.context_cards or [],
+                    card_count=len(get_result.context_cards) if get_result.context_cards else 0,
+                )
 
         # 7b. Spawn
         env = {
@@ -785,6 +835,7 @@ def handle_delegate(
             "PERMISSION_MODE": "auto",
         }
 
+        spawn_time = time.monotonic()
         handle: AgentHandle = runtime.spawn(
             agent_id=agent_id,
             working_dir=working_dir,
@@ -796,9 +847,28 @@ def handle_delegate(
             task=task_text,
             env=env,
         )
+        if tracer is not None and delegate_span_id is not None:
+            tracer.agent_spawn(
+                span_id=delegate_span_id,
+                agent_id=agent_id,
+                runtime=runtime.name,
+                pid=handle.pid,
+            )
+            if agent_spans is not None:
+                agent_spans[agent_id] = delegate_span_id
 
         # 8. Wait
         result = runtime.wait(handle, timeout=config.agent_timeout)
+        if tracer is not None and delegate_span_id is not None:
+            agent_duration_ms = int(
+                (time.monotonic() - spawn_time) * 1000
+            )
+            tracer.agent_end(
+                span_id=delegate_span_id,
+                exit_code=result.exit_code,
+                output=result.output,
+                duration_ms=agent_duration_ms,
+            )
 
         # 8a. Memory dump — record result after wait
         timed_out = (
@@ -815,10 +885,22 @@ def handle_delegate(
                 output=result.output,
                 parent_agent_id=request.parent_agent_id,
             )
+            if tracer is not None and delegate_span_id is not None:
+                tracer.memory_dump(
+                    span_id=delegate_span_id,
+                    provider=memory_provider.name,
+                    entries=result.output,
+                    entry_count=1,
+                )
 
         # 8b. Handle timeout — no retry on timeout
         if timed_out:
             runtime.kill(handle)
+            _emit_delegate_end(
+                tracer, delegate_span_id, 1,
+                f"Agent timed out after {config.agent_timeout}s",
+                delegate_start_time,
+            )
             return DelegateResult(
                 summary=f"Agent timed out after {config.agent_timeout}s",
                 output=result.output,
@@ -827,6 +909,10 @@ def handle_delegate(
 
         # 8c. No retry on non-zero exit
         if result.exit_code != 0:
+            _emit_delegate_end(
+                tracer, delegate_span_id, result.exit_code,
+                result.summary, delegate_start_time,
+            )
             return DelegateResult(
                 summary=result.summary,
                 output=result.output,
@@ -838,6 +924,10 @@ def handle_delegate(
             result.output, request.return_format
         )
         if validation_error is None:
+            _emit_delegate_end(
+                tracer, delegate_span_id, result.exit_code,
+                result.summary, delegate_start_time,
+            )
             return DelegateResult(
                 summary=result.summary,
                 output=result.output,
@@ -852,6 +942,10 @@ def handle_delegate(
                 request.role_slug,
                 max_attempts,
                 validation_error,
+            )
+            _emit_delegate_end(
+                tracer, delegate_span_id, result.exit_code,
+                result.summary, delegate_start_time,
             )
             return DelegateResult(
                 summary=result.summary,
@@ -875,6 +969,10 @@ def handle_delegate(
 
     # Defensive: should never reach here
     assert result is not None
+    _emit_delegate_end(
+        tracer, delegate_span_id, result.exit_code,
+        result.summary, delegate_start_time,
+    )
     return DelegateResult(
         summary=result.summary,
         output=result.output,

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -36,6 +36,7 @@ from strawpot.memory.protocol import MemoryProvider
 from strawpot.memory.registry import MemorySpec, load_provider, resolve_memory
 from strawpot.isolation.protocol import IsolatedEnv, Isolator, NoneIsolator
 from strawpot.isolation.worktree import WorktreeIsolator
+from strawpot.trace import Tracer
 
 logger = logging.getLogger(__name__)
 
@@ -252,6 +253,10 @@ class Session:
         self._session_file: str | None = None
         self._session_data: dict = {}
         self._memory_provider: MemoryProvider | None = None
+        self._tracer: Tracer | None = None
+        self._session_span_id: str | None = None
+        self._session_start_time: float = 0.0
+        self._agent_spans: dict[str, str] = {}
         self._shutting_down: bool = False
         self._interrupted: bool = False
         self._last_sigint_time: float = 0.0
@@ -273,6 +278,17 @@ class Session:
 
         # Set session_dir on wrapper so PID/log files go to the right place
         self.wrapper.session_dir = self._session_dir()
+
+        # Initialize tracer (before try block so session_dir exists)
+        if self.config.trace:
+            self._tracer = Tracer(self._session_dir(), self._run_id)
+            self._session_span_id = self._tracer.session_start(
+                run_id=self._run_id,
+                role=self.config.orchestrator_role,
+                runtime=self.config.runtime,
+                isolation=self.config.isolation,
+            )
+            self._session_start_time = time.monotonic()
 
         original_sigint = signal.getsignal(signal.SIGINT)
         try:
@@ -325,6 +341,13 @@ class Session:
                 )
                 if get_result.context_cards:
                     memory_prompt = _format_memory_prompt(get_result)
+                if self._tracer is not None:
+                    self._tracer.memory_get(
+                        span_id=self._session_span_id,
+                        provider=self._memory_provider.name,
+                        cards=get_result.context_cards or [],
+                        card_count=len(get_result.context_cards) if get_result.context_cards else 0,
+                    )
 
             # 5b. Spawn orchestrator (interactive mode)
             env = {
@@ -346,6 +369,14 @@ class Session:
                 env=env,
             )
             self._orchestrator_handle = handle
+            if self._tracer is not None:
+                self._tracer.agent_spawn(
+                    span_id=self._session_span_id,
+                    agent_id=agent_id,
+                    runtime=self.config.runtime,
+                    pid=handle.pid,
+                )
+                self._agent_spans[agent_id] = self._session_span_id
             self._register_agent(
                 agent_id,
                 role=self.config.orchestrator_role,
@@ -373,6 +404,17 @@ class Session:
 
     def stop(self) -> None:
         """Clean up the session: kill agents, stop server, merge changes, remove isolation."""
+        # 0. Emit session_end trace event before cleanup that might fail
+        if self._tracer is not None and self._session_span_id is not None:
+            duration_ms = int(
+                (time.monotonic() - self._session_start_time) * 1000
+            )
+            self._tracer.session_end(
+                span_id=self._session_span_id,
+                merge_strategy=self.config.merge_strategy,
+                duration_ms=duration_ms,
+            )
+
         # 1. Kill remaining sub-agents
         for agent_id, handle in self._agents.items():
             if handle is self._orchestrator_handle:
@@ -599,6 +641,10 @@ class Session:
         )
 
         try:
+            # Look up the span for the requesting agent (for call tree)
+            requester_span = self._agent_spans.get(
+                trace.agent_instance_id, self._session_span_id
+            )
             result = handle_delegate(
                 request=delegate_req,
                 config=self.config,
@@ -609,6 +655,9 @@ class Session:
                 resolve_role_dirs=self._resolve_role_dirs,
                 denden_addr=self._denden_addr,
                 memory_provider=self._memory_provider,
+                tracer=self._tracer,
+                parent_span=requester_span,
+                agent_spans=self._agent_spans,
             )
             return ok_response(
                 request.request_id,
@@ -617,6 +666,12 @@ class Session:
                 ),
             )
         except PolicyDenied as exc:
+            if self._tracer is not None:
+                self._tracer.delegate_denied(
+                    role=delegate_req.role_slug,
+                    parent_span=requester_span,
+                    reason=exc.reason,
+                )
             return denied_response(
                 request.request_id, exc.reason, str(exc)
             )

--- a/cli/src/strawpot/trace.py
+++ b/cli/src/strawpot/trace.py
@@ -1,0 +1,245 @@
+"""Session tracing — JSONL event stream with content-addressed artifact storage."""
+
+import hashlib
+import json
+import logging
+import os
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TraceEvent:
+    """Single trace event written to trace.jsonl."""
+
+    ts: str
+    event: str
+    trace_id: str
+    span_id: str
+    parent_span: str | None = None
+    data: dict = field(default_factory=dict)
+
+
+class Tracer:
+    """Lightweight JSONL tracer with content-addressed artifact storage.
+
+    Created once per session.  Writes events to
+    ``<session_dir>/trace.jsonl`` and stores large payloads under
+    ``<session_dir>/artifacts/<sha256[:12]>``.
+    """
+
+    def __init__(self, session_dir: str, trace_id: str) -> None:
+        self._session_dir = session_dir
+        self._trace_id = trace_id
+        self._trace_path = os.path.join(session_dir, "trace.jsonl")
+        self._artifacts_dir = os.path.join(session_dir, "artifacts")
+        os.makedirs(self._artifacts_dir, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Artifact storage
+    # ------------------------------------------------------------------
+
+    def store_artifact(self, content: str) -> str | None:
+        """Write *content* to ``artifacts/<sha256[:12]>`` and return the ref.
+
+        Returns ``None`` if *content* is empty.  Deduplicates: if the
+        artifact already exists on disk the write is skipped.
+        """
+        if not content:
+            return None
+        content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()[:12]
+        artifact_path = os.path.join(self._artifacts_dir, content_hash)
+        if not os.path.exists(artifact_path):
+            try:
+                with open(artifact_path, "w", encoding="utf-8") as f:
+                    f.write(content)
+            except OSError:
+                logger.debug(
+                    "Failed to write artifact %s", content_hash, exc_info=True
+                )
+        return content_hash
+
+    # ------------------------------------------------------------------
+    # Low-level event emit
+    # ------------------------------------------------------------------
+
+    def emit(
+        self,
+        event: str,
+        span_id: str,
+        parent_span: str | None = None,
+        **data,
+    ) -> None:
+        """Append a single :class:`TraceEvent` to ``trace.jsonl``."""
+        te = TraceEvent(
+            ts=datetime.now(timezone.utc).isoformat(),
+            event=event,
+            trace_id=self._trace_id,
+            span_id=span_id,
+            parent_span=parent_span,
+            data=data,
+        )
+        try:
+            line = json.dumps(asdict(te), separators=(",", ":"))
+            with open(self._trace_path, "a", encoding="utf-8") as f:
+                f.write(line + "\n")
+        except OSError:
+            logger.debug("Failed to write trace event: %s", event, exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Span ID generation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _new_span_id() -> str:
+        return uuid.uuid4().hex[:12]
+
+    # ------------------------------------------------------------------
+    # Convenience methods
+    # ------------------------------------------------------------------
+
+    def session_start(
+        self, *, run_id: str, role: str, runtime: str, isolation: str
+    ) -> str:
+        """Emit ``session_start``.  Returns the root span_id."""
+        span_id = self._new_span_id()
+        self.emit(
+            "session_start",
+            span_id,
+            run_id=run_id,
+            role=role,
+            runtime=runtime,
+            isolation=isolation,
+        )
+        return span_id
+
+    def session_end(
+        self, *, span_id: str, merge_strategy: str, duration_ms: int
+    ) -> None:
+        """Emit ``session_end``."""
+        self.emit(
+            "session_end",
+            span_id,
+            merge_strategy=merge_strategy,
+            duration_ms=duration_ms,
+        )
+
+    def delegate_start(
+        self, *, role: str, parent_span: str, context: str
+    ) -> str:
+        """Emit ``delegate_start``.  Stores context as artifact.  Returns new span_id."""
+        span_id = self._new_span_id()
+        context_ref = self.store_artifact(context)
+        self.emit(
+            "delegate_start",
+            span_id,
+            parent_span=parent_span,
+            role=role,
+            context_ref=context_ref,
+        )
+        return span_id
+
+    def delegate_end(
+        self,
+        *,
+        span_id: str,
+        exit_code: int,
+        summary: str,
+        duration_ms: int,
+    ) -> None:
+        """Emit ``delegate_end``."""
+        self.emit(
+            "delegate_end",
+            span_id,
+            exit_code=exit_code,
+            summary=summary,
+            duration_ms=duration_ms,
+        )
+
+    def delegate_denied(
+        self, *, role: str, parent_span: str, reason: str
+    ) -> None:
+        """Emit ``delegate_denied``."""
+        span_id = self._new_span_id()
+        self.emit(
+            "delegate_denied",
+            span_id,
+            parent_span=parent_span,
+            role=role,
+            reason=reason,
+        )
+
+    def memory_get(
+        self,
+        *,
+        span_id: str,
+        provider: str,
+        cards: list,
+        card_count: int,
+    ) -> None:
+        """Emit ``memory_get``.  Stores serialised cards as artifact."""
+        cards_content = json.dumps([str(c) for c in cards]) if cards else ""
+        cards_ref = self.store_artifact(cards_content)
+        self.emit(
+            "memory_get",
+            span_id,
+            provider=provider,
+            cards_ref=cards_ref,
+            card_count=card_count,
+        )
+
+    def memory_dump(
+        self,
+        *,
+        span_id: str,
+        provider: str,
+        entries: str,
+        entry_count: int,
+    ) -> None:
+        """Emit ``memory_dump``.  Stores entries as artifact."""
+        entries_ref = self.store_artifact(entries)
+        self.emit(
+            "memory_dump",
+            span_id,
+            provider=provider,
+            entries_ref=entries_ref,
+            entry_count=entry_count,
+        )
+
+    def agent_spawn(
+        self,
+        *,
+        span_id: str,
+        agent_id: str,
+        runtime: str,
+        pid: int | None,
+    ) -> None:
+        """Emit ``agent_spawn``."""
+        self.emit(
+            "agent_spawn",
+            span_id,
+            agent_id=agent_id,
+            runtime=runtime,
+            pid=pid,
+        )
+
+    def agent_end(
+        self,
+        *,
+        span_id: str,
+        exit_code: int,
+        output: str,
+        duration_ms: int,
+    ) -> None:
+        """Emit ``agent_end``.  Stores output as artifact."""
+        output_ref = self.store_artifact(output)
+        self.emit(
+            "agent_end",
+            span_id,
+            exit_code=exit_code,
+            output_ref=output_ref,
+            duration_ms=duration_ms,
+        )

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -25,6 +25,7 @@ def test_defaults():
     assert config.merge_strategy == "auto"
     assert config.pull_before_session == "prompt"
     assert "gh pr create" in config.pr_command
+    assert config.trace is True
 
 
 def test_strawpot_home_default(monkeypatch):
@@ -268,6 +269,21 @@ def test_roles_merge_global_project(tmp_path, monkeypatch):
 
     config = load_config(project_dir)
     assert config.roles == {"implementer": {"default_agent": "claude_code"}}
+
+
+def test_trace_disabled_via_toml(tmp_path, monkeypatch):
+    """[trace] enabled = false disables tracing."""
+    monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "nonexistent"))
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir(parents=True)
+    (project_dir / "strawpot.toml").write_text(
+        "[trace]\n"
+        "enabled = false\n"
+    )
+
+    config = load_config(project_dir)
+    assert config.trace is False
 
 
 def test_save_skill_env_creates_file(tmp_path):

--- a/cli/tests/test_trace.py
+++ b/cli/tests/test_trace.py
@@ -1,0 +1,345 @@
+"""Tests for strawpot.trace."""
+
+import json
+import os
+import stat
+
+import pytest
+
+from strawpot.trace import TraceEvent, Tracer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_events(session_dir):
+    """Read all JSONL events from trace.jsonl."""
+    path = os.path.join(session_dir, "trace.jsonl")
+    with open(path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _make_tracer(tmp_path, trace_id="run_test123"):
+    session_dir = str(tmp_path / "session")
+    os.makedirs(session_dir, exist_ok=True)
+    return Tracer(session_dir, trace_id), session_dir
+
+
+# ---------------------------------------------------------------------------
+# TraceEvent dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestTraceEvent:
+    def test_fields(self):
+        te = TraceEvent(
+            ts="2026-01-01T00:00:00+00:00",
+            event="test",
+            trace_id="t1",
+            span_id="s1",
+            parent_span="s0",
+            data={"key": "val"},
+        )
+        assert te.event == "test"
+        assert te.parent_span == "s0"
+        assert te.data == {"key": "val"}
+
+    def test_parent_span_defaults_none(self):
+        te = TraceEvent(ts="", event="e", trace_id="t", span_id="s")
+        assert te.parent_span is None
+        assert te.data == {}
+
+
+# ---------------------------------------------------------------------------
+# Tracer init
+# ---------------------------------------------------------------------------
+
+
+class TestTracerInit:
+    def test_creates_artifacts_dir(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        assert os.path.isdir(os.path.join(session_dir, "artifacts"))
+
+    def test_trace_jsonl_created_on_first_emit(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        trace_path = os.path.join(session_dir, "trace.jsonl")
+        assert not os.path.exists(trace_path)
+        tracer.emit("test_event", "span1")
+        assert os.path.isfile(trace_path)
+
+
+# ---------------------------------------------------------------------------
+# store_artifact
+# ---------------------------------------------------------------------------
+
+
+class TestStoreArtifact:
+    def test_stores_content_by_hash(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        ref = tracer.store_artifact("hello world")
+        assert ref is not None
+        artifact_path = os.path.join(session_dir, "artifacts", ref)
+        assert os.path.isfile(artifact_path)
+        with open(artifact_path, encoding="utf-8") as f:
+            assert f.read() == "hello world"
+
+    def test_returns_hash_ref(self, tmp_path):
+        tracer, _ = _make_tracer(tmp_path)
+        ref = tracer.store_artifact("test content")
+        assert isinstance(ref, str)
+        assert len(ref) == 12
+
+    def test_empty_content_returns_none(self, tmp_path):
+        tracer, _ = _make_tracer(tmp_path)
+        assert tracer.store_artifact("") is None
+
+    def test_deduplication(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        ref1 = tracer.store_artifact("same content")
+        ref2 = tracer.store_artifact("same content")
+        assert ref1 == ref2
+        artifacts = os.listdir(os.path.join(session_dir, "artifacts"))
+        assert len(artifacts) == 1
+
+    def test_different_content_different_hash(self, tmp_path):
+        tracer, _ = _make_tracer(tmp_path)
+        ref1 = tracer.store_artifact("content A")
+        ref2 = tracer.store_artifact("content B")
+        assert ref1 != ref2
+
+
+# ---------------------------------------------------------------------------
+# emit
+# ---------------------------------------------------------------------------
+
+
+class TestEmit:
+    def test_writes_jsonl_line(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.emit("test_event", "span1", key="value")
+        events = _read_events(session_dir)
+        assert len(events) == 1
+        assert events[0]["event"] == "test_event"
+        assert events[0]["span_id"] == "span1"
+        assert events[0]["data"]["key"] == "value"
+
+    def test_multiple_events_appended(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.emit("e1", "s1")
+        tracer.emit("e2", "s2")
+        tracer.emit("e3", "s3")
+        events = _read_events(session_dir)
+        assert len(events) == 3
+        assert [e["event"] for e in events] == ["e1", "e2", "e3"]
+
+    def test_event_has_iso_timestamp(self, tmp_path):
+        from datetime import datetime
+
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.emit("e", "s")
+        events = _read_events(session_dir)
+        ts = events[0]["ts"]
+        # Should parse without error
+        datetime.fromisoformat(ts)
+
+    def test_event_has_trace_id(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path, trace_id="run_abc")
+        tracer.emit("e", "s")
+        events = _read_events(session_dir)
+        assert events[0]["trace_id"] == "run_abc"
+
+    def test_parent_span_can_be_none(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.emit("e", "s")
+        events = _read_events(session_dir)
+        assert events[0]["parent_span"] is None
+
+    def test_parent_span_set(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.emit("e", "s", parent_span="p1")
+        events = _read_events(session_dir)
+        assert events[0]["parent_span"] == "p1"
+
+
+# ---------------------------------------------------------------------------
+# Session events
+# ---------------------------------------------------------------------------
+
+
+class TestSessionEvents:
+    def test_session_start_returns_span_id(self, tmp_path):
+        tracer, _ = _make_tracer(tmp_path)
+        span_id = tracer.session_start(
+            run_id="run_1", role="orchestrator",
+            runtime="claude_code", isolation="none",
+        )
+        assert isinstance(span_id, str)
+        assert len(span_id) == 12
+
+    def test_session_start_event_written(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.session_start(
+            run_id="run_1", role="orchestrator",
+            runtime="claude_code", isolation="worktree",
+        )
+        events = _read_events(session_dir)
+        assert len(events) == 1
+        assert events[0]["event"] == "session_start"
+        assert events[0]["data"]["role"] == "orchestrator"
+        assert events[0]["data"]["isolation"] == "worktree"
+
+    def test_session_end_event_written(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        span_id = tracer.session_start(
+            run_id="r", role="o", runtime="r", isolation="n",
+        )
+        tracer.session_end(
+            span_id=span_id, merge_strategy="local", duration_ms=5000,
+        )
+        events = _read_events(session_dir)
+        assert events[1]["event"] == "session_end"
+        assert events[1]["data"]["duration_ms"] == 5000
+        assert events[1]["data"]["merge_strategy"] == "local"
+
+
+# ---------------------------------------------------------------------------
+# Delegate events
+# ---------------------------------------------------------------------------
+
+
+class TestDelegateEvents:
+    def test_delegate_start_stores_context_artifact(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        span_id = tracer.delegate_start(
+            role="reviewer", parent_span="root",
+            context="Review this code please.",
+        )
+        assert isinstance(span_id, str)
+        events = _read_events(session_dir)
+        assert events[0]["event"] == "delegate_start"
+        ref = events[0]["data"]["context_ref"]
+        assert ref is not None
+        artifact_path = os.path.join(session_dir, "artifacts", ref)
+        with open(artifact_path, encoding="utf-8") as f:
+            assert f.read() == "Review this code please."
+
+    def test_delegate_end_event(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.delegate_end(
+            span_id="s1", exit_code=0, summary="Done", duration_ms=1234,
+        )
+        events = _read_events(session_dir)
+        assert events[0]["event"] == "delegate_end"
+        assert events[0]["data"]["exit_code"] == 0
+        assert events[0]["data"]["summary"] == "Done"
+        assert events[0]["data"]["duration_ms"] == 1234
+
+    def test_delegate_denied_event(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.delegate_denied(
+            role="admin", parent_span="root", reason="DENY_ROLE_NOT_ALLOWED",
+        )
+        events = _read_events(session_dir)
+        assert events[0]["event"] == "delegate_denied"
+        assert events[0]["data"]["role"] == "admin"
+        assert events[0]["data"]["reason"] == "DENY_ROLE_NOT_ALLOWED"
+
+
+# ---------------------------------------------------------------------------
+# Memory events
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryEvents:
+    def test_memory_get_stores_cards_artifact(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.memory_get(
+            span_id="s1", provider="semantic",
+            cards=["card1", "card2"], card_count=2,
+        )
+        events = _read_events(session_dir)
+        assert events[0]["event"] == "memory_get"
+        assert events[0]["data"]["card_count"] == 2
+        ref = events[0]["data"]["cards_ref"]
+        assert ref is not None
+
+    def test_memory_get_empty_cards(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.memory_get(
+            span_id="s1", provider="noop", cards=[], card_count=0,
+        )
+        events = _read_events(session_dir)
+        assert events[0]["data"]["cards_ref"] is None
+
+    def test_memory_dump_stores_entries_artifact(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.memory_dump(
+            span_id="s1", provider="semantic",
+            entries="agent output text", entry_count=1,
+        )
+        events = _read_events(session_dir)
+        assert events[0]["event"] == "memory_dump"
+        ref = events[0]["data"]["entries_ref"]
+        assert ref is not None
+        artifact_path = os.path.join(session_dir, "artifacts", ref)
+        with open(artifact_path, encoding="utf-8") as f:
+            assert f.read() == "agent output text"
+
+
+# ---------------------------------------------------------------------------
+# Agent events
+# ---------------------------------------------------------------------------
+
+
+class TestAgentEvents:
+    def test_agent_spawn_event(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.agent_spawn(
+            span_id="s1", agent_id="agent_abc",
+            runtime="claude_code", pid=12345,
+        )
+        events = _read_events(session_dir)
+        assert events[0]["event"] == "agent_spawn"
+        assert events[0]["data"]["agent_id"] == "agent_abc"
+        assert events[0]["data"]["pid"] == 12345
+
+    def test_agent_end_stores_output_artifact(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.agent_end(
+            span_id="s1", exit_code=0,
+            output="task completed successfully", duration_ms=9876,
+        )
+        events = _read_events(session_dir)
+        assert events[0]["event"] == "agent_end"
+        assert events[0]["data"]["exit_code"] == 0
+        assert events[0]["data"]["duration_ms"] == 9876
+        ref = events[0]["data"]["output_ref"]
+        assert ref is not None
+        artifact_path = os.path.join(session_dir, "artifacts", ref)
+        with open(artifact_path, encoding="utf-8") as f:
+            assert f.read() == "task completed successfully"
+
+
+# ---------------------------------------------------------------------------
+# I/O error resilience
+# ---------------------------------------------------------------------------
+
+
+class TestIOResilience:
+    @pytest.mark.skipif(
+        os.getuid() == 0, reason="root can write to read-only dirs"
+    )
+    def test_emit_on_readonly_dir_does_not_raise(self, tmp_path):
+        session_dir = str(tmp_path / "readonly_session")
+        os.makedirs(session_dir)
+        tracer = Tracer(session_dir, "run_x")
+        # Make session dir read-only
+        os.chmod(session_dir, stat.S_IRUSR | stat.S_IXUSR)
+        try:
+            # Should not raise
+            tracer.emit("test", "span1")
+        finally:
+            # Restore permissions for cleanup
+            os.chmod(session_dir, stat.S_IRWXU)

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -95,6 +95,12 @@ SCANNER_API_KEY = "sk-..."
 # Override role settings from ROLE.md frontmatter.
 [roles.implementer]
 default_agent = "claude_code"
+
+# ── Tracing ──────────────────────────────────────────────
+# JSONL event stream + content-addressed artifacts per session.
+# Enabled by default. Set to false to disable.
+[trace]
+enabled = true
 ```
 
 ## Environment Variables

--- a/docs/concepts/delegation.mdx
+++ b/docs/concepts/delegation.mdx
@@ -100,3 +100,15 @@ If a memory provider is configured, StrawPot retrieves context before spawning e
 3. Context is injected into the agent's prompt via `--memory-prompt`
 
 After the sub-agent completes, `memory.dump()` records the result for future reference.
+
+## Tracing
+
+When tracing is enabled (the default), every delegation emits structured events to the session's `trace.jsonl`:
+
+- `delegate_start` — records the role and stores the full context prompt as an artifact
+- `agent_spawn` / `agent_end` — tracks the sub-agent process lifecycle with timing
+- `memory_get` / `memory_dump` — records memory interactions with artifact references
+- `delegate_end` — captures exit code, summary, and total duration
+- `delegate_denied` — logged when policy blocks a delegation request
+
+These events include span IDs that link to the parent agent's span, enabling full call-tree reconstruction across nested delegations. See [Sessions](/concepts/sessions#tracing) for the complete event reference.

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -81,3 +81,60 @@ Each session tracks:
 - Session ID, start time, working directory
 - Denden server address and PID
 - All spawned agents with their role, runtime, parent, and status
+
+## Tracing
+
+StrawPot records structured trace events for every session using a two-tier system:
+
+1. **JSONL event stream** (`trace.jsonl`) — lightweight metadata with timing, span IDs, and artifact references
+2. **Artifact store** (`artifacts/`) — content-addressed storage for large payloads (context prompts, agent output, memory cards)
+
+This separation keeps the event stream small and scannable while preserving full payloads for debugging.
+
+### Session directory layout
+
+```
+.strawpot/sessions/<session_id>/
+  session.json
+  trace.jsonl
+  artifacts/
+    a1b2c3d4e5f6
+    ...
+```
+
+### Events
+
+| Event | When | Key data |
+|-------|------|----------|
+| `session_start` | Session begins | role, runtime, isolation |
+| `session_end` | Session stops | merge_strategy, duration_ms |
+| `delegate_start` | Delegation begins | role, context_ref (artifact) |
+| `delegate_end` | Delegation completes | exit_code, summary, duration_ms |
+| `delegate_denied` | Policy blocks delegation | role, reason |
+| `memory_get` | Memory context retrieved | provider, cards_ref, card_count |
+| `memory_dump` | Memory recorded after agent | provider, entries_ref, entry_count |
+| `agent_spawn` | Agent process launched | agent_id, runtime, pid |
+| `agent_end` | Agent process exits | exit_code, output_ref, duration_ms |
+
+### Call tree reconstruction
+
+Each event has a `span_id` and optional `parent_span`. The `session_start` span is the root. Delegation spans reference the requesting agent's span as their parent, forming a tree that reflects the actual delegation chain:
+
+```
+session_start (root)
+  └─ delegate_start (orchestrator → implementer)
+       ├─ agent_spawn
+       ├─ delegate_start (implementer → reviewer)
+       │    ├─ agent_spawn
+       │    └─ agent_end
+       └─ agent_end
+```
+
+### Disabling
+
+Tracing is enabled by default. Disable it in `strawpot.toml`:
+
+```toml
+[trace]
+enabled = false
+```


### PR DESCRIPTION
## Summary

- Introduce `trace.py` with `Tracer` class that writes JSONL events to `trace.jsonl` and stores large payloads (context prompts, agent output, memory cards) in a content-addressed `artifacts/` directory using sha256[:12] hashing
- Instrument `session.py` and `delegation.py` with 9 event types: `session_start`, `session_end`, `delegate_start`, `delegate_end`, `delegate_denied`, `memory_get`, `memory_dump`, `agent_spawn`, `agent_end`
- Span-based parent-child linking via `_agent_spans` dict enables full call-tree reconstruction across nested delegations
- Add `trace: bool = True` config field with `[trace] enabled = false` TOML support to disable
- Update DESIGN.md, sessions.mdx, delegation.mdx, and configuration.mdx with tracing documentation

## Test plan

- [x] `pytest cli/tests/test_trace.py` — 27 tests for Tracer (artifacts, events, resilience)
- [x] `pytest cli/tests/test_config.py` — config defaults and `[trace]` parsing
- [x] `pytest cli/tests/` — full suite (476 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)