### PR TITLE
Fix e2e timeout in _detect_base_branch subprocess call

### DIFF
--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -717,10 +717,11 @@ class Session:
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
+                timeout=5,
             )
             if result.returncode == 0:
                 return result.stdout.strip() or None
-        except FileNotFoundError:
+        except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
         return None
 


### PR DESCRIPTION
## Summary
- Add `timeout=5` to the `subprocess.run` call in `Session._detect_base_branch` to prevent hangs when gRPC server threads interfere with `fork()` on macOS
- Catch `subprocess.TimeoutExpired` alongside `FileNotFoundError`

## Context
The `test_delegation_depth_limit` e2e test was timing out at 30s in CI. The stack trace showed the hang occurred in `_detect_base_branch` where `subprocess.run(["git", "rev-parse", ...])` blocked indefinitely because gRPC server threads (already running) interfered with `fork()` on macOS.

## Test plan
- [ ] Existing e2e tests pass (especially `test_delegation_depth_limit`)
- [ ] Unit tests pass (`pytest cli/tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)