### PR TITLE
Add headless mode and pluggable ask_user handler

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -578,8 +578,14 @@ enabled = true
      config from [skills.<slug>.env], then prompts interactively for any
      still-missing required vars are prompted interactively
 4. wrapper = WrapperRuntime(agent_spec)                      # generic, works for any agent
-   runtime = InteractiveWrapperRuntime(wrapper)              # tmux available → tmux session
-          or DirectWrapperRuntime(wrapper)                   # no tmux → direct terminal attach
+   if --headless:
+     runtime = wrapper                                       # headless → output to .log file
+   elif --task:
+     runtime = DirectWrapperRuntime(wrapper)                 # task → direct terminal attach
+   elif tmux available:
+     runtime = InteractiveWrapperRuntime(wrapper)            # interactive → tmux session
+   else:
+     runtime = DirectWrapperRuntime(wrapper)                 # fallback → direct terminal attach
 5. isolator = resolve_isolator(config.isolation)             # none | worktree | docker
 6. session = Session(config, wrapper, runtime, isolator)
 7. session.start():
@@ -699,8 +705,77 @@ No per-agent worktree creation or cleanup. All agents share the session worktree
 ### ask_user Request
 
 Agent calls `denden send '{"ask_user": {"question": "which db?", "choices": ["postgres", "sqlite"]}}'`.
-Forwarded to the user via the orchestrator's terminal. Orchestrator's response
-flows back through denden.
+Dispatched to `Session._handle_ask_user`, which delegates to a pluggable
+callback.
+
+**DenDen protobuf types:**
+
+- `AskUserPayload`: `question`, `choices[]`, `default_value`, `why`, `response_format`
+- `AskUserResult`: `text`, `json`
+
+**Pluggable handler:**
+
+`Session` accepts an `ask_user_handler` callback at construction.
+The handler receives an `AskUserRequest` dataclass and returns an
+`AskUserResponse` dataclass — both transport-agnostic (no protobuf
+dependency for handler authors).
+
+```python
+@dataclass(frozen=True)
+class AskUserRequest:
+    question: str
+    choices: list[str]
+    default_value: str
+    why: str               # informational context for the user
+    response_format: str   # "text" or "json"
+
+@dataclass(frozen=True)
+class AskUserResponse:
+    text: str = ""         # plain text answer
+    json: str = ""         # JSON string (converted to protobuf Struct on the wire)
+
+AskUserHandler = Callable[[AskUserRequest], AskUserResponse]
+```
+
+`_handle_ask_user` converts protobuf → `AskUserRequest`, calls the
+handler, then converts `AskUserResponse` → protobuf `AskUserResult`.
+This is the only place that touches protobuf types.
+
+**Handlers by mode:**
+
+| Mode | Handler | Wired in |
+|------|---------|----------|
+| All CLI modes | `_default_ask_user_handler` — returns `default_value` or auto-responds | `session.py` (default) |
+| GUI interactive | Bridge to SSE → chat panel → user response | `gui/` (future) |
+| Trigger ongoing | Bridge to adapter queue (Slack, Telegram) | (future) |
+
+All CLI modes (headless, task, interactive) use the default auto-respond
+handler. The orchestrator is an AI agent that can make decisions on
+behalf of the user. A terminal interactive handler that prompts via
+stdin is deferred — it requires routing questions through the
+orchestrator's own UI (e.g., via a denden bidirectional channel) to
+avoid stdin/stdout conflicts with the orchestrator subprocess.
+
+### Headless Mode
+
+`strawpot start --task "..." --headless` runs the orchestrator in the
+same way as sub-agents: stdout/stderr captured to `.log` file, stdin is
+`/dev/null`, process runs in a new session group.
+
+```
+strawpot start --task "implement feature X" --headless
+  → uses WrapperRuntime (not DirectWrapperRuntime or InteractiveWrapperRuntime)
+  → orchestrator output at: .strawpot/sessions/<run_id>/agents/<agent_id>/.log
+  → blocks until orchestrator exits (runtime.wait)
+  → exit code propagated to caller
+```
+
+This is the mode the GUI uses to launch sessions. The GUI can stream the
+`.log` file via SSE for real-time output, and read `trace.jsonl` for
+structured lifecycle events.
+
+`--headless` requires `--task`. Without a task, the orchestrator would
+be launched with no instructions and no stdin — an error.
 
 ---
 

--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -123,7 +123,13 @@ def _ensure_skill_installed(name: str, working_dir: str) -> None:
 @click.option("--host", default=None, help="Denden server host.")
 @click.option("--port", default=None, type=int, help="Denden server port.")
 @click.option("--task", default=None, help="Run noninteractively with a task string.")
-def start(role, runtime, isolation, merge_strategy, pull, host, port, task):
+@click.option(
+    "--headless",
+    is_flag=True,
+    default=False,
+    help="Run detached with output to log file (requires --task).",
+)
+def start(role, runtime, isolation, merge_strategy, pull, host, port, task, headless):
     """Start an orchestration session.
 
     Runs in the foreground — creates an isolated environment (if configured),
@@ -208,8 +214,14 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task):
         pass  # Role resolution failures handled by Session.start()
 
     # 3. Build runtimes (session_dir set later by Session.start())
+    if headless and not task:
+        click.echo("Error: --headless requires --task", err=True)
+        sys.exit(1)
+
     wrapper = WrapperRuntime(spec)
-    if task:
+    if headless:
+        rt = wrapper  # WrapperRuntime directly → output to .log file
+    elif task:
         rt = DirectWrapperRuntime(wrapper)
     elif shutil.which("tmux"):
         rt = InteractiveWrapperRuntime(wrapper)

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -9,6 +9,7 @@ import sys
 import time
 import uuid
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from denden import (
@@ -204,6 +205,38 @@ def resolve_isolator(isolation: str) -> Isolator:
     raise ValueError(f"Unknown isolation mode: {isolation}")
 
 
+@dataclass(frozen=True)
+class AskUserRequest:
+    """Transport-agnostic representation of an ask_user request."""
+
+    question: str
+    choices: list[str]
+    default_value: str
+    why: str
+    response_format: str
+
+
+@dataclass(frozen=True)
+class AskUserResponse:
+    """Transport-agnostic representation of an ask_user response.
+
+    Attributes:
+        text: Plain text answer.
+        json: JSON string for structured responses (converted to
+            protobuf Struct on the wire). Leave empty for text-only.
+    """
+
+    text: str = ""
+    json: str = ""
+
+
+def _default_ask_user_handler(req: AskUserRequest) -> AskUserResponse:
+    """Default ask_user handler — auto-responds for headless/autonomous mode."""
+    if req.default_value:
+        return AskUserResponse(text=req.default_value)
+    return AskUserResponse(text="Proceed with your best judgment.")
+
+
 class Session:
     """Orchestration session — manages the full lifecycle.
 
@@ -233,6 +266,7 @@ class Session:
         resolve_role: Callable[..., dict],
         resolve_role_dirs: Callable[[str], str | None],
         task: str = "",
+        ask_user_handler: Callable[[AskUserRequest], AskUserResponse] | None = None,
     ) -> None:
         self.config = config
         self.wrapper = wrapper
@@ -241,6 +275,7 @@ class Session:
         self.task = task
         self._resolve_role = resolve_role
         self._resolve_role_dirs = resolve_role_dirs
+        self._ask_user_handler = ask_user_handler or _default_ask_user_handler
 
         self._run_id: str | None = None
         self._env: IsolatedEnv | None = None
@@ -686,12 +721,30 @@ class Session:
     def _handle_ask_user(
         self, request: denden_pb2.DenDenRequest
     ) -> denden_pb2.DenDenResponse:
-        """Handle an ask_user request (placeholder)."""
-        return error_response(
-            request.request_id,
-            "NOT_IMPLEMENTED",
-            "ask_user is not yet implemented",
+        """Handle an ask_user request via the pluggable handler callback."""
+        ask = request.ask_user
+        req = AskUserRequest(
+            question=ask.question,
+            choices=list(ask.choices),
+            default_value=ask.default_value,
+            why=ask.why,
+            response_format=ask.response_format,
         )
+        try:
+            resp = self._ask_user_handler(req)
+        except Exception as exc:
+            logger.exception("ask_user handler failed")
+            return error_response(
+                request.request_id,
+                "ERR_ASK_USER",
+                str(exc),
+            )
+        result = denden_pb2.AskUserResult(text=resp.text)
+        if resp.json:
+            import json as _json
+
+            result.json.update(_json.loads(resp.json))
+        return ok_response(request.request_id, ask_user_result=result)
 
     # ------------------------------------------------------------------
     # Session directory and state file

--- a/cli/tests/test_session.py
+++ b/cli/tests/test_session.py
@@ -11,7 +11,13 @@ from strawpot.agents.protocol import AgentHandle, AgentResult
 from strawpot.config import StrawPotConfig
 from strawpot.delegation import PolicyDenied
 from strawpot.isolation.protocol import IsolatedEnv, NoneIsolator
-from strawpot.session import Session, recover_stale_sessions, resolve_isolator
+from strawpot.session import (
+    AskUserRequest,
+    AskUserResponse,
+    Session,
+    recover_stale_sessions,
+    resolve_isolator,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -570,21 +576,124 @@ class TestHandleDelegate:
 
 
 class TestHandleAskUser:
-    @patch("strawpot.session.error_response")
-    def test_returns_not_implemented(self, mock_error, tmp_path):
-        """ask_user returns NOT_IMPLEMENTED error for now."""
-        mock_error.return_value = "not_impl"
+    @patch("strawpot.session.ok_response")
+    def test_default_handler_auto_responds(self, mock_ok, tmp_path):
+        """Default ask_user handler returns auto-response."""
+        mock_ok.return_value = "ok"
 
         session = _make_session(tmp_path)
         request = MagicMock()
         request.request_id = "req_456"
+        request.ask_user.question = "which db?"
+        request.ask_user.choices = ["postgres", "sqlite"]
+        request.ask_user.default_value = ""
+        request.ask_user.why = ""
+        request.ask_user.response_format = ""
+
+        result = session._handle_ask_user(request)
+
+        mock_ok.assert_called_once()
+        call_kwargs = mock_ok.call_args
+        assert call_kwargs[0][0] == "req_456"
+        assert result == "ok"
+
+    @patch("strawpot.session.ok_response")
+    def test_default_handler_uses_default_value(self, mock_ok, tmp_path):
+        """Default handler returns default_value when provided."""
+        mock_ok.return_value = "ok"
+
+        session = _make_session(tmp_path)
+        request = MagicMock()
+        request.request_id = "req_789"
+        request.ask_user.question = "which db?"
+        request.ask_user.choices = []
+        request.ask_user.default_value = "postgres"
+        request.ask_user.why = ""
+        request.ask_user.response_format = ""
+
+        session._handle_ask_user(request)
+
+        call_kwargs = mock_ok.call_args
+        ask_result = call_kwargs[1]["ask_user_result"]
+        assert ask_result.text == "postgres"
+
+    @patch("strawpot.session.ok_response")
+    def test_custom_handler(self, mock_ok, tmp_path):
+        """Custom ask_user handler is called when provided."""
+        mock_ok.return_value = "ok"
+
+        def custom_handler(req: AskUserRequest) -> AskUserResponse:
+            return AskUserResponse(text=f"custom: {req.question}")
+
+        session = _make_session(tmp_path, ask_user_handler=custom_handler)
+        request = MagicMock()
+        request.request_id = "req_abc"
+        request.ask_user.question = "pick one"
+        request.ask_user.choices = ["a", "b"]
+        request.ask_user.default_value = ""
+        request.ask_user.why = ""
+        request.ask_user.response_format = ""
+
+        session._handle_ask_user(request)
+
+        call_kwargs = mock_ok.call_args
+        ask_result = call_kwargs[1]["ask_user_result"]
+        assert ask_result.text == "custom: pick one"
+
+    @patch("strawpot.session.ok_response")
+    def test_passes_all_fields_to_handler(self, mock_ok, tmp_path):
+        """Handler receives all protobuf fields via AskUserRequest."""
+        mock_ok.return_value = "ok"
+        received = {}
+
+        def capture_handler(req: AskUserRequest) -> AskUserResponse:
+            received["question"] = req.question
+            received["choices"] = req.choices
+            received["default_value"] = req.default_value
+            received["why"] = req.why
+            received["response_format"] = req.response_format
+            return AskUserResponse(text="ok")
+
+        session = _make_session(tmp_path, ask_user_handler=capture_handler)
+        request = MagicMock()
+        request.request_id = "req_fields"
+        request.ask_user.question = "which db?"
+        request.ask_user.choices = ["pg", "sqlite"]
+        request.ask_user.default_value = "pg"
+        request.ask_user.why = "need to pick a database"
+        request.ask_user.response_format = "text"
+
+        session._handle_ask_user(request)
+
+        assert received["question"] == "which db?"
+        assert received["choices"] == ["pg", "sqlite"]
+        assert received["default_value"] == "pg"
+        assert received["why"] == "need to pick a database"
+        assert received["response_format"] == "text"
+
+    @patch("strawpot.session.error_response")
+    def test_handler_exception_returns_error(self, mock_error, tmp_path):
+        """If the handler raises, return an error response."""
+        mock_error.return_value = "err"
+
+        def failing_handler(req: AskUserRequest) -> AskUserResponse:
+            raise RuntimeError("handler broke")
+
+        session = _make_session(tmp_path, ask_user_handler=failing_handler)
+        request = MagicMock()
+        request.request_id = "req_fail"
+        request.ask_user.question = "test"
+        request.ask_user.choices = []
+        request.ask_user.default_value = ""
+        request.ask_user.why = ""
+        request.ask_user.response_format = ""
 
         result = session._handle_ask_user(request)
 
         mock_error.assert_called_once_with(
-            "req_456", "NOT_IMPLEMENTED", "ask_user is not yet implemented"
+            "req_fail", "ERR_ASK_USER", "handler broke"
         )
-        assert result == "not_impl"
+        assert result == "err"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `--headless` flag to `strawpot start` — uses `WrapperRuntime` for orchestrator, producing `.log` file for GUI streaming
- Implement pluggable `ask_user` handler with transport-agnostic `AskUserRequest`/`AskUserResponse` dataclasses
- All CLI modes use default auto-respond handler; terminal interactive prompting deferred pending denden bidirectional channel
- Document headless mode and ask_user handler design in DESIGN.md

## Test plan
- [x] 72 session tests pass (5 new ask_user tests: default handler, default_value, custom handler, all-fields passthrough, error handling)
- [ ] `strawpot start --task "test" --headless` produces orchestrator `.log` file
- [ ] `strawpot start --headless` (no task) prints error
- [ ] `strawpot start --task "test"` unchanged behavior (terminal output)
- [ ] `strawpot start` unchanged behavior (interactive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)