### PR TITLE
Add GUI test job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,12 @@ on:
     branches: [main]
   pull_request:
 
-defaults:
-  run:
-    working-directory: cli
-
 jobs:
-  test:
+  cli:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: cli
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -32,3 +31,29 @@ jobs:
 
       - name: Run E2E tests
         run: pytest tests/e2e -v --timeout=30
+
+  gui:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: gui
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install CLI dependency
+        run: pip install -e ../cli
+
+      - name: Install GUI dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest tests/ -v --timeout=30


### PR DESCRIPTION
## Summary

- Add `gui` job to CI workflow running GUI tests across the same OS/Python matrix
- Move `defaults.run.working-directory` from top-level to per-job since CLI and GUI have different working directories
- Rename `test` job to `cli` for clarity

## Test plan

- [ ] CI `cli` job passes (no behavior change, just renamed)
- [ ] CI `gui` job passes — installs CLI dep first, then GUI dev deps, runs 27 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)