### PR TITLE
Add session index sync on GUI startup

### DIFF
--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 
 from strawpot.config import get_strawpot_home
 
-from strawpot_gui.db import init_db
+from strawpot_gui.db import init_db, sync_sessions
 from strawpot_gui.routers import config, health, projects
 
 
@@ -24,6 +24,7 @@ def create_app(db_path: str | None = None) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         init_db(db_path)
+        sync_sessions(db_path)
         yield
 
     app = FastAPI(title="StrawPot GUI", version="0.1.0", lifespan=lifespan)

--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -1,10 +1,15 @@
 """SQLite database management — schema initialization and connection helpers."""
 
+import json
+import logging
+import os
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
 
 from fastapi import Request
+
+logger = logging.getLogger(__name__)
 
 _SCHEMA = """\
 CREATE TABLE IF NOT EXISTS projects (
@@ -88,3 +93,165 @@ def get_db_conn(request: Request):
     """FastAPI dependency that yields a database connection."""
     with get_db(request.app.state.db_path) as conn:
         yield conn
+
+
+# ---------------------------------------------------------------------------
+# Session index sync
+# ---------------------------------------------------------------------------
+
+
+def _parse_trace(trace_path: str) -> dict:
+    """Extract completion fields from a trace.jsonl file.
+
+    Returns dict with keys: ended_at, duration_ms, exit_code, summary.
+    Missing fields are omitted.
+    """
+    result: dict = {}
+    try:
+        with open(trace_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                etype = event.get("event")
+                data = event.get("data", {})
+                if etype == "session_end":
+                    result["ended_at"] = event.get("ts")
+                    if "duration_ms" in data:
+                        result["duration_ms"] = data["duration_ms"]
+                elif etype == "delegate_end" and not event.get("parent_span"):
+                    result["exit_code"] = data.get("exit_code")
+                    result["summary"] = data.get("summary")
+    except OSError:
+        pass
+    return result
+
+
+def _is_pid_alive(pid: int) -> bool:
+    """Check if a process is alive (thin wrapper, no strawpot dependency)."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+
+
+def sync_sessions(db_path: str) -> None:
+    """Scan all registered projects and upsert session rows into gui.db."""
+    with get_db(db_path) as conn:
+        projects = conn.execute(
+            "SELECT id, working_dir FROM projects"
+        ).fetchall()
+
+        for project in projects:
+            project_id = project["id"]
+            working_dir = project["working_dir"]
+            _sync_project_sessions(conn, project_id, working_dir)
+
+
+def _sync_project_sessions(
+    conn: sqlite3.Connection, project_id: int, working_dir: str
+) -> None:
+    """Scan a single project's session directories and upsert rows."""
+    sessions_base = os.path.join(working_dir, ".strawpot", "sessions")
+    if not os.path.isdir(sessions_base):
+        return
+
+    # Scan active sessions
+    for entry in os.listdir(sessions_base):
+        if entry == "archive" or not entry.startswith("run_"):
+            continue
+        session_dir = os.path.join(sessions_base, entry)
+        _upsert_session(conn, project_id, session_dir, is_archived=False)
+
+    # Scan archived sessions
+    archive_dir = os.path.join(sessions_base, "archive")
+    if os.path.isdir(archive_dir):
+        for entry in os.listdir(archive_dir):
+            if not entry.startswith("run_"):
+                continue
+            session_dir = os.path.join(archive_dir, entry)
+            _upsert_session(conn, project_id, session_dir, is_archived=True)
+
+
+def _upsert_session(
+    conn: sqlite3.Connection,
+    project_id: int,
+    session_dir: str,
+    *,
+    is_archived: bool,
+) -> None:
+    """Read session.json + trace.jsonl and upsert a session row."""
+    session_file = os.path.join(session_dir, "session.json")
+    if not os.path.isfile(session_file):
+        return
+
+    try:
+        with open(session_file, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        logger.debug("Skipping unreadable session file: %s", session_file)
+        return
+
+    run_id = data.get("run_id")
+    if not run_id:
+        return
+
+    # Extract role from first agent
+    agents = data.get("agents", {})
+    role = "unknown"
+    if agents:
+        first_agent = next(iter(agents.values()))
+        role = first_agent.get("role", "unknown")
+
+    runtime = data.get("runtime", "unknown")
+    isolation = data.get("isolation", "none")
+    started_at = data.get("started_at", "")
+
+    # Determine status and parse trace
+    trace_path = os.path.join(session_dir, "trace.jsonl")
+    trace_info = _parse_trace(trace_path)
+
+    if is_archived:
+        exit_code = trace_info.get("exit_code")
+        if exit_code is not None and exit_code == 0:
+            status = "completed"
+        elif exit_code is not None:
+            status = "failed"
+        elif "ended_at" in trace_info:
+            status = "completed"
+        else:
+            status = "failed"
+    else:
+        pid = data.get("pid")
+        if pid is not None and _is_pid_alive(pid):
+            status = "running"
+        else:
+            status = "stale"
+
+    conn.execute(
+        """INSERT OR REPLACE INTO sessions
+           (run_id, project_id, role, runtime, isolation, status,
+            started_at, ended_at, duration_ms, exit_code, session_dir,
+            task, summary)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            run_id,
+            project_id,
+            role,
+            runtime,
+            isolation,
+            status,
+            started_at,
+            trace_info.get("ended_at"),
+            trace_info.get("duration_ms"),
+            trace_info.get("exit_code"),
+            session_dir,
+            None,  # task not stored in session.json
+            trace_info.get("summary"),
+        ),
+    )

--- a/gui/tests/test_sessions_sync.py
+++ b/gui/tests/test_sessions_sync.py
@@ -1,0 +1,277 @@
+"""Tests for session index sync on startup."""
+
+import json
+import os
+
+from strawpot_gui.db import _parse_trace, sync_sessions
+
+
+def _register_project(client, working_dir):
+    """Helper to register a project and return its ID."""
+    resp = client.post("/api/projects", json={
+        "display_name": "Test",
+        "working_dir": str(working_dir),
+    })
+    return resp.json()["id"]
+
+
+def _write_session(base_dir, run_id, *, archived=False, **overrides):
+    """Write a minimal session.json and return the session directory path."""
+    if archived:
+        session_dir = os.path.join(
+            str(base_dir), ".strawpot", "sessions", "archive", run_id
+        )
+    else:
+        session_dir = os.path.join(
+            str(base_dir), ".strawpot", "sessions", run_id
+        )
+    os.makedirs(session_dir, exist_ok=True)
+
+    data = {
+        "run_id": run_id,
+        "working_dir": str(base_dir),
+        "isolation": "none",
+        "runtime": "claude_code",
+        "denden_addr": "127.0.0.1:9700",
+        "started_at": "2026-01-01T12:00:00+00:00",
+        "pid": 999999,
+        "agents": {
+            "agent_abc": {
+                "role": "orchestrator",
+                "runtime": "claude_code",
+                "parent": None,
+                "started_at": "2026-01-01T12:00:01+00:00",
+                "pid": 999998,
+            }
+        },
+    }
+    data.update(overrides)
+
+    with open(os.path.join(session_dir, "session.json"), "w") as f:
+        json.dump(data, f)
+
+    return session_dir
+
+
+def _write_trace(session_dir, events):
+    """Write trace events to trace.jsonl in the given session dir."""
+    trace_path = os.path.join(session_dir, "trace.jsonl")
+    with open(trace_path, "w") as f:
+        for event in events:
+            f.write(json.dumps(event) + "\n")
+
+
+class TestParseTrace:
+    def test_empty_file(self, tmp_path):
+        path = str(tmp_path / "trace.jsonl")
+        with open(path, "w") as f:
+            f.write("")
+        assert _parse_trace(path) == {}
+
+    def test_missing_file(self, tmp_path):
+        assert _parse_trace(str(tmp_path / "nonexistent.jsonl")) == {}
+
+    def test_session_end_event(self, tmp_path):
+        path = str(tmp_path / "trace.jsonl")
+        _write_trace(str(tmp_path), [
+            {
+                "ts": "2026-01-01T12:05:00+00:00",
+                "event": "session_end",
+                "trace_id": "run_x",
+                "span_id": "span1",
+                "data": {"merge_strategy": "auto", "duration_ms": 300000},
+            }
+        ])
+        result = _parse_trace(os.path.join(str(tmp_path), "trace.jsonl"))
+        assert result["ended_at"] == "2026-01-01T12:05:00+00:00"
+        assert result["duration_ms"] == 300000
+
+    def test_delegate_end_root(self, tmp_path):
+        path = str(tmp_path / "trace.jsonl")
+        _write_trace(str(tmp_path), [
+            {
+                "ts": "2026-01-01T12:04:00+00:00",
+                "event": "delegate_end",
+                "trace_id": "run_x",
+                "span_id": "span2",
+                "parent_span": None,
+                "data": {"exit_code": 0, "summary": "Done", "duration_ms": 250000},
+            }
+        ])
+        result = _parse_trace(os.path.join(str(tmp_path), "trace.jsonl"))
+        assert result["exit_code"] == 0
+        assert result["summary"] == "Done"
+
+    def test_non_root_delegate_end_ignored(self, tmp_path):
+        _write_trace(str(tmp_path), [
+            {
+                "ts": "2026-01-01T12:04:00+00:00",
+                "event": "delegate_end",
+                "trace_id": "run_x",
+                "span_id": "span2",
+                "parent_span": "span1",
+                "data": {"exit_code": 1, "summary": "Sub failed", "duration_ms": 5000},
+            }
+        ])
+        result = _parse_trace(os.path.join(str(tmp_path), "trace.jsonl"))
+        assert "exit_code" not in result
+
+
+class TestSyncSessions:
+    def test_no_projects(self, client):
+        """Sync with no registered projects is a no-op."""
+        sync_sessions(client.app.state.db_path)
+
+    def test_project_no_sessions_dir(self, client, tmp_path):
+        """Project with no .strawpot/sessions/ directory."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        sync_sessions(client.app.state.db_path)
+        # No crash, no sessions created
+
+    def test_archived_session_minimal(self, client, tmp_path):
+        """Archived session with session.json only → row with minimal fields."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        pid = _register_project(client, project_dir)
+
+        _write_session(project_dir, "run_abc123", archived=True)
+
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get("/api/projects")
+        # Check db directly
+        from strawpot_gui.db import get_db
+        with get_db(client.app.state.db_path) as conn:
+            row = conn.execute(
+                "SELECT * FROM sessions WHERE run_id = ?", ("run_abc123",)
+            ).fetchone()
+        assert row is not None
+        assert row["project_id"] == pid
+        assert row["role"] == "orchestrator"
+        assert row["runtime"] == "claude_code"
+        assert row["isolation"] == "none"
+        assert row["status"] == "failed"  # no trace → failed
+
+    def test_archived_session_with_trace(self, client, tmp_path):
+        """Archived session with trace.jsonl → has completion fields."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        pid = _register_project(client, project_dir)
+
+        session_dir = _write_session(project_dir, "run_traced", archived=True)
+        _write_trace(session_dir, [
+            {
+                "ts": "2026-01-01T12:00:01+00:00",
+                "event": "session_start",
+                "trace_id": "run_traced",
+                "span_id": "s1",
+                "data": {"run_id": "run_traced", "role": "orchestrator",
+                         "runtime": "claude_code", "isolation": "none"},
+            },
+            {
+                "ts": "2026-01-01T12:05:00+00:00",
+                "event": "delegate_end",
+                "trace_id": "run_traced",
+                "span_id": "s2",
+                "parent_span": None,
+                "data": {"exit_code": 0, "summary": "All done", "duration_ms": 300000},
+            },
+            {
+                "ts": "2026-01-01T12:05:01+00:00",
+                "event": "session_end",
+                "trace_id": "run_traced",
+                "span_id": "s1",
+                "data": {"merge_strategy": "auto", "duration_ms": 300100},
+            },
+        ])
+
+        sync_sessions(client.app.state.db_path)
+
+        from strawpot_gui.db import get_db
+        with get_db(client.app.state.db_path) as conn:
+            row = conn.execute(
+                "SELECT * FROM sessions WHERE run_id = ?", ("run_traced",)
+            ).fetchone()
+        assert row["status"] == "completed"
+        assert row["exit_code"] == 0
+        assert row["summary"] == "All done"
+        assert row["duration_ms"] == 300100
+        assert row["ended_at"] == "2026-01-01T12:05:01+00:00"
+
+    def test_active_session_live_pid(self, client, tmp_path):
+        """Active session with live PID → status 'running'."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        # Use current process PID so it's alive
+        _write_session(project_dir, "run_live", pid=os.getpid())
+
+        sync_sessions(client.app.state.db_path)
+
+        from strawpot_gui.db import get_db
+        with get_db(client.app.state.db_path) as conn:
+            row = conn.execute(
+                "SELECT * FROM sessions WHERE run_id = ?", ("run_live",)
+            ).fetchone()
+        assert row["status"] == "running"
+
+    def test_corrupt_session_json_skipped(self, client, tmp_path):
+        """Corrupt session.json is skipped without crashing."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        session_dir = os.path.join(
+            str(project_dir), ".strawpot", "sessions", "archive", "run_corrupt"
+        )
+        os.makedirs(session_dir)
+        with open(os.path.join(session_dir, "session.json"), "w") as f:
+            f.write("NOT JSON")
+
+        sync_sessions(client.app.state.db_path)
+
+        from strawpot_gui.db import get_db
+        with get_db(client.app.state.db_path) as conn:
+            count = conn.execute("SELECT count(*) FROM sessions").fetchone()[0]
+        assert count == 0
+
+    def test_multiple_projects(self, client, tmp_path):
+        """Sessions from multiple projects are all synced."""
+        p1 = tmp_path / "proj1"
+        p1.mkdir()
+        p2 = tmp_path / "proj2"
+        p2.mkdir()
+        _register_project(client, p1)
+        _register_project(client, p2)
+
+        _write_session(p1, "run_p1", archived=True)
+        _write_session(p2, "run_p2", archived=True)
+
+        sync_sessions(client.app.state.db_path)
+
+        from strawpot_gui.db import get_db
+        with get_db(client.app.state.db_path) as conn:
+            count = conn.execute("SELECT count(*) FROM sessions").fetchone()[0]
+        assert count == 2
+
+    def test_idempotent(self, client, tmp_path):
+        """Running sync twice doesn't duplicate rows."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        _write_session(project_dir, "run_idem", archived=True)
+
+        sync_sessions(client.app.state.db_path)
+        sync_sessions(client.app.state.db_path)
+
+        from strawpot_gui.db import get_db
+        with get_db(client.app.state.db_path) as conn:
+            count = conn.execute(
+                "SELECT count(*) FROM sessions WHERE run_id = ?", ("run_idem",)
+            ).fetchone()[0]
+        assert count == 1


### PR DESCRIPTION
## Summary
- Add `sync_sessions()` to scan all registered projects' session directories on startup and upsert rows into the `sessions` table
- Parse `trace.jsonl` for completion fields (`ended_at`, `duration_ms`, `exit_code`, `summary`)
- Determine session status: archived sessions → completed/failed based on trace; active sessions → running/stale based on PID liveness
- Call `sync_sessions()` in the FastAPI lifespan after `init_db()`
- Add 13 tests covering trace parsing, sync edge cases, and idempotency

## Test plan
- [x] `pytest gui/tests/ -v --timeout=30` — all 40 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)