### PR TITLE
Add session list endpoint

### DIFF
--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI
 from strawpot.config import get_strawpot_home
 
 from strawpot_gui.db import init_db, sync_sessions
-from strawpot_gui.routers import config, health, projects
+from strawpot_gui.routers import config, health, projects, sessions
 
 
 def create_app(db_path: str | None = None) -> FastAPI:
@@ -33,5 +33,6 @@ def create_app(db_path: str | None = None) -> FastAPI:
     app.include_router(health.router)
     app.include_router(projects.router)
     app.include_router(config.router)
+    app.include_router(sessions.router)
 
     return app

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -1,0 +1,24 @@
+"""Session list endpoint."""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from strawpot_gui.db import get_db_conn
+
+router = APIRouter(prefix="/api", tags=["sessions"])
+
+
+@router.get("/projects/{project_id}/sessions")
+def list_sessions(project_id: int, conn=Depends(get_db_conn)):
+    project = conn.execute(
+        "SELECT id FROM projects WHERE id = ?", (project_id,)
+    ).fetchone()
+    if not project:
+        raise HTTPException(404, "Project not found")
+
+    rows = conn.execute(
+        "SELECT run_id, project_id, role, runtime, isolation, status,"
+        "       started_at, ended_at, duration_ms, exit_code, task, summary"
+        "  FROM sessions WHERE project_id = ? ORDER BY started_at DESC",
+        (project_id,),
+    ).fetchall()
+    return [dict(row) for row in rows]

--- a/gui/tests/test_sessions.py
+++ b/gui/tests/test_sessions.py
@@ -1,0 +1,103 @@
+"""Tests for session list endpoint."""
+
+from strawpot_gui.db import sync_sessions
+
+from test_sessions_sync import _register_project, _write_session, _write_trace
+
+
+class TestListSessions:
+    def test_empty_list(self, client, tmp_path):
+        """Project with no sessions returns empty list."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        pid = _register_project(client, project_dir)
+
+        resp = client.get(f"/api/projects/{pid}/sessions")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_lists_sessions(self, client, tmp_path):
+        """Returns sessions with correct fields."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        pid = _register_project(client, project_dir)
+
+        session_dir = _write_session(project_dir, "run_abc", archived=True)
+        _write_trace(session_dir, [
+            {
+                "ts": "2026-01-01T12:05:00+00:00",
+                "event": "delegate_end",
+                "trace_id": "run_abc",
+                "span_id": "s1",
+                "parent_span": None,
+                "data": {"exit_code": 0, "summary": "Done", "duration_ms": 300000},
+            },
+            {
+                "ts": "2026-01-01T12:05:01+00:00",
+                "event": "session_end",
+                "trace_id": "run_abc",
+                "span_id": "s0",
+                "data": {"duration_ms": 300100},
+            },
+        ])
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get(f"/api/projects/{pid}/sessions")
+        assert resp.status_code == 200
+        sessions = resp.json()
+        assert len(sessions) == 1
+
+        s = sessions[0]
+        assert s["run_id"] == "run_abc"
+        assert s["project_id"] == pid
+        assert s["status"] == "completed"
+        assert s["exit_code"] == 0
+        assert s["summary"] == "Done"
+        assert s["duration_ms"] == 300100
+        # session_dir should not be exposed
+        assert "session_dir" not in s
+
+    def test_nonexistent_project_returns_404(self, client):
+        """Requesting sessions for unknown project returns 404."""
+        resp = client.get("/api/projects/9999/sessions")
+        assert resp.status_code == 404
+
+    def test_ordered_by_most_recent(self, client, tmp_path):
+        """Sessions are ordered by started_at descending."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        pid = _register_project(client, project_dir)
+
+        _write_session(
+            project_dir, "run_old", archived=True,
+            started_at="2026-01-01T10:00:00+00:00",
+        )
+        _write_session(
+            project_dir, "run_new", archived=True,
+            started_at="2026-01-01T14:00:00+00:00",
+        )
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get(f"/api/projects/{pid}/sessions")
+        sessions = resp.json()
+        assert len(sessions) == 2
+        assert sessions[0]["run_id"] == "run_new"
+        assert sessions[1]["run_id"] == "run_old"
+
+    def test_scoped_to_project(self, client, tmp_path):
+        """Sessions from other projects are not included."""
+        p1 = tmp_path / "proj1"
+        p1.mkdir()
+        p2 = tmp_path / "proj2"
+        p2.mkdir()
+        pid1 = _register_project(client, p1)
+        _register_project(client, p2)
+
+        _write_session(p1, "run_p1", archived=True)
+        _write_session(p2, "run_p2", archived=True)
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get(f"/api/projects/{pid1}/sessions")
+        sessions = resp.json()
+        assert len(sessions) == 1
+        assert sessions[0]["run_id"] == "run_p1"


### PR DESCRIPTION
## Summary
- Add `GET /api/projects/{project_id}/sessions` endpoint returning sessions ordered by most recent first
- Validates project exists (404 if not), excludes internal `session_dir` from response
- Register sessions router in app factory

## Test plan
- [x] `pytest gui/tests/ -v --timeout=30` — all new tests pass (5 tests)
- [x] Empty list, field validation, 404, ordering, project scoping

🤖 Generated with [Claude Code](https://claude.com/claude-code)