### PR TITLE
Add pip-based memory provider loading

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1794,7 +1794,13 @@ class MemoryProvider(Protocol):
 Memory providers follow the same [Agent Skills](https://agentskills.io) open
 format — YAML frontmatter (`name`, `description`) + markdown body. The body
 describes the provider's capabilities and storage approach. StrawPot-specific
-config (wrapper, tools, params, env) lives under `metadata.strawpot`:
+config (wrapper, tools, params, env) lives under `metadata.strawpot`.
+
+There are two distribution modes:
+
+**Pip-based (recommended)** — The provider is distributed as a Python package.
+`MEMORY.md` references the pip package name and a dotted module path. StrawPot
+auto-installs the package on first use if not already installed.
 
 ```yaml
 ---
@@ -1803,7 +1809,8 @@ description: Default file-based memory provider for StrawPot
 metadata:
   version: "0.1.0"
   strawpot:
-    memory_module: provider.py
+    pip: dial-memory
+    memory_module: dial_memory.provider
     params:
       storage_dir:
         type: string
@@ -1821,6 +1828,30 @@ metadata:
 Default file-based memory provider. Two memory layers — Event Memory
 and a unified Knowledge store — using local JSON/JSONL files.
 ```
+
+**File-based** — The provider Python file is bundled alongside `MEMORY.md`.
+`memory_module` is a relative file path. Used for built-in providers (e.g. noop).
+
+```yaml
+---
+name: noop
+description: No-op memory provider
+metadata:
+  version: "0.1.0"
+  strawpot:
+    memory_module: provider.py
+---
+```
+
+#### Fields
+
+| Field | Description |
+|-------|-------------|
+| `pip` | PyPI package name (e.g. `dial-memory`). When present, StrawPot uses `importlib.import_module` and auto-runs `pip install` on `ImportError`. |
+| `memory_module` | Dotted module path (e.g. `dial_memory.provider`) when `pip` is set, or relative file path (e.g. `provider.py`) for file-based providers. |
+| `params` | Parameter definitions with types and defaults. Merged with user config from `strawpot.toml`. |
+| `tools` | System tool dependencies with install hints (same as agent skills). |
+| `env` | Environment variable requirements. |
 
 Installed to `~/.strawpot/memory/<name>/`, resolved the same way as agents:
 project-local → global.
@@ -1842,13 +1873,16 @@ flow works as before.
 
 ### Installation
 
-Memory providers will be installable via strawhub once the `memory` package
-type is added (planned strawhub addition):
+Memory providers are installable via strawhub:
 
 ```
 strawpot install memory <slug>     →  strawhub install memory <slug>
 strawpot uninstall memory <slug>   →  strawhub uninstall memory <slug>
 ```
+
+For pip-based providers, strawhub installs the `MEMORY.md` manifest. The
+Python package itself is auto-installed by StrawPot on first use when
+`importlib.import_module` raises `ImportError`.
 
 ---
 

--- a/cli/src/strawpot/memory/registry.py
+++ b/cli/src/strawpot/memory/registry.py
@@ -1,8 +1,12 @@
 """Memory registry — discover MEMORY.md manifests and resolve to MemorySpec."""
 
+import importlib
 import importlib.util
+import logging
 import os
 import shutil
+import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -13,16 +17,21 @@ from strawpot.config import get_strawpot_home
 from strawpot.memory.protocol import MemoryProvider
 
 
+log = logging.getLogger(__name__)
+
+
 @dataclass
 class MemorySpec:
     """Resolved memory manifest ready for loading."""
 
     name: str
     version: str
-    script: str
+    script: str = ""
     config: dict = field(default_factory=dict)
     env_schema: dict = field(default_factory=dict)
     tools: dict = field(default_factory=dict)
+    pip: str = ""
+    module_path: str = ""
 
 
 def parse_memory_md(path: Path) -> tuple[dict, str]:
@@ -45,28 +54,37 @@ def parse_memory_md(path: Path) -> tuple[dict, str]:
     return frontmatter, body
 
 
-def _resolve_script(memory_dir: Path, strawpot_meta: dict) -> str:
-    """Resolve the provider script path from metadata.strawpot.memory_module.
+def _resolve_script(memory_dir: Path, strawpot_meta: dict) -> tuple[str, str, str]:
+    """Resolve the provider module from metadata.strawpot.
 
-    Args:
-        memory_dir: Directory containing the MEMORY.md.
-        strawpot_meta: The ``metadata.strawpot`` dict from frontmatter.
+    When ``pip`` is present, ``memory_module`` is treated as a dotted Python
+    import path (e.g. ``dial_memory.provider``).  Otherwise it is a file path
+    relative to the MEMORY.md directory.
 
     Returns:
-        Absolute path to the provider script.
+        ``(script_path, pip_package, module_path)`` — only one of
+        ``script_path`` or ``module_path`` will be non-empty.
 
     Raises:
-        ValueError: If memory_module is missing or file does not exist.
+        ValueError: If memory_module is missing or (for file mode) file
+            does not exist.
     """
-    script = strawpot_meta.get("memory_module")
-    if not script:
+    module = strawpot_meta.get("memory_module")
+    if not module:
         raise ValueError(
             "MEMORY.md must define metadata.strawpot.memory_module"
         )
-    script_path = memory_dir / script
+
+    pip_package = strawpot_meta.get("pip", "")
+    if pip_package:
+        # pip-based: memory_module is a dotted import path
+        return ("", pip_package, module)
+
+    # File-based: memory_module is a relative file path
+    script_path = memory_dir / module
     if not script_path.is_file():
         raise ValueError(f"Memory provider script not found: {script_path}")
-    return str(script_path.resolve())
+    return (str(script_path.resolve()), "", "")
 
 
 def _merge_config(params: dict, user_config: dict) -> dict:
@@ -126,7 +144,7 @@ def resolve_memory(
     metadata = frontmatter.get("metadata", {})
     strawpot_meta = metadata.get("strawpot", {})
 
-    script = _resolve_script(memory_dir, strawpot_meta)
+    script, pip_package, module_path = _resolve_script(memory_dir, strawpot_meta)
     params = strawpot_meta.get("params", {})
     config = _merge_config(params, user_config or {})
     env_schema = strawpot_meta.get("env", {})
@@ -140,29 +158,62 @@ def resolve_memory(
         config=config,
         env_schema=env_schema,
         tools=tools,
+        pip=pip_package,
+        module_path=module_path,
     )
 
 
-def load_provider(spec: MemorySpec) -> MemoryProvider:
-    """Dynamically load a memory provider from a MemorySpec.
+def _pip_install(package: str) -> None:
+    """Install a Python package via pip."""
+    log.info("Installing %s via pip...", package)
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", package],
+        stdout=subprocess.DEVNULL,
+    )
 
-    Imports the script file, scans for a class that satisfies
-    ``MemoryProvider``, and returns an instance.
 
-    Args:
-        spec: A resolved MemorySpec with an absolute script path.
+def _load_module(spec: MemorySpec):
+    """Import the provider module, auto-installing pip packages if needed."""
+    if spec.module_path:
+        # pip-based provider
+        try:
+            return importlib.import_module(spec.module_path)
+        except ImportError:
+            if not spec.pip:
+                raise
+            _pip_install(spec.pip)
+            return importlib.import_module(spec.module_path)
 
-    Returns:
-        An instance of the first class found that satisfies MemoryProvider.
-
-    Raises:
-        ValueError: If no MemoryProvider implementation is found in the script.
-    """
+    # File-based provider
     mod_spec = importlib.util.spec_from_file_location(
         "_memory_provider", spec.script
     )
     mod = importlib.util.module_from_spec(mod_spec)  # type: ignore[arg-type]
     mod_spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def load_provider(spec: MemorySpec) -> MemoryProvider:
+    """Dynamically load a memory provider from a MemorySpec.
+
+    For pip-based providers (``spec.module_path`` is set), imports via
+    ``importlib.import_module`` and auto-installs the pip package on
+    ``ImportError``.  For file-based providers, loads from ``spec.script``.
+
+    Scans the loaded module for a class satisfying ``MemoryProvider``
+    and returns an instance.
+
+    Args:
+        spec: A resolved MemorySpec.
+
+    Returns:
+        An instance of the first class found that satisfies MemoryProvider.
+
+    Raises:
+        ValueError: If no MemoryProvider implementation is found.
+    """
+    mod = _load_module(spec)
+    source = spec.module_path or spec.script
 
     for attr_name in dir(mod):
         attr = getattr(mod, attr_name)
@@ -179,7 +230,7 @@ def load_provider(spec: MemorySpec) -> MemoryProvider:
                 return instance
 
     raise ValueError(
-        f"No MemoryProvider implementation found in {spec.script}"
+        f"No MemoryProvider implementation found in {source}"
     )
 
 

--- a/cli/tests/test_memory_registry.py
+++ b/cli/tests/test_memory_registry.py
@@ -94,8 +94,18 @@ def test_resolve_script_found(tmp_path):
     script = tmp_path / "provider.py"
     script.write_text("# stub")
     meta = {"memory_module": "provider.py"}
-    result = _resolve_script(tmp_path, meta)
-    assert result == str(script.resolve())
+    script_path, pip, module_path = _resolve_script(tmp_path, meta)
+    assert script_path == str(script.resolve())
+    assert pip == ""
+    assert module_path == ""
+
+
+def test_resolve_script_pip_mode(tmp_path):
+    meta = {"memory_module": "dial_memory.provider", "pip": "dial-memory"}
+    script_path, pip, module_path = _resolve_script(tmp_path, meta)
+    assert script_path == ""
+    assert pip == "dial-memory"
+    assert module_path == "dial_memory.provider"
 
 
 def test_resolve_script_missing_field():
@@ -256,6 +266,18 @@ def test_memory_spec_defaults():
     assert spec.config == {}
     assert spec.env_schema == {}
     assert spec.tools == {}
+    assert spec.pip == ""
+    assert spec.module_path == ""
+
+
+def test_memory_spec_pip():
+    spec = MemorySpec(
+        name="m", version="1.0",
+        pip="dial-memory", module_path="dial_memory.provider",
+    )
+    assert spec.script == ""
+    assert spec.pip == "dial-memory"
+    assert spec.module_path == "dial_memory.provider"
 
 
 # --- Built-in noop provider ---
@@ -353,3 +375,76 @@ def test_load_provider_noop(tmp_path, monkeypatch):
     provider = load_provider(spec)
     assert isinstance(provider, MemoryProvider)
     assert provider.name == "noop"
+
+
+# --- pip-based provider ---
+
+
+PIP_MEMORY_MD = dedent("""\
+    ---
+    name: pip-memory
+    description: A pip-based memory provider
+    metadata:
+      version: "1.0.0"
+      strawpot:
+        pip: dial-memory
+        memory_module: dial_memory.provider
+        params:
+          storage_dir:
+            type: string
+            default: .strawpot/memory/dial-data
+    ---
+
+    # Pip Memory
+""")
+
+
+def test_resolve_pip_provider(tmp_path, monkeypatch):
+    monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "global"))
+    project_dir = tmp_path / "project"
+    memory_dir = project_dir / ".strawpot" / "memory"
+    _write_memory(memory_dir, "pip-memory", PIP_MEMORY_MD, script=False)
+
+    spec = resolve_memory("pip-memory", str(project_dir))
+    assert spec.name == "pip-memory"
+    assert spec.pip == "dial-memory"
+    assert spec.module_path == "dial_memory.provider"
+    assert spec.script == ""
+
+
+def test_load_provider_pip(tmp_path, monkeypatch):
+    """load_provider works with a pip-installed module."""
+    # Create a fake pip-installed module in a temp directory
+    fake_pkg = tmp_path / "dial_memory"
+    fake_pkg.mkdir()
+    (fake_pkg / "__init__.py").write_text("")
+    (fake_pkg / "provider.py").write_text(dedent("""\
+        from strawpot.memory.protocol import DumpReceipt, GetResult, RememberResult
+
+        class DialMemoryProvider:
+            name = "dial"
+
+            def get(self, *, session_id, agent_id, role, behavior_ref,
+                    task, budget=None, parent_agent_id=None):
+                return GetResult()
+
+            def dump(self, *, session_id, agent_id, role, behavior_ref,
+                     task, status, output, tool_trace="",
+                     parent_agent_id=None, artifacts=None):
+                return DumpReceipt()
+
+            def remember(self, *, session_id, agent_id, role, content,
+                         keywords=None, scope="project"):
+                return RememberResult(status="accepted")
+    """))
+
+    # Add temp dir to sys.path so importlib can find it
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    spec = MemorySpec(
+        name="dial", version="1.0",
+        pip="dial-memory", module_path="dial_memory.provider",
+    )
+    provider = load_provider(spec)
+    assert isinstance(provider, MemoryProvider)
+    assert provider.name == "dial"

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -72,7 +72,12 @@ pr_command = "gh pr create --base {base_branch} --head {session_branch}"
 # ── Memory ───────────────────────────────────────────────
 [memory]
 # Memory provider name (default: noop)
-provider = "noop"
+provider = "dial"
+
+# Provider-specific config (merged with MEMORY.md param defaults)
+[memory_config]
+storage_dir = ".strawpot/memory/dial-data"
+em_tail_count = 20
 
 # ── Agent-Specific Config ────────────────────────────────
 # Keyed by agent name. Passed as --config JSON to the wrapper.

--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -108,7 +108,12 @@ class MemoryProvider(Protocol):
     name: str
     def get(self, *, session_id, agent_id, role, ...) -> GetResult: ...
     def dump(self, *, session_id, agent_id, role, ...) -> DumpReceipt: ...
+    def remember(self, *, session_id, agent_id, role,
+                 content, keywords=None, scope="project") -> RememberResult: ...
 ```
+
+Memory providers are distributed as pip packages with a `MEMORY.md` manifest.
+StrawPot auto-installs the package on first use. See [DESIGN.md](https://github.com/strawpot/strawpot/blob/main/DESIGN.md#memory-manifest-memorymd) for the manifest format.
 
 ## Agent Wrapper Protocol
 

--- a/docs/concepts/delegation.mdx
+++ b/docs/concepts/delegation.mdx
@@ -101,6 +101,8 @@ If a memory provider is configured, StrawPot retrieves context before spawning e
 
 After the sub-agent completes, `memory.dump()` records the result for future reference.
 
+Agents can also store knowledge explicitly via `memory.remember()`, which persists facts and domain knowledge at global, project, or role scope for retrieval in future sessions.
+
 ## Tracing
 
 When tracing is enabled (the default), every delegation emits structured events to the session's `trace.jsonl`:

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -113,6 +113,7 @@ This separation keeps the event stream small and scannable while preserving full
 | `delegate_denied` | Policy blocks delegation | role, reason |
 | `memory_get` | Memory context retrieved | provider, cards_ref, card_count |
 | `memory_dump` | Memory recorded after agent | provider, entries_ref, entry_count |
+| `memory_remember` | Agent stores knowledge | provider, entry_id, scope |
 | `agent_spawn` | Agent process launched | agent_id, runtime, pid |
 | `agent_end` | Agent process exits | exit_code, output_ref, duration_ms |
 


### PR DESCRIPTION
## Summary
- Add `pip` and `module_path` fields to `MemorySpec` for pip-based memory provider distribution
- Auto-install pip packages on `ImportError` during provider loading (file-based loading still supported)
- Update `DESIGN.md` Memory Manifest section with both distribution modes and field reference
- Update docs: `configuration.mdx`, `architecture.mdx`, `delegation.mdx`, `sessions.mdx`
- Add tests for pip-based resolution and loading

## Test plan
- [x] All 28 memory registry tests pass
- [x] New tests: `test_resolve_script_pip_mode`, `test_memory_spec_pip`, `test_resolve_pip_provider`, `test_load_provider_pip`
- [ ] Verify CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)