### PR TITLE
Remove hasattr guard for on_remember in denden fallback

### DIFF
--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -645,8 +645,7 @@ class Session:
             self._server = DenDenServer(addr=f"{host}:0")
             self._server.on_delegate(self._handle_delegate)
             self._server.on_ask_user(self._handle_ask_user)
-            if hasattr(self._server, "on_remember"):
-                self._server.on_remember(self._handle_remember)
+            self._server.on_remember(self._handle_remember)
             self._server.start()
 
         self._denden_addr = self._server.bound_addr


### PR DESCRIPTION
## Summary
- Remove the temporary `hasattr` guard for `on_remember` in the denden server fallback path
- `on_remember` is available in denden-server 0.1.8+ (current release)
- The primary path (line 635) already calls `on_remember` unconditionally; the fallback path (line 648) had an inconsistent `hasattr` guard

## Test plan
- [x] All 480 tests pass (468 unit + 12 e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)