### PR TITLE
Add session detail endpoint

### DIFF
--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -1,4 +1,7 @@
-"""Session list endpoint."""
+"""Session endpoints."""
+
+import json
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
 
@@ -22,3 +25,48 @@ def list_sessions(project_id: int, conn=Depends(get_db_conn)):
         (project_id,),
     ).fetchall()
     return [dict(row) for row in rows]
+
+
+@router.get("/projects/{project_id}/sessions/{run_id}")
+def get_session(project_id: int, run_id: str, conn=Depends(get_db_conn)):
+    row = conn.execute(
+        "SELECT run_id, project_id, role, runtime, isolation, status,"
+        "       started_at, ended_at, duration_ms, exit_code, task, summary,"
+        "       session_dir"
+        "  FROM sessions WHERE project_id = ? AND run_id = ?",
+        (project_id, run_id),
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, "Session not found")
+
+    result = {
+        k: row[k]
+        for k in row.keys()
+        if k != "session_dir"
+    }
+
+    session_dir = Path(row["session_dir"])
+
+    # Load agents from session.json
+    agents = {}
+    session_json = session_dir / "session.json"
+    try:
+        data = json.loads(session_json.read_text(encoding="utf-8"))
+        agents = data.get("agents", {})
+    except (OSError, json.JSONDecodeError):
+        pass
+    result["agents"] = agents
+
+    # Load trace events from trace.jsonl
+    events = []
+    trace_path = session_dir / "trace.jsonl"
+    try:
+        for line in trace_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                events.append(json.loads(line))
+    except (OSError, json.JSONDecodeError):
+        pass
+    result["events"] = events
+
+    return result

--- a/gui/tests/test_sessions.py
+++ b/gui/tests/test_sessions.py
@@ -1,4 +1,6 @@
-"""Tests for session list endpoint."""
+"""Tests for session list and detail endpoints."""
+
+import shutil
 
 from strawpot_gui.db import sync_sessions
 
@@ -101,3 +103,103 @@ class TestListSessions:
         sessions = resp.json()
         assert len(sessions) == 1
         assert sessions[0]["run_id"] == "run_p1"
+
+
+class TestGetSession:
+    def _setup_session(self, client, tmp_path):
+        """Create a project with one archived session and return (pid, session_dir)."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        pid = _register_project(client, project_dir)
+
+        session_dir = _write_session(project_dir, "run_detail", archived=True)
+        _write_trace(session_dir, [
+            {
+                "ts": "2026-01-01T12:05:00+00:00",
+                "event": "delegate_end",
+                "trace_id": "run_detail",
+                "span_id": "s1",
+                "parent_span": None,
+                "data": {"exit_code": 0, "summary": "All done", "duration_ms": 60000},
+            },
+            {
+                "ts": "2026-01-01T12:05:01+00:00",
+                "event": "session_end",
+                "trace_id": "run_detail",
+                "span_id": "s0",
+                "data": {"duration_ms": 60100},
+            },
+        ])
+        sync_sessions(client.app.state.db_path)
+        return pid, session_dir
+
+    def test_get_session_basic(self, client, tmp_path):
+        """Detail endpoint returns metadata without session_dir."""
+        pid, _ = self._setup_session(client, tmp_path)
+
+        resp = client.get(f"/api/projects/{pid}/sessions/run_detail")
+        assert resp.status_code == 200
+        s = resp.json()
+        assert s["run_id"] == "run_detail"
+        assert s["project_id"] == pid
+        assert s["status"] == "completed"
+        assert s["exit_code"] == 0
+        assert s["summary"] == "All done"
+        assert "session_dir" not in s
+
+    def test_get_session_agents(self, client, tmp_path):
+        """Detail endpoint returns agents from session.json."""
+        pid, _ = self._setup_session(client, tmp_path)
+
+        resp = client.get(f"/api/projects/{pid}/sessions/run_detail")
+        agents = resp.json()["agents"]
+        assert "agent_abc" in agents
+        assert agents["agent_abc"]["role"] == "orchestrator"
+
+    def test_get_session_events(self, client, tmp_path):
+        """Detail endpoint returns trace events."""
+        pid, _ = self._setup_session(client, tmp_path)
+
+        resp = client.get(f"/api/projects/{pid}/sessions/run_detail")
+        events = resp.json()["events"]
+        assert len(events) == 2
+        assert events[0]["event"] == "delegate_end"
+        assert events[1]["event"] == "session_end"
+
+    def test_get_session_not_found(self, client, tmp_path):
+        """Nonexistent run_id returns 404."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        pid = _register_project(client, project_dir)
+
+        resp = client.get(f"/api/projects/{pid}/sessions/run_nope")
+        assert resp.status_code == 404
+
+    def test_get_session_wrong_project(self, client, tmp_path):
+        """Session from another project returns 404."""
+        p1 = tmp_path / "proj1"
+        p1.mkdir()
+        p2 = tmp_path / "proj2"
+        p2.mkdir()
+        pid1 = _register_project(client, p1)
+        pid2 = _register_project(client, p2)
+
+        _write_session(p1, "run_p1", archived=True)
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get(f"/api/projects/{pid2}/sessions/run_p1")
+        assert resp.status_code == 404
+
+    def test_get_session_missing_files(self, client, tmp_path):
+        """Returns empty agents/events when session dir is deleted."""
+        pid, session_dir = self._setup_session(client, tmp_path)
+
+        # Delete the session directory after sync
+        shutil.rmtree(session_dir)
+
+        resp = client.get(f"/api/projects/{pid}/sessions/run_detail")
+        assert resp.status_code == 200
+        s = resp.json()
+        assert s["run_id"] == "run_detail"
+        assert s["agents"] == {}
+        assert s["events"] == []


### PR DESCRIPTION
## Summary
- Add `GET /api/projects/{project_id}/sessions/{run_id}` returning session metadata, agents dict from session.json, and trace events from trace.jsonl
- Gracefully returns empty agents/events when session directory is missing
- 6 new tests covering basic fields, agents, events, 404, project scoping, and missing files

## Test plan
- [x] All 51 GUI tests pass
- [ ] Manually verify with a real session directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)