### PR TITLE
Add session launch endpoint

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -161,7 +161,8 @@ def _ensure_memory_installed(name: str, working_dir: str) -> None:
     default=False,
     help="Run detached with output to log file (requires --task).",
 )
-def start(role, runtime, isolation, merge_strategy, pull, host, port, task, headless):
+@click.option("--run-id", "run_id", default=None, help="Pre-assigned run ID (used by GUI).")
+def start(role, runtime, isolation, merge_strategy, pull, host, port, task, headless, run_id):
     """Start an orchestration session.
 
     Runs in the foreground — creates an isolated environment (if configured),
@@ -252,6 +253,10 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task, head
         click.echo("Error: --headless requires --task", err=True)
         sys.exit(1)
 
+    if run_id and not run_id.startswith("run_"):
+        click.echo("Error: --run-id must start with 'run_'", err=True)
+        sys.exit(1)
+
     wrapper = WrapperRuntime(spec)
     if headless:
         rt = wrapper  # WrapperRuntime directly → output to .log file
@@ -288,6 +293,7 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task, head
         resolve_role=_resolve_role,
         resolve_role_dirs=_resolve_role_dirs,
         task=task or "",
+        run_id=run_id,
     )
     session.start(working_dir)
 

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -271,6 +271,7 @@ class Session:
         resolve_role: Callable[..., dict],
         resolve_role_dirs: Callable[[str], str | None],
         task: str = "",
+        run_id: str | None = None,
         ask_user_handler: Callable[[AskUserRequest], AskUserResponse] | None = None,
     ) -> None:
         self.config = config
@@ -281,6 +282,7 @@ class Session:
         self._resolve_role = resolve_role
         self._resolve_role_dirs = resolve_role_dirs
         self._ask_user_handler = ask_user_handler or _default_ask_user_handler
+        self._provided_run_id = run_id
 
         self._run_id: str | None = None
         self._env: IsolatedEnv | None = None
@@ -314,7 +316,7 @@ class Session:
             working_dir: Project directory (CWD at invocation time).
         """
         self._working_dir = working_dir
-        self._run_id = f"run_{uuid.uuid4().hex[:12]}"
+        self._run_id = self._provided_run_id or f"run_{uuid.uuid4().hex[:12]}"
 
         # Set session_dir on wrapper so PID/log files go to the right place
         self.wrapper.session_dir = self._session_dir()
@@ -836,6 +838,7 @@ class Session:
             "denden_addr": self._denden_addr,
             "started_at": datetime.now(timezone.utc).isoformat(),
             "pid": os.getpid(),
+            "task": self.task or None,
             "agents": {},
         }
 

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -346,3 +346,59 @@ def test_start_host_port_override(
     runner.invoke(cli, ["start", "--host", "0.0.0.0", "--port", "8080"])
 
     assert config.denden_addr == "0.0.0.0:8080"
+
+
+# ---------------------------------------------------------------------------
+# Run ID
+# ---------------------------------------------------------------------------
+
+
+@patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_skill_installed")
+@patch("strawpot.cli._ensure_agent_installed")
+@patch("strawpot.cli.Session")
+@patch("strawpot.cli.resolve_isolator")
+@patch("strawpot.cli.WrapperRuntime")
+@patch("strawpot.cli.validate_agent", return_value=ValidationResult())
+@patch("strawpot.cli.resolve_agent")
+@patch("strawpot.cli.load_config")
+def test_start_run_id_override(
+    mock_load, mock_resolve, mock_validate, mock_wrapper, mock_isolator,
+    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+):
+    """--run-id passes the pre-assigned run ID to Session constructor."""
+    from strawpot.config import StrawPotConfig
+
+    mock_load.return_value = StrawPotConfig()
+    mock_resolve.return_value = _make_spec()
+
+    runner = CliRunner()
+    runner.invoke(cli, [
+        "start", "--headless", "--task", "do stuff", "--run-id", "run_gui123"
+    ])
+
+    call_kwargs = mock_session.call_args.kwargs
+    assert call_kwargs["run_id"] == "run_gui123"
+
+
+@patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_skill_installed")
+@patch("strawpot.cli._ensure_agent_installed")
+@patch("strawpot.cli.resolve_agent")
+@patch("strawpot.cli.load_config")
+def test_start_invalid_run_id_rejected(
+    mock_load, mock_resolve, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+):
+    """--run-id without 'run_' prefix fails with error."""
+    from strawpot.config import StrawPotConfig
+
+    mock_load.return_value = StrawPotConfig()
+    mock_resolve.return_value = _make_spec()
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        "start", "--headless", "--task", "do stuff", "--run-id", "bad_id"
+    ])
+
+    assert result.exit_code != 0
+    assert "run_" in result.output

--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -251,7 +251,7 @@ def _upsert_session(
             trace_info.get("duration_ms"),
             trace_info.get("exit_code"),
             session_dir,
-            None,  # task not stored in session.json
+            data.get("task"),
             trace_info.get("summary"),
         ),
     )

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -1,13 +1,123 @@
 """Session endpoints."""
 
 import json
+import shutil
+import subprocess
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, field_validator
 
+from strawpot.config import load_config
 from strawpot_gui.db import get_db_conn
 
 router = APIRouter(prefix="/api", tags=["sessions"])
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class SessionOverrides(BaseModel):
+    runtime: str | None = None
+    isolation: str | None = None
+    merge_strategy: str | None = None
+
+
+class SessionLaunch(BaseModel):
+    project_id: int
+    task: str
+    role: str | None = None
+    overrides: SessionOverrides | None = None
+
+    @field_validator("task")
+    @classmethod
+    def task_must_be_nonempty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("task must be non-empty")
+        return v.strip()
+
+
+@router.post("/sessions", status_code=201)
+def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
+    """Launch a new headless session as a detached subprocess."""
+    project = conn.execute(
+        "SELECT id, working_dir FROM projects WHERE id = ?",
+        (body.project_id,),
+    ).fetchone()
+    if not project:
+        raise HTTPException(404, "Project not found")
+
+    working_dir = project["working_dir"]
+    if not Path(working_dir).is_dir():
+        raise HTTPException(
+            422, "Project working directory does not exist"
+        )
+
+    # Load project config for defaults
+    config = load_config(Path(working_dir))
+    role = body.role or config.orchestrator_role
+    runtime = config.runtime
+    isolation = config.isolation
+
+    if body.overrides:
+        if body.overrides.runtime:
+            runtime = body.overrides.runtime
+        if body.overrides.isolation:
+            isolation = body.overrides.isolation
+
+    # Pre-generate run_id
+    run_id = f"run_{uuid.uuid4().hex[:12]}"
+    session_dir = str(Path(working_dir) / ".strawpot" / "sessions" / run_id)
+    now = datetime.now(timezone.utc).isoformat()
+
+    conn.execute(
+        """INSERT INTO sessions
+           (run_id, project_id, role, runtime, isolation, status,
+            started_at, session_dir, task)
+           VALUES (?, ?, ?, ?, ?, 'starting', ?, ?, ?)""",
+        (run_id, body.project_id, role, runtime, isolation, now,
+         session_dir, body.task),
+    )
+
+    # Build CLI command
+    strawpot_cmd = shutil.which("strawpot")
+    if strawpot_cmd is None:
+        raise HTTPException(500, "strawpot CLI not found on PATH")
+
+    cmd = [
+        strawpot_cmd, "start",
+        "--headless",
+        "--task", body.task,
+        "--run-id", run_id,
+    ]
+    if body.role:
+        cmd.extend(["--role", body.role])
+    if body.overrides:
+        if body.overrides.runtime:
+            cmd.extend(["--runtime", body.overrides.runtime])
+        if body.overrides.isolation:
+            cmd.extend(["--isolation", body.overrides.isolation])
+        if body.overrides.merge_strategy:
+            cmd.extend(["--merge-strategy", body.overrides.merge_strategy])
+
+    try:
+        subprocess.Popen(
+            cmd,
+            cwd=working_dir,
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+        )
+    except OSError:
+        conn.execute("DELETE FROM sessions WHERE run_id = ?", (run_id,))
+        raise HTTPException(500, "Failed to start session subprocess")
+
+    return {"run_id": run_id, "status": "starting"}
 
 
 @router.get("/projects/{project_id}/sessions")

--- a/gui/tests/test_session_launch.py
+++ b/gui/tests/test_session_launch.py
@@ -1,0 +1,141 @@
+"""Tests for POST /api/sessions (session launch) endpoint."""
+
+from unittest.mock import patch
+
+from test_sessions_sync import _register_project
+
+from strawpot_gui.db import get_db
+
+
+class TestLaunchSession:
+    def _launch(self, client, pid, **json_overrides):
+        """POST /api/sessions with mocked subprocess and shutil.which."""
+        body = {"project_id": pid, "task": "Fix the tests"}
+        body.update(json_overrides)
+        with patch("strawpot_gui.routers.sessions.shutil.which", return_value="/usr/bin/strawpot"), \
+             patch("strawpot_gui.routers.sessions.subprocess.Popen") as mock_popen, \
+             patch("strawpot_gui.routers.sessions.load_config") as mock_config:
+            from strawpot.config import StrawPotConfig
+            mock_config.return_value = StrawPotConfig()
+            resp = client.post("/api/sessions", json=body)
+        return resp, mock_popen
+
+    def test_launch_returns_201(self, client, tmp_path):
+        """Successful launch returns 201 with run_id and status."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        pid = _register_project(client, project_dir)
+
+        resp, mock_popen = self._launch(client, pid)
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["run_id"].startswith("run_")
+        assert data["status"] == "starting"
+        mock_popen.assert_called_once()
+
+    def test_launch_passes_run_id_to_cli(self, client, tmp_path):
+        """The subprocess command includes --run-id with the pre-generated ID."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        pid = _register_project(client, project_dir)
+
+        resp, mock_popen = self._launch(client, pid)
+
+        run_id = resp.json()["run_id"]
+        cmd = mock_popen.call_args[0][0]
+        assert "--run-id" in cmd
+        assert run_id in cmd
+        assert "--headless" in cmd
+        assert "--task" in cmd
+
+    def test_launch_with_overrides(self, client, tmp_path):
+        """Overrides are passed as CLI flags."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        pid = _register_project(client, project_dir)
+
+        resp, mock_popen = self._launch(
+            client, pid,
+            role="deployer",
+            overrides={"runtime": "gemini", "isolation": "worktree"},
+        )
+
+        assert resp.status_code == 201
+        cmd = mock_popen.call_args[0][0]
+        assert "--role" in cmd
+        assert "deployer" in cmd
+        assert "--runtime" in cmd
+        assert "gemini" in cmd
+        assert "--isolation" in cmd
+        assert "worktree" in cmd
+
+    def test_launch_inserts_db_row(self, client, tmp_path):
+        """A DB row with status 'starting' is inserted."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        pid = _register_project(client, project_dir)
+
+        resp, _ = self._launch(client, pid, task="Build feature")
+
+        run_id = resp.json()["run_id"]
+        with get_db(client.app.state.db_path) as conn:
+            row = conn.execute(
+                "SELECT * FROM sessions WHERE run_id = ?", (run_id,)
+            ).fetchone()
+        assert row is not None
+        assert row["status"] == "starting"
+        assert row["task"] == "Build feature"
+        assert row["project_id"] == pid
+
+    def test_launch_nonexistent_project_returns_404(self, client):
+        """Unknown project_id returns 404."""
+        resp = client.post("/api/sessions", json={
+            "project_id": 9999,
+            "task": "anything",
+        })
+        assert resp.status_code == 404
+
+    def test_launch_missing_dir_returns_422(self, client, tmp_path):
+        """Project whose working_dir no longer exists returns 422."""
+        resp = client.post("/api/projects", json={
+            "display_name": "Ghost",
+            "working_dir": str(tmp_path / "vanished"),
+        })
+        pid = resp.json()["id"]
+
+        with patch("strawpot_gui.routers.sessions.load_config"):
+            resp = client.post("/api/sessions", json={
+                "project_id": pid,
+                "task": "doomed",
+            })
+        assert resp.status_code == 422
+
+    def test_launch_empty_task_returns_422(self, client, tmp_path):
+        """Empty or whitespace-only task is rejected."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        pid = _register_project(client, project_dir)
+
+        resp = client.post("/api/sessions", json={
+            "project_id": pid,
+            "task": "   ",
+        })
+        assert resp.status_code == 422
+
+    def test_launch_strawpot_not_on_path_returns_500(self, client, tmp_path):
+        """If strawpot binary is not on PATH, returns 500."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        pid = _register_project(client, project_dir)
+
+        with patch("strawpot_gui.routers.sessions.shutil.which", return_value=None), \
+             patch("strawpot_gui.routers.sessions.load_config") as mock_config:
+            from strawpot.config import StrawPotConfig
+            mock_config.return_value = StrawPotConfig()
+
+            resp = client.post("/api/sessions", json={
+                "project_id": pid,
+                "task": "anything",
+            })
+        assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- Add `POST /api/sessions` endpoint to launch headless sessions as detached subprocesses from the GUI
- Add `--run-id` CLI flag to `strawpot start` so the GUI can pre-assign a run ID and return it immediately
- Persist `task` field in `session.json` so `sync_sessions` preserves it when upserting rows

## Test plan
- [x] 2 new CLI tests: `--run-id` passthrough and invalid prefix rejection (13 total pass)
- [x] 8 new GUI launch tests: 201 response, CLI args, overrides, DB row, 404/422/500 errors (59 total pass)
- [x] All 482 CLI tests pass
- [x] All 59 GUI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)