### PR TITLE
Add Memories concept page to StrawHub docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -48,6 +48,7 @@
           "strawhub/concepts/skills",
           "strawhub/concepts/roles",
           "strawhub/concepts/agents",
+          "strawhub/concepts/memories",
           "strawhub/concepts/dependencies",
           "strawhub/cli/commands",
           "strawhub/publishing/guide",

--- a/docs/strawhub/concepts/agents.mdx
+++ b/docs/strawhub/concepts/agents.mdx
@@ -307,14 +307,15 @@ metadata:
 A StrawPot agent wrapper for the my-ai CLI tool.
 ```
 
-## Skills vs Roles vs Agents
+## Skills vs Roles vs Agents vs Memories
 
-| | Skills | Roles | Agents |
-|---|--------|-------|--------|
-| **Purpose** | Reusable instructions | Agent behavior definition | CLI wrapper for an AI tool |
-| **File** | `SKILL.md` | `ROLE.md` | `AGENT.md` |
-| **Can depend on** | Other skills | Skills and roles | System tools |
-| **Default agent** | No | Yes | N/A (is the agent) |
-| **Env vars** | Yes | No | Yes |
-| **Params** | No | No | Yes |
-| **Namespace** | Separate | Separate | Separate |
+| | Skills | Roles | Agents | Memories |
+|---|--------|-------|--------|----------|
+| **Purpose** | Reusable instructions | Agent behavior definition | CLI wrapper for an AI tool | Persistent knowledge bank |
+| **File** | `SKILL.md` | `ROLE.md` | `AGENT.md` | `MEMORY.md` |
+| **Can depend on** | Other skills | Skills and roles | System tools | None |
+| **Default agent** | No | Yes | N/A (is the agent) | No |
+| **Env vars** | Yes | No | Yes | No |
+| **Params** | No | No | Yes | No |
+| **Binary files** | No | No | Yes | Yes |
+| **Namespace** | Separate | Separate | Separate | Separate |

--- a/docs/strawhub/concepts/memories.mdx
+++ b/docs/strawhub/concepts/memories.mdx
@@ -1,0 +1,73 @@
+---
+title: Memories
+description: Persistent knowledge banks for AI agents
+---
+
+A memory is a persistent knowledge bank that stores context, patterns, and learned information across agent sessions. Memories let agents retain and reuse project-specific knowledge without re-discovering it each time.
+
+## Format
+
+Every memory is a directory containing a `MEMORY.md` file with YAML frontmatter and a markdown body:
+
+```yaml
+---
+name: project-context
+description: "Persistent project context and conventions"
+---
+
+# Project Context
+
+Knowledge and context for the agent to remember across sessions...
+```
+
+### Required Fields
+
+| Field | Description |
+|-------|-------------|
+| `name` | Package slug (unique identifier, used for install/publish) |
+| `description` | One-line summary |
+
+### Optional Fields
+
+| Field | Description |
+|-------|-------------|
+| `version` | Semver version (auto-incremented if omitted) |
+
+## Supporting Files
+
+A memory directory can contain additional files alongside `MEMORY.md`:
+
+- Data files, indexes, binary assets
+- Any file type is allowed (including binaries)
+- Max 50 files, 10 MB each, 50 MB total
+
+## How Agents Use Memories
+
+When StrawPot spawns an agent, memory content is assembled and passed via the `--memory-prompt` argument to the agent wrapper's `build` command. The agent receives this as persistent context alongside the role prompt and skill instructions.
+
+```
+<agent-workspace>/
+├── skills/
+│   └── git-workflow/SKILL.md
+├── roles/
+│   └── implementer/ROLE.md
+└── memories/
+    └── project-context/MEMORY.md
+```
+
+## Use Cases
+
+- **Project conventions** — Coding standards, architectural decisions, naming patterns
+- **Code patterns** — Recurring solutions and preferred approaches for the codebase
+- **Team decisions** — Design choices, trade-offs, and rationale that agents should follow
+- **Debugging insights** — Known issues, workarounds, and troubleshooting steps
+
+## Skills vs Roles vs Agents vs Memories
+
+| | Skills | Roles | Agents | Memories |
+|---|--------|-------|--------|----------|
+| **Purpose** | Reusable instructions | Agent behavior definition | CLI wrapper for an AI tool | Persistent knowledge bank |
+| **File** | `SKILL.md` | `ROLE.md` | `AGENT.md` | `MEMORY.md` |
+| **Can depend on** | Other skills | Skills and roles | System tools | None |
+| **Binary files** | No | No | Yes | Yes |
+| **Namespace** | Separate | Separate | Separate | Separate |

--- a/docs/strawhub/index.mdx
+++ b/docs/strawhub/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: StrawHub Introduction
-description: Public registry for agent skills and roles
+description: Public registry for agent skills, roles, agents, and memories
 ---
 
-StrawHub is the public registry for [StrawPot](https://strawpot.com) skills and roles. Discover, publish, and install reusable instruction modules for AI agents with automatic dependency resolution.
+StrawHub is the public registry for [StrawPot](https://strawpot.com) skills, roles, agents, and memories. Discover, publish, and install reusable agent components with automatic dependency resolution.
 
 **Live at [strawhub.dev](https://strawhub.dev)**
 
-## What Are Skills and Roles?
+## Content Types
 
 <CardGroup cols={2}>
   <Card title="Skills" icon="book-open">
@@ -16,13 +16,19 @@ StrawHub is the public registry for [StrawPot](https://strawpot.com) skills and 
   <Card title="Roles" icon="user-cog">
     Define agent behavior, model configuration, and task specialization. Roles depend on both skills and other roles.
   </Card>
+  <Card title="Agents" icon="bot">
+    CLI wrapper binaries that translate StrawPot's protocol into a specific AI platform's native interface.
+  </Card>
+  <Card title="Memories" icon="brain">
+    Persistent knowledge banks that store context, patterns, and learned information across agent sessions.
+  </Card>
 </CardGroup>
 
-Both use the same format: YAML frontmatter + markdown body, following the [Agent Skills](https://agentskills.io/) open spec with StrawPot-specific extensions.
+All use the same format: YAML frontmatter + markdown body, following the [Agent Skills](https://agentskills.io/) open spec with StrawPot-specific extensions.
 
 ## Key Features
 
-- **Browse & Search** — Discover skills and roles with vector + lexical hybrid search
+- **Browse & Search** — Discover skills, roles, agents, and memories with vector + lexical hybrid search
 - **Publish** — Upload via web UI, GitHub import, or REST API
 - **Dependency Resolution** — Transitive dependencies resolved automatically on install
 - **Version Management** — Semver with latest (`*`) and exact (`==`) version constraints
@@ -44,6 +50,6 @@ Both use the same format: YAML frontmatter + markdown body, following the [Agent
     Install the CLI and get your first skill in 2 minutes.
   </Card>
   <Card title="Publishing Guide" icon="upload" href="/strawhub/publishing/guide">
-    Learn how to publish your own skills and roles.
+    Learn how to publish your own content.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Add new `memories.mdx` concept page documenting MEMORY.md format, supporting files, agent usage, and use cases
- Update `index.mdx` with Agents and Memories cards, updated descriptions to cover all 4 content types
- Expand `agents.mdx` comparison table to include Memories column and Binary files row
- Add memories page to `docs.json` navigation

## Test plan
- [ ] Verify Mintlify dev server renders the new memories page correctly
- [ ] Check navigation includes the new page between agents and dependencies
- [ ] Verify all internal links and cards render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)