### PR TITLE
Add memory feature across all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Define your AI team in Markdown. No Python. No orchestration code.
 | **Roles** | Agent attribute | — | Standalone Markdown |
 | **Skill dependency resolution** | — | — | Automatic |
 | **Multi-agent delegation** | Python config | Runtime (subagent spawn) | Declarative (role deps) |
+| **Persistent memory** | — | — | Built-in (pluggable providers) |
 
 ## Quick Start
 
@@ -35,6 +36,7 @@ strawpot start
 - **Zero boilerplate** — A role is a Markdown file with YAML frontmatter. That's it.
 - **Automatic dependency resolution** — Install a role and every skill it needs comes with it.
 - **Declarative delegation** — A team-lead role depends on other roles. StrawPot handles the orchestration.
+- **Persistent memory** — Agents learn from past sessions. Context is retrieved before each run and results are recorded after.
 - **Agent-agnostic** — Same role works with Claude Code, Codex, Gemini, or your own runtime.
 
 ## How It Works
@@ -53,10 +55,11 @@ When you run `strawpot start`:
 
 1. Creates an isolated git worktree
 2. Starts the Denden gRPC server for agent communication
-3. Launches the orchestrator agent (e.g. team-lead)
-4. Agents delegate tasks to sub-roles automatically
-5. Required roles and skills are resolved from StrawHub
-6. On exit, everything is cleaned up
+3. Retrieves memory context from past sessions
+4. Launches the orchestrator agent (e.g. team-lead)
+5. Agents delegate tasks to sub-roles automatically
+6. Required roles and skills are resolved from StrawHub
+7. On exit, records results to memory and cleans up
 
 ## The Workforce Model
 
@@ -79,7 +82,7 @@ Role: implementer
 | Project | Role |
 |---------|------|
 | [**StrawPot**](https://strawpot.com) | Runtime — runs role-based AI agents locally |
-| [**StrawHub**](https://strawhub.dev) | Registry — distributes roles, skills, and agents |
+| [**StrawHub**](https://strawhub.dev) | Registry — distributes roles, skills, agents, and memories |
 | [**Denden**](https://github.com/strawpot/denden) | Transport — gRPC bridge between agents and the orchestrator |
 
 ## Usage
@@ -119,6 +122,9 @@ role = "team-lead"
 [policy]
 allowed_roles = ["implementer", "reviewer", "fixer"]
 max_depth = 3
+
+[memory]
+provider = "dial"             # default; "" to disable
 ```
 
 ## Repository Structure

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -73,11 +73,12 @@ StrawPot delegates these commands to the `strawhub` CLI. They work identically t
 
 ### `install`
 
-Install a skill or role from StrawHub.
+Install a skill, role, or memory provider from StrawHub.
 
 ```bash
 strawpot install skill <slug> [options]
 strawpot install role <slug> [options]
+strawpot install memory <slug> [options]
 ```
 
 | Option | Description |
@@ -94,15 +95,15 @@ strawpot install role <slug> [options]
 Search the StrawHub registry.
 
 ```bash
-strawpot search <query> [--kind skill|role|all] [--limit N]
+strawpot search <query> [--kind skill|role|memory|all] [--limit N]
 ```
 
 ### `list`
 
-List available skills and roles.
+List available packages.
 
 ```bash
-strawpot list [--kind skills|roles|all] [--sort updated|downloads|stars]
+strawpot list [--kind skills|roles|memories|all] [--sort updated|downloads|stars]
 ```
 
 ### `info`
@@ -112,6 +113,7 @@ Show detailed information about a package.
 ```bash
 strawpot info skill <slug>
 strawpot info role <slug>
+strawpot info memory <slug>
 ```
 
 ### `resolve`
@@ -121,15 +123,17 @@ Resolve a package to its installed path and dependencies.
 ```bash
 strawpot resolve skill <slug>
 strawpot resolve role <slug>
+strawpot resolve memory <slug>
 ```
 
 ### `publish`
 
-Publish a skill or role to StrawHub.
+Publish a skill, role, or memory provider to StrawHub.
 
 ```bash
 strawpot publish skill [<path>]
 strawpot publish role [<path>]
+strawpot publish memory [<path>]
 ```
 
 ### Authentication

--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -28,9 +28,10 @@ strawpot start              ← CLI entry point
     StrawPot handles delegation:
       1. Policy check (role allowed? depth limit?)
       2. Resolve role + skills from StrawHub
-      3. Spawn sub-agent in session worktree
-      4. Wait for completion
-      5. Return result to caller
+      3. Retrieve memory context from provider
+      4. Spawn sub-agent in session worktree
+      5. Wait for completion, record to memory
+      6. Return result to caller
       │
       ├─ Sub-agent A (implementer role)
       │    └─ can also delegate via Denden

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -14,10 +14,11 @@ When you run `strawpot start`:
 3. **Validate** — Check required tools and environment variables
 4. **Create isolation** — Set up worktree or use project directory directly
 5. **Start Denden** — Launch gRPC server on `127.0.0.1:9700`
-6. **Resolve orchestrator role** — Fetch from StrawHub, stage dependencies
-7. **Spawn orchestrator** — Launch the agent in tmux (or direct terminal)
-8. **Block** — Wait for the orchestrator to exit
-9. **Cleanup** — Kill sub-agents, stop Denden, merge changes, remove worktree
+6. **Resolve memory provider** — Load the configured provider (default: `dial`), auto-install if needed
+7. **Resolve orchestrator role** — Fetch from StrawHub, stage dependencies
+8. **Spawn orchestrator** — Launch the agent with role, skills, and memory context in tmux (or direct terminal)
+9. **Block** — Wait for the orchestrator to exit
+10. **Cleanup** — Kill sub-agents, stop Denden, merge changes, remove worktree
 
 Session state is tracked in `.strawpot/sessions/<session_id>/session.json`.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -16,9 +16,10 @@ strawpot start --role team-lead
 
 1. Creates a git worktree for the session
 2. Starts a Denden gRPC server
-3. Spawns an orchestrator agent (Claude Code, Codex, or OpenHands)
-4. Agents delegate sub-tasks via Denden — StrawPot resolves the role + skills from StrawHub and spawns sub-agents in the same worktree
-5. On exit, cleans up everything automatically
+3. Retrieves memory context from the configured provider
+4. Spawns an orchestrator agent (Claude Code, Codex, or OpenHands)
+5. Agents delegate sub-tasks via Denden — StrawPot resolves the role + skills from StrawHub, retrieves memory, and spawns sub-agents in the same worktree
+6. On exit, records results to memory and cleans up everything automatically
 
 ## Key Features
 
@@ -35,6 +36,9 @@ strawpot start --role team-lead
   <Card title="Skill & Role Registry" icon="book">
     Agents load reusable skills and roles from StrawHub with automatic dependency resolution and version management.
   </Card>
+  <Card title="Persistent Memory" icon="brain">
+    Memory providers give agents context from past sessions and persist knowledge across runs. Pluggable via pip packages.
+  </Card>
 </CardGroup>
 
 ## Ecosystem
@@ -42,8 +46,9 @@ strawpot start --role team-lead
 | Project | Description |
 |---------|-------------|
 | [StrawPot](https://strawpot.com) | CLI orchestrator (this project) |
-| [StrawHub](https://strawhub.dev) | Public registry for skills and roles |
+| [StrawHub](https://strawhub.dev) | Public registry for skills, roles, and memories |
 | [Denden](https://github.com/strawpot/denden) | gRPC transport between agents and orchestrator |
+| [strawpot-memory](https://github.com/strawpot/strawpot-memory) | Memory provider protocol and types |
 
 ## Next Steps
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -87,6 +87,9 @@ max_depth = 3
 
 [agents.claude_code]
 model = "claude-sonnet-4-6"
+
+[memory]
+provider = "dial"  # default; set to "" to disable
 ```
 
 See [Configuration](/cli/configuration) for the full reference.
@@ -97,13 +100,15 @@ When the orchestrator agent needs help, it delegates sub-tasks via Denden:
 
 1. **Policy check** — Is the requested role allowed? Is the depth limit reached?
 2. **Role resolution** — StrawPot fetches the role and its dependencies from StrawHub
-3. **Agent spawn** — A sub-agent is launched with the role's instructions and skills
-4. **Result** — The sub-agent's output is returned to the caller
+3. **Memory retrieval** — The memory provider supplies context from past sessions
+4. **Agent spawn** — A sub-agent is launched with the role's instructions, skills, and memory context
+5. **Result** — The sub-agent's output is recorded to memory and returned to the caller
 
 All agents work in the same directory (worktree or project dir), so they can see each other's changes.
 
 ## Next Steps
 
 - [Architecture](/concepts/architecture) — Understand the full system
+- [Memory](/concepts/memory) — How memory providers work
 - [CLI Reference](/cli/commands) — All available commands
 - [Agents](/agents/overview) — How agent runtimes work

--- a/docs/strawhub/api/reference.mdx
+++ b/docs/strawhub/api/reference.mdx
@@ -173,6 +173,49 @@ DELETE /api/v1/roles/:slug
 
 ---
 
+## Memories
+
+### List Memories
+
+```
+GET /api/v1/memories?limit=50&sort=updated
+```
+
+Same parameters and response shape as List Skills.
+
+### Get Memory Detail
+
+```
+GET /api/v1/memories/:slug
+```
+
+### Get Memory File
+
+```
+GET /api/v1/memories/:slug/file?path=MEMORY.md
+```
+
+### Publish Memory
+
+<Note>Requires authentication.</Note>
+
+```
+POST /api/v1/memories
+Content-Type: multipart/form-data
+```
+
+Same payload as Publish Skill. Must include a `MEMORY.md` file. Max 50 files, 10 MB each.
+
+### Delete Memory
+
+<Note>Requires admin role.</Note>
+
+```
+DELETE /api/v1/memories/:slug
+```
+
+---
+
 ## Search
 
 ```
@@ -182,7 +225,7 @@ GET /api/v1/search?q=review&kind=all&limit=20
 | Param | Description | Default |
 |-------|-------------|---------|
 | `q` | Search query (required) | — |
-| `kind` | `all`, `skill`, or `role` | `all` |
+| `kind` | `all`, `skill`, `role`, `agent`, or `memory` | `all` |
 | `limit` | Results (1-100) | `20` |
 
 Uses hybrid ranking: vector similarity + lexical matching + popularity boost.
@@ -199,7 +242,7 @@ Uses hybrid ranking: vector similarity + lexical matching + popularity boost.
 POST /api/v1/stars/toggle
 Content-Type: application/json
 
-{ "slug": "git-workflow", "kind": "skill" }
+{ "slug": "git-workflow", "kind": "skill" }  // kind: skill | role | agent | memory
 ```
 
 Returns `{ "starred": true }` or `{ "starred": false }`.

--- a/docs/strawhub/cli/commands.mdx
+++ b/docs/strawhub/cli/commands.mdx
@@ -17,7 +17,7 @@ strawhub [--version] [--help] <command>
 
 ### `install`
 
-Install a skill or role with all dependencies. Without a subcommand, installs from `strawpot.toml`.
+Install a skill, role, or memory provider with all dependencies. Without a subcommand, installs from `strawpot.toml`.
 
 ```bash
 # From project file
@@ -26,6 +26,7 @@ strawhub install [--skip-tools] [--yes]
 # Specific package
 strawhub install skill <slug> [options]
 strawhub install role <slug> [options]
+strawhub install memory <slug> [options]
 ```
 
 | Option | Description |
@@ -49,6 +50,7 @@ strawhub install skill code-review --version 2.1.0  # specific version
 strawhub install role implementer --global           # global install
 strawhub install skill code-review --save            # save to project file
 strawhub install skill code-review --update          # update to latest
+strawhub install memory dial --global                # memory provider
 ```
 
 ### `uninstall`
@@ -58,6 +60,7 @@ Remove a package and clean up orphaned dependencies.
 ```bash
 strawhub uninstall skill <slug> [--version <ver>] [--global] [--save]
 strawhub uninstall role <slug> [--version <ver>] [--global] [--save]
+strawhub uninstall memory <slug> [--version <ver>] [--global] [--save]
 ```
 
 ### `update`
@@ -67,6 +70,7 @@ Update packages to their latest versions.
 ```bash
 strawhub update skill <slug> [--global] [--save] [--skip-tools] [--yes]
 strawhub update role <slug> [--global] [--save] [--skip-tools] [--yes]
+strawhub update memory <slug> [--global] [--save]
 strawhub update --all [--global] [--save] [--skip-tools] [--yes]
 ```
 
@@ -95,7 +99,7 @@ strawhub install-tools [--global] [--yes]
 Search the registry.
 
 ```bash
-strawhub search <query> [--kind skill|role|all] [--limit N] [--json]
+strawhub search <query> [--kind skill|role|agent|memory|all] [--limit N] [--json]
 ```
 
 ### `info`
@@ -105,6 +109,7 @@ Show package details.
 ```bash
 strawhub info skill <slug> [--file PATH] [--json]
 strawhub info role <slug> [--file PATH] [--json]
+strawhub info memory <slug> [--file PATH] [--json]
 ```
 
 ### `list`
@@ -112,7 +117,7 @@ strawhub info role <slug> [--file PATH] [--json]
 List available packages.
 
 ```bash
-strawhub list [--kind skills|roles|all] [--limit N] [--sort updated|downloads|stars] [--json]
+strawhub list [--kind skills|roles|agents|memories|all] [--limit N] [--sort updated|downloads|stars] [--json]
 ```
 
 ---
@@ -126,6 +131,7 @@ Resolve a package to its installed path and dependency paths.
 ```bash
 strawhub resolve skill <slug> [--version <ver>] [--global]
 strawhub resolve role <slug> [--version <ver>] [--global]
+strawhub resolve memory <slug> [--version <ver>] [--global]
 ```
 
 Returns JSON with the resolved path and all transitive dependencies.
@@ -136,14 +142,15 @@ Returns JSON with the resolved path and all transitive dependencies.
 
 ### `publish`
 
-Publish a skill or role to the registry. Requires authentication.
+Publish a skill, role, or memory provider to the registry. Requires authentication.
 
 ```bash
 strawhub publish skill [<path>] [--version <ver>] [--changelog <text>] [--tag <tag>]...
 strawhub publish role [<path>] [--version <ver>] [--changelog <text>] [--tag <tag>]...
+strawhub publish memory [<path>] [--version <ver>] [--changelog <text>] [--tag <tag>]...
 ```
 
-The directory must contain `SKILL.md` or `ROLE.md` with valid frontmatter. See [Publishing Guide](/strawhub/publishing/guide).
+The directory must contain `SKILL.md`, `ROLE.md`, or `MEMORY.md` with valid frontmatter. See [Publishing Guide](/strawhub/publishing/guide).
 
 ---
 
@@ -191,6 +198,7 @@ Requires admin privileges.
 ```bash
 strawhub delete skill <slug> [--yes]
 strawhub delete role <slug> [--yes]
+strawhub delete memory <slug> [--yes]
 ```
 
 ### `ban-user`

--- a/docs/strawhub/publishing/frontmatter.mdx
+++ b/docs/strawhub/publishing/frontmatter.mdx
@@ -1,9 +1,9 @@
 ---
 title: Frontmatter Reference
-description: Complete YAML frontmatter schema for skills, roles, and agents
+description: Complete YAML frontmatter schema for skills, roles, agents, and memories
 ---
 
-Skills, roles, and agents use YAML frontmatter in their markdown files. This page documents the complete schema.
+Skills, roles, agents, and memories use YAML frontmatter in their markdown files. This page documents the complete schema.
 
 ## Skill Frontmatter (`SKILL.md`)
 
@@ -159,6 +159,56 @@ Markdown body describing the agent (shown to LLMs for discovery).
 | `metadata.strawpot.params` | No | Custom parameters for the agent binary |
 | `metadata.strawpot.env` | No | Required environment variables |
 
+## Memory Frontmatter (`MEMORY.md`)
+
+```yaml
+---
+name: my-provider                              # Required: provider slug
+description: "My custom memory provider"       # Required: one-line summary
+metadata:
+  version: "1.0.0"                             # Optional: semver version
+  strawpot:
+    pip: my-provider-package                   # PyPI package name (auto-installed)
+    memory_module: my_provider.provider        # Dotted import path to provider class
+    params:                                    # Optional: configurable parameters
+      storage_dir:
+        type: string
+        default: .strawpot/memory/my-data
+        description: Where to store memory data
+      em_tail_count:
+        type: integer
+        default: 20
+        description: Number of event memory entries to return
+    tools:                                     # Optional: system tool requirements
+      sqlite3:
+        description: SQLite CLI
+        install:
+          macos: brew install sqlite
+          linux: apt install sqlite3
+    env:                                       # Optional: required environment variables
+      MY_PROVIDER_KEY:
+        required: false
+        description: Optional API key for cloud sync
+---
+
+# My Provider
+
+Description of what this provider does and how it stores data.
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Provider slug (unique within memories) |
+| `description` | Yes | One-line summary |
+| `metadata.version` | No | Semver version string |
+| `metadata.strawpot.pip` | No | PyPI package name — StrawPot auto-installs on first use |
+| `metadata.strawpot.memory_module` | Yes | Dotted import path to the module containing the provider class, or relative file path |
+| `metadata.strawpot.params` | No | Configurable parameters (merged with `[memory_config]` in `strawpot.toml`) |
+| `metadata.strawpot.tools` | No | System tool requirements |
+| `metadata.strawpot.env` | No | Required environment variables |
+
 ## Parameters Schema
 
 ```yaml
@@ -175,13 +225,14 @@ metadata:
 - User values take precedence over defaults
 - The merged config is passed to the agent binary as the `--config` JSON string
 
-## Key Differences: Skills vs Roles vs Agents
+## Key Differences: Skills vs Roles vs Agents vs Memories
 
-| Aspect | Skills | Roles | Agents |
-|--------|--------|-------|--------|
-| File | `SKILL.md` | `ROLE.md` | `AGENT.md` |
-| Dependencies | Flat list (skills only) | Structured (`skills` + `roles`) | System tools only |
-| Default agent | No | `default_agent` field | N/A (is the agent) |
-| Env vars | Yes | No | Yes |
-| Params | No | No | Yes |
-| Namespace | Separate | Separate | Separate |
+| Aspect | Skills | Roles | Agents | Memories |
+|--------|--------|-------|--------|----------|
+| File | `SKILL.md` | `ROLE.md` | `AGENT.md` | `MEMORY.md` |
+| Dependencies | Flat list (skills only) | Structured (`skills` + `roles`) | System tools only | None |
+| Default agent | No | `default_agent` field | N/A (is the agent) | No |
+| Env vars | Yes | No | Yes | Yes |
+| Params | No | No | Yes | Yes |
+| Pip package | No | No | No | Yes (`pip` field) |
+| Namespace | Separate | Separate | Separate | Separate |

--- a/docs/strawhub/publishing/guide.mdx
+++ b/docs/strawhub/publishing/guide.mdx
@@ -1,9 +1,9 @@
 ---
 title: Publishing Guide
-description: How to publish skills and roles to StrawHub
+description: How to publish skills, roles, and memories to StrawHub
 ---
 
-You can publish skills and roles via the web UI, GitHub import, or the CLI.
+You can publish skills, roles, and memory providers via the web UI, GitHub import, or the CLI.
 
 ## Prerequisites
 
@@ -12,9 +12,9 @@ You can publish skills and roles via the web UI, GitHub import, or the CLI.
 
 ## Publishing via CLI
 
-### 1. Create your skill or role
+### 1. Create your package
 
-Create a directory with a `SKILL.md` or `ROLE.md`:
+Create a directory with a `SKILL.md`, `ROLE.md`, or `MEMORY.md`:
 
 ```bash
 mkdir my-skill
@@ -27,6 +27,26 @@ description: "A brief description of what this skill does"
 # My Skill
 
 Instructions for the agent...
+EOF
+```
+
+For memory providers, create a `MEMORY.md` with pip and module fields:
+
+```bash
+mkdir my-memory
+cat > my-memory/MEMORY.md << 'EOF'
+---
+name: my-memory
+description: "My custom memory provider"
+metadata:
+  strawpot:
+    pip: my-memory-package
+    memory_module: my_memory.provider
+---
+
+# My Memory Provider
+
+Description of how this provider stores and retrieves context.
 EOF
 ```
 
@@ -66,7 +86,7 @@ strawhub publish skill ./my-skill --tag python --tag testing
 ## Publishing via GitHub Import
 
 1. Go to [strawhub.dev/upload](https://strawhub.dev/upload)
-2. Paste a **GitHub repository URL** containing your `SKILL.md` or `ROLE.md`
+2. Paste a **GitHub repository URL** containing your `SKILL.md`, `ROLE.md`, or `MEMORY.md`
 3. Files are fetched via the GitHub Contents API
 4. Review and publish
 
@@ -113,9 +133,9 @@ description: "A brief description"
 
 | Constraint | Limit |
 |------------|-------|
-| Required file | `SKILL.md` (skills) or `ROLE.md` (roles) |
-| Max files per package | 20 |
-| Max file size | 512 KB |
+| Required file | `SKILL.md` (skills), `ROLE.md` (roles), or `MEMORY.md` (memories) |
+| Max files per package | 20 (skills/roles), 50 (memories) |
+| Max file size | 512 KB (skills/roles), 10 MB (memories) |
 | Max total size | 50 MB |
 
 ## Dependency Validation

--- a/docs/strawhub/quickstart.mdx
+++ b/docs/strawhub/quickstart.mdx
@@ -27,6 +27,14 @@ strawhub install role implementer
 
 Roles can depend on both skills and other roles. Dependencies are resolved automatically via the StrawHub API.
 
+## Install a Memory Provider
+
+```bash
+strawhub install memory dial
+```
+
+Memory providers are installed to `.strawpot/memory/` and supply agents with context from past sessions.
+
 ## Search the Registry
 
 ```bash
@@ -67,7 +75,7 @@ strawhub init
 
 ## Authentication
 
-To publish skills and roles, you need an API token:
+To publish skills, roles, and memories, you need an API token:
 
 1. Sign in at [strawhub.dev](https://strawhub.dev) with GitHub
 2. Go to **Settings > API Tokens** and create a token
@@ -80,7 +88,7 @@ strawhub login
 
 ## Using with StrawPot
 
-StrawPot automatically resolves and installs skills and roles from StrawHub during orchestration sessions. You can also use the same commands through `strawpot`:
+StrawPot automatically resolves and installs skills, roles, and memory providers from StrawHub during orchestration sessions. You can also use the same commands through `strawpot`:
 
 ```bash
 strawpot install skill git-workflow
@@ -91,5 +99,6 @@ strawpot search "testing"
 
 - [Skills](/strawhub/concepts/skills) — Understand how skills work
 - [Roles](/strawhub/concepts/roles) — Understand how roles work
+- [Memories](/strawhub/concepts/memories) — Understand how memory providers work
 - [CLI Reference](/strawhub/cli/commands) — All available commands
-- [Publishing](/strawhub/publishing/guide) — Publish your own skills and roles
+- [Publishing](/strawhub/publishing/guide) — Publish your own skills, roles, and memories


### PR DESCRIPTION
## Summary

- Surfaces memory as a first-class feature across the entire doc site and README
- Previously only `concepts/memory.mdx` and `strawhub/concepts/memories.mdx` covered memory; 10 other pages described the system as if it only had skills, roles, and agents
- Adds `memory` to all CLI command references (install, search, info, publish, etc.)
- Adds MEMORY.md frontmatter schema to the frontmatter reference
- Adds memories API endpoints to the HTTP API reference
- Updates README with memory as a competitive differentiator in the comparison table

## Files changed (11)

- `README.md` — comparison table row, "Why StrawPot" bullet, how-it-works steps, config example
- `docs/index.mdx` — how-it-works flow, feature card, ecosystem table
- `docs/quickstart.mdx` — config example, session flow, next steps link
- `docs/concepts/architecture.mdx` — delegation diagram
- `docs/concepts/sessions.mdx` — session lifecycle steps
- `docs/cli/commands.mdx` — install, search, list, info, resolve, publish
- `docs/strawhub/quickstart.mdx` — install example, next steps
- `docs/strawhub/cli/commands.mdx` — all command types
- `docs/strawhub/publishing/guide.mdx` — MEMORY.md example, file constraints
- `docs/strawhub/publishing/frontmatter.mdx` — full MEMORY.md schema, comparison table
- `docs/strawhub/api/reference.mdx` — memories endpoints, search/stars kind params

## Test plan

- [ ] Verify all cross-links resolve (e.g. `/concepts/memory`, `/strawhub/concepts/memories`)
- [ ] Confirm Mintlify renders the new CardGroup entry and tables correctly
- [ ] Spot-check CLI command examples match actual `strawhub --help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)