### PR TITLE
Remove allowed_roles policy and update README

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -395,7 +395,6 @@ class StrawPotConfig:
     isolation: str = "none"
     denden_addr: str = "127.0.0.1:9700"
     orchestrator_role: str = "orchestrator"
-    allowed_roles: list[str] | None = None   # None = all
     max_depth: int = 3
     permission_mode: str = "default"   # orchestrator permission mode
     agent_timeout: int | None = None   # sub-agent timeout in seconds (None = no limit)
@@ -529,7 +528,6 @@ role = "team-lead"           # strawhub role slug (default: "orchestrator")
 permission_mode = "default"  # orchestrator permission mode (sub-agents always "auto")
 
 [policy]
-allowed_roles = ["implementer", "reviewer", "fixer"]
 max_depth = 3
 agent_timeout = 300          # sub-agent timeout in seconds (omit for no limit)
 
@@ -646,15 +644,14 @@ Denden server dispatches to `Session._handle_delegate`:
 ```
 1. Extract: role_slug, task_text, parent_agent_id, run_id from request
 2. Policy check:
-   - role_slug in allowed_roles?  → DENY_ROLE_NOT_ALLOWED (+ trace: delegate_denied)
    - depth > max_depth?           → DENY_DEPTH_LIMIT (+ trace: delegate_denied)
 3. Resolve:
    resolved = strawhub.resolver.resolve(role_slug, kind="role")
    → {slug, version, path, dependencies: [{slug, kind, path}, ...]}
-   Build delegatable roles list for the sub-agent:
+   Build delegatable roles list from the role's own declared role dependencies:
    → excludes the current role (can't self-delegate)
    → excludes the requester role (can't delegate back to parent)
-   → only includes roles in allowed_roles with resolvable directories
+   → only includes roles with resolvable directories
 4. Build prompt:
    system_prompt = context.build_prompt(resolved,
      delegatable_roles=..., requester_role=parent_role)

--- a/README.md
+++ b/README.md
@@ -14,14 +14,32 @@ Define your AI team in Markdown. No Python. No orchestration code.
 # StrawPot: One ROLE.md file. Done.
 ```
 
+```yaml
+# team-lead/ROLE.md
+---
+name: team-lead
+description: "Orchestrates implementation and review"
+metadata:
+  strawpot:
+    dependencies:
+      roles: [implementer, reviewer]
+    default_agent: claude_code
+---
+
+# Team Lead
+
+Break the task into subtasks.
+Delegate implementation and code review to sub-roles.
+```
+
 | | CrewAI | OpenClaw | StrawPot |
 |---|---|---|---|
 | **Format** | YAML + Python | JSON5 + Markdown | Markdown only |
 | **Skills / Tools** | Python (tools) | Markdown (skills) | Markdown (skills) |
 | **Roles** | Agent attribute | — | Standalone Markdown |
+| **Memory** | Python config | Markdown/YAML (local) | Markdown (installable) |
 | **Skill dependency resolution** | — | — | Automatic |
 | **Multi-agent delegation** | Python config | Runtime (subagent spawn) | Declarative (role deps) |
-| **Persistent memory** | — | — | Built-in (pluggable providers) |
 
 ## Quick Start
 
@@ -36,7 +54,7 @@ strawpot start
 - **Zero boilerplate** — A role is a Markdown file with YAML frontmatter. That's it.
 - **Automatic dependency resolution** — Install a role and every skill it needs comes with it.
 - **Declarative delegation** — A team-lead role depends on other roles. StrawPot handles the orchestration.
-- **Persistent memory** — Agents learn from past sessions. Context is retrieved before each run and results are recorded after.
+- **Installable memory** — Memory banks are packages. Install shared context and patterns from StrawHub.
 - **Agent-agnostic** — Same role works with Claude Code, Codex, Gemini, or your own runtime.
 
 ## How It Works
@@ -68,6 +86,7 @@ Skills are abilities. Roles are jobs. Teams are roles collaborating.
 - **Skills** — Atomic capabilities such as writing code, searching documents, or running tests.
 - **Roles** — Job definitions that automatically load the skills needed for the work.
 - **Teams** — Roles collaborating to complete tasks.
+- **Memories** — Persistent knowledge banks shared across sessions.
 
 ```
 Role: implementer
@@ -120,7 +139,6 @@ addr = "127.0.0.1:9700"
 role = "team-lead"
 
 [policy]
-allowed_roles = ["implementer", "reviewer", "fixer"]
 max_depth = 3
 
 [memory]

--- a/cli/README.md
+++ b/cli/README.md
@@ -46,7 +46,6 @@ addr = "127.0.0.1:9700"
 role = "team-lead"
 
 [policy]
-allowed_roles = ["implementer", "reviewer", "fixer"]
 max_depth = 3
 ```
 

--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -307,7 +307,6 @@ def show_config():
     click.echo(f"denden_addr:          {config.denden_addr}")
     click.echo(f"orchestrator_role:    {config.orchestrator_role}")
     click.echo(f"permission_mode:      {config.permission_mode}")
-    click.echo(f"allowed_roles:        {config.allowed_roles}")
     click.echo(f"max_depth:            {config.max_depth}")
     click.echo(f"agent_timeout:        {config.agent_timeout}")
     click.echo(f"merge_strategy:       {config.merge_strategy}")

--- a/cli/src/strawpot/config.py
+++ b/cli/src/strawpot/config.py
@@ -26,7 +26,6 @@ class StrawPotConfig:
     isolation: str = "none"
     denden_addr: str = "127.0.0.1:9700"
     orchestrator_role: str = "orchestrator"
-    allowed_roles: list[str] | None = None
     max_depth: int = 3
     permission_mode: str = "default"
     agent_timeout: int | None = None
@@ -68,8 +67,6 @@ def _apply(config: StrawPotConfig, data: dict) -> None:
         config.permission_mode = orch["permission_mode"]
 
     policy = data.get("policy", {})
-    if "allowed_roles" in policy:
-        config.allowed_roles = policy["allowed_roles"]
     if "max_depth" in policy:
         config.max_depth = policy["max_depth"]
     if "agent_timeout" in policy:

--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -71,11 +71,6 @@ def _check_policy(
     config: StrawPotConfig,
 ) -> None:
     """Raise PolicyDenied if the request violates policy."""
-    if (
-        config.allowed_roles is not None
-        and request.role_slug not in config.allowed_roles
-    ):
-        raise PolicyDenied("DENY_ROLE_NOT_ALLOWED")
     if request.depth + 1 > config.max_depth:
         raise PolicyDenied("DENY_DEPTH_LIMIT")
 
@@ -579,17 +574,18 @@ def create_agent_workspace(session_dir: str, agent_id: str) -> str:
 
 
 def _build_delegatable_roles(
-    config: StrawPotConfig,
+    candidate_slugs: list[str],
     current_role: str,
     resolve_role_dirs: Callable[[str], str | None],
     requester_role: str | None = None,
 ) -> list[tuple[str, str]]:
     """Build list of (slug, description) for roles the sub-agent can delegate to.
 
+    Candidate slugs come from the role's own declared dependencies.
     Excludes the current role and the requester role. Only includes roles
-    in allowed_roles (if set) that have resolvable directories.
+    with resolvable directories.
     """
-    if config.allowed_roles is None:
+    if not candidate_slugs:
         return []
 
     skip = {current_role}
@@ -597,7 +593,7 @@ def _build_delegatable_roles(
         skip.add(requester_role)
 
     roles: list[tuple[str, str]] = []
-    for slug in config.allowed_roles:
+    for slug in candidate_slugs:
         if slug in skip:
             continue
         role_dir = resolve_role_dirs(slug)
@@ -669,7 +665,7 @@ def handle_delegate(
     """Handle a delegation request end-to-end.
 
     Steps:
-      1. Policy check (allowed_roles, max_depth)
+      1. Policy check (max_depth)
       2. Resolve role + skills via resolver
       3. Build delegatable roles list for sub-agent
       4. Build system prompt
@@ -764,8 +760,12 @@ def handle_delegate(
             )
 
     # 3. Build delegatable roles for the sub-agent
+    #    Candidates come from the role's own declared role dependencies.
+    _, role_dep_slugs, wildcard = _parse_role_deps(resolved["path"])
+    if wildcard:
+        role_dep_slugs = [slug for slug, _ in _discover_all_roles()]
     delegatable = _build_delegatable_roles(
-        config, request.role_slug, resolve_role_dirs,
+        role_dep_slugs, request.role_slug, resolve_role_dirs,
         requester_role=request.parent_role,
     )
 

--- a/cli/tests/e2e/conftest.py
+++ b/cli/tests/e2e/conftest.py
@@ -150,7 +150,6 @@ def make_config():
             isolation="none",
             denden_addr="127.0.0.1:0",
             orchestrator_role="orchestrator",
-            allowed_roles=["orchestrator", "implementer"],
             max_depth=3,
             memory="",
         )

--- a/cli/tests/e2e/test_delegation_flow.py
+++ b/cli/tests/e2e/test_delegation_flow.py
@@ -28,19 +28,6 @@ class TestDelegationFlow:
         assert (git_project / "delegated.txt").exists()
         assert "Written by stub agent" in (git_project / "delegated.txt").read_text()
 
-    def test_delegation_policy_denied(self, make_session, git_project):
-        """Delegation to a role not in allowed_roles returns DENIED."""
-        session = make_session(
-            str(git_project),
-            task="delegate implementer write denied.txt",
-            agent_script=STUB_AGENT_DELEGATE,
-            config_overrides={"allowed_roles": ["orchestrator"]},
-        )
-        session.start(str(git_project))
-
-        # Sub-agent should NOT have run — file must not exist
-        assert not (git_project / "denied.txt").exists()
-
     def test_delegation_depth_limit(self, make_session, git_project):
         """Delegation beyond max_depth returns DENIED."""
         session = make_session(

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -12,7 +12,6 @@ def test_defaults():
     assert config.isolation == "none"
     assert config.denden_addr == "127.0.0.1:9700"
     assert config.orchestrator_role == "orchestrator"
-    assert config.allowed_roles is None
     assert config.max_depth == 3
     assert config.permission_mode == "default"
     assert config.agent_timeout is None
@@ -91,7 +90,6 @@ def test_load_config_full(tmp_path, monkeypatch):
         'permission_mode = "plan"\n'
         "\n"
         "[policy]\n"
-        'allowed_roles = ["implementer", "reviewer"]\n'
         "max_depth = 5\n"
         "agent_timeout = 300\n"
         "max_delegate_retries = 2\n"
@@ -113,7 +111,6 @@ def test_load_config_full(tmp_path, monkeypatch):
     assert config.isolation == "docker"
     assert config.denden_addr == "0.0.0.0:8080"
     assert config.orchestrator_role == "team-lead"
-    assert config.allowed_roles == ["implementer", "reviewer"]
     assert config.max_depth == 5
     assert config.permission_mode == "plan"
     assert config.agent_timeout == 300

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -182,24 +182,11 @@ def _mock_runtime(summary="Done", output="ok", exit_code=0):
 
 
 class TestCheckPolicy:
-    def test_allowed_roles_none_allows_all(self):
-        """allowed_roles=None means all roles are allowed."""
-        config = _make_config(allowed_roles=None)
+    def test_any_role_allowed(self):
+        """Any installed role passes policy check."""
+        config = _make_config()
         request = _make_request(role_slug="anything")
         _check_policy(request, config)  # should not raise
-
-    def test_role_in_allowed_list(self):
-        """Role in allowed_roles passes."""
-        config = _make_config(allowed_roles=["implementer", "reviewer"])
-        request = _make_request(role_slug="implementer")
-        _check_policy(request, config)  # should not raise
-
-    def test_role_not_in_allowed_list(self):
-        """Role not in allowed_roles raises DENY_ROLE_NOT_ALLOWED."""
-        config = _make_config(allowed_roles=["implementer"])
-        request = _make_request(role_slug="admin")
-        with pytest.raises(PolicyDenied, match="DENY_ROLE_NOT_ALLOWED"):
-            _check_policy(request, config)
 
     def test_depth_under_limit(self):
         """depth + 1 <= max_depth passes."""
@@ -703,10 +690,9 @@ class TestCreateAgentWorkspace:
 
 
 class TestBuildDelegatableRoles:
-    def test_none_allowed_roles_returns_empty(self, tmp_path):
-        """When allowed_roles is None, no delegatable roles are listed."""
-        config = _make_config(allowed_roles=None)
-        result = _build_delegatable_roles(config, "implementer", lambda s: None)
+    def test_empty_candidates_returns_empty(self):
+        """When no candidate slugs are given, no delegatable roles are listed."""
+        result = _build_delegatable_roles([], "implementer", lambda s: None)
         assert result == []
 
     def test_excludes_current_role(self, tmp_path):
@@ -715,9 +701,8 @@ class TestBuildDelegatableRoles:
         _write_role(base, "implementer", description="Writes code")
         impl_dir = os.path.join(base, "roles", "implementer")
 
-        config = _make_config(allowed_roles=["implementer", "reviewer"])
         result = _build_delegatable_roles(
-            config,
+            ["implementer", "reviewer"],
             "implementer",
             lambda s: impl_dir if s == "implementer" else None,
         )
@@ -728,9 +713,8 @@ class TestBuildDelegatableRoles:
         base = str(tmp_path)
         rev_dir = _write_role(base, "reviewer", description="Reviews code")
 
-        config = _make_config(allowed_roles=["implementer", "reviewer"])
         result = _build_delegatable_roles(
-            config,
+            ["implementer", "reviewer"],
             "implementer",
             lambda s: rev_dir if s == "reviewer" else None,
         )
@@ -742,10 +726,6 @@ class TestBuildDelegatableRoles:
         impl_dir = _write_role(base, "implementer", description="Writes code")
         orch_dir = _write_role(base, "orchestrator", description="Orchestrates")
 
-        config = _make_config(
-            allowed_roles=["implementer", "orchestrator", "reviewer"]
-        )
-
         def resolve(s):
             if s == "implementer":
                 return impl_dir
@@ -754,7 +734,8 @@ class TestBuildDelegatableRoles:
             return None
 
         result = _build_delegatable_roles(
-            config, "reviewer", resolve, requester_role="orchestrator"
+            ["implementer", "orchestrator", "reviewer"],
+            "reviewer", resolve, requester_role="orchestrator",
         )
         slugs = [slug for slug, _ in result]
         assert "orchestrator" not in slugs
@@ -762,9 +743,8 @@ class TestBuildDelegatableRoles:
 
     def test_skips_unresolvable_roles(self):
         """Roles that can't be resolved are skipped."""
-        config = _make_config(allowed_roles=["implementer", "ghost"])
         result = _build_delegatable_roles(
-            config, "orchestrator", lambda s: None
+            ["implementer", "ghost"], "orchestrator", lambda s: None
         )
         assert result == []
 
@@ -809,7 +789,10 @@ class TestPromptBuilding:
     def test_delegatable_roles_in_prompt(self, tmp_path):
         """When sub-agent has delegatable roles, prompt includes delegation section."""
         base = str(tmp_path / "registry")
-        role_path = _write_role(base, "orchestrator", "You orchestrate.")
+        role_path = _write_role(
+            base, "orchestrator", "You orchestrate.",
+            role_deps=["reviewer"],
+        )
         rev_dir = _write_role(base, "reviewer", description="Reviews code")
 
         resolved = {
@@ -822,7 +805,7 @@ class TestPromptBuilding:
         }
 
         runtime = _mock_runtime()
-        config = _make_config(allowed_roles=["orchestrator", "reviewer"])
+        config = _make_config()
 
         handle_delegate(
             request=_make_request(role_slug="orchestrator"),
@@ -1446,23 +1429,6 @@ class TestRetryPolicy:
 
 
 class TestHandleDelegatePolicyDenial:
-    def test_denied_role_does_not_spawn(self, tmp_path):
-        """PolicyDenied is raised before spawn when role is not allowed."""
-        runtime = _mock_runtime()
-
-        with pytest.raises(PolicyDenied, match="DENY_ROLE_NOT_ALLOWED"):
-            handle_delegate(
-                request=_make_request(role_slug="admin"),
-                config=_make_config(allowed_roles=["implementer"]),
-                runtime=runtime,
-                working_dir=str(tmp_path),
-                session_dir=str(tmp_path / "session"),
-                resolve_role=lambda slug, kind="role": {},
-                resolve_role_dirs=lambda s: None,
-            )
-
-        runtime.spawn.assert_not_called()
-
     def test_denied_depth_does_not_spawn(self, tmp_path):
         """PolicyDenied is raised before spawn when depth exceeds limit."""
         runtime = _mock_runtime()
@@ -2271,7 +2237,7 @@ class TestHandleDelegateSkillEnv:
             }
 
         request = _make_request(role_slug="my-role")
-        config = StrawPotConfig(allowed_roles=["my-role"])
+        config = StrawPotConfig()
 
         runtime = MagicMock()
         runtime.name = "mock"
@@ -2561,7 +2527,6 @@ class TestHandleDelegateSkillEnvSaved:
 
         request = _make_request(role_slug="my-role")
         config = _make_config(
-            allowed_roles=["my-role"],
             skills={"needs-token": {"REQUIRED_TOKEN": "saved_value"}},
         )
         runtime = _mock_runtime()

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -42,10 +42,6 @@ permission_mode = "default"
 
 # ── Policy ───────────────────────────────────────────────
 [policy]
-# Roles that agents are allowed to delegate to
-# Omit to allow all roles. Empty list denies all.
-allowed_roles = ["implementer", "reviewer", "fixer"]
-
 # Maximum delegation depth (orchestrator = depth 0)
 max_depth = 3
 

--- a/docs/concepts/delegation.mdx
+++ b/docs/concepts/delegation.mdx
@@ -26,17 +26,6 @@ StrawPot delegation handler:
 
 Every delegation request is checked against the session policy before proceeding:
 
-### Allowed Roles
-
-Restrict which roles agents can delegate to:
-
-```toml
-[policy]
-allowed_roles = ["implementer", "reviewer", "fixer"]
-```
-
-Set to an empty list to deny all delegations. Omit to allow all roles.
-
 ### Max Depth
 
 Limit how deep delegation chains can go:

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -82,7 +82,6 @@ isolation = "worktree"
 role = "team-lead"
 
 [policy]
-allowed_roles = ["implementer", "reviewer"]
 max_depth = 3
 
 [agents.claude_code]

--- a/gui/DESIGN.md
+++ b/gui/DESIGN.md
@@ -180,7 +180,6 @@ Project: `<project>/strawpot.toml` (overrides global)
 | `isolation` | str | `"none"` |
 | `denden_addr` | str | `"127.0.0.1:9700"` |
 | `orchestrator_role` | str | `"orchestrator"` |
-| `allowed_roles` | list[str] \| None | `None` (all allowed) |
 | `max_depth` | int | `3` |
 | `permission_mode` | str | `"default"` |
 | `agent_timeout` | int \| None | `None` |


### PR DESCRIPTION
## Summary
- **Remove `allowed_roles`** from config, policy checks, CLI output, docs, and all tests (14 files). Delegatable roles now come from the role's own declared dependencies in ROLE.md via `_parse_role_deps`, making delegation fully declarative. The install mechanism already controls which roles are available — `allowed_roles` was redundant double-gating.
- **Update README** with an inline ROLE.md example (delivers on "One ROLE.md file. Done."), align comparison table with StrawHub (adds Memory row), and update memory bullet to "Installable memory."

## Test plan
- [x] All 143 unit tests pass (`test_config.py` + `test_delegation.py`)
- [ ] E2E delegation flow test passes (delegation still works without `allowed_roles`)
- [ ] Verify `strawpot config` output no longer shows `allowed_roles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)