### PR TITLE
Add global session list endpoint with pagination and filters

### DIFF
--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -9,7 +9,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, field_validator
 
 from strawpot.config import load_config
@@ -120,6 +120,56 @@ def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
         raise HTTPException(500, "Failed to start session subprocess")
 
     return {"run_id": run_id, "status": "starting"}
+
+
+@router.get("/sessions")
+def list_all_sessions(
+    project_id: int | None = Query(None),
+    status: str | None = Query(None),
+    since: str | None = Query(None, description="ISO 8601 datetime lower bound"),
+    until: str | None = Query(None, description="ISO 8601 datetime upper bound"),
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=100),
+    conn=Depends(get_db_conn),
+):
+    """List sessions across all projects with optional filters and pagination."""
+    clauses: list[str] = []
+    params: list = []
+
+    if project_id is not None:
+        clauses.append("project_id = ?")
+        params.append(project_id)
+    if status is not None:
+        clauses.append("status = ?")
+        params.append(status)
+    if since is not None:
+        clauses.append("started_at >= ?")
+        params.append(since)
+    if until is not None:
+        clauses.append("started_at <= ?")
+        params.append(until)
+
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+
+    total = conn.execute(
+        f"SELECT count(*) FROM sessions{where}", params
+    ).fetchone()[0]
+
+    offset = (page - 1) * per_page
+    rows = conn.execute(
+        f"SELECT run_id, project_id, role, runtime, isolation, status,"
+        f"       started_at, ended_at, duration_ms, exit_code, task, summary"
+        f"  FROM sessions{where} ORDER BY started_at DESC"
+        f"  LIMIT ? OFFSET ?",
+        [*params, per_page, offset],
+    ).fetchall()
+
+    return {
+        "items": [dict(row) for row in rows],
+        "total": total,
+        "page": page,
+        "per_page": per_page,
+    }
 
 
 @router.get("/projects/{project_id}/sessions")

--- a/gui/tests/test_sessions_list_all.py
+++ b/gui/tests/test_sessions_list_all.py
@@ -1,0 +1,184 @@
+"""Tests for GET /api/sessions (global session list with pagination/filters)."""
+
+import os
+
+from strawpot_gui.db import sync_sessions
+
+from test_sessions_sync import _register_project, _write_session, _write_trace
+
+
+def _setup_sessions(client, tmp_path):
+    """Create two projects with sessions and return their IDs."""
+    p1 = tmp_path / "proj1"
+    p1.mkdir()
+    p2 = tmp_path / "proj2"
+    p2.mkdir()
+    pid1 = _register_project(client, p1)
+    pid2 = _register_project(client, p2)
+
+    # Project 1: two archived sessions
+    sd1 = _write_session(
+        p1, "run_a", archived=True,
+        started_at="2026-01-01T10:00:00+00:00",
+    )
+    _write_trace(sd1, [
+        {
+            "ts": "2026-01-01T10:05:00+00:00",
+            "event": "delegate_end",
+            "trace_id": "run_a", "span_id": "s1", "parent_span": None,
+            "data": {"exit_code": 0, "summary": "Done A", "duration_ms": 300000},
+        },
+        {
+            "ts": "2026-01-01T10:05:01+00:00",
+            "event": "session_end",
+            "trace_id": "run_a", "span_id": "s0",
+            "data": {"duration_ms": 300100},
+        },
+    ])
+
+    sd2 = _write_session(
+        p1, "run_b", archived=True,
+        started_at="2026-01-02T10:00:00+00:00",
+    )
+    _write_trace(sd2, [
+        {
+            "ts": "2026-01-02T10:01:00+00:00",
+            "event": "delegate_end",
+            "trace_id": "run_b", "span_id": "s1", "parent_span": None,
+            "data": {"exit_code": 1, "summary": "Failed B", "duration_ms": 60000},
+        },
+    ])
+
+    # Project 2: one archived session
+    _write_session(
+        p2, "run_c", archived=True,
+        started_at="2026-01-03T10:00:00+00:00",
+    )
+
+    sync_sessions(client.app.state.db_path)
+    return pid1, pid2
+
+
+class TestListAllSessions:
+    def test_returns_all_sessions(self, client, tmp_path):
+        """Without filters, returns all sessions."""
+        _setup_sessions(client, tmp_path)
+
+        resp = client.get("/api/sessions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 3
+        assert len(data["items"]) == 3
+        assert data["page"] == 1
+        assert data["per_page"] == 20
+
+    def test_ordered_by_most_recent(self, client, tmp_path):
+        """Sessions are ordered by started_at descending."""
+        _setup_sessions(client, tmp_path)
+
+        items = client.get("/api/sessions").json()["items"]
+        assert items[0]["run_id"] == "run_c"
+        assert items[1]["run_id"] == "run_b"
+        assert items[2]["run_id"] == "run_a"
+
+    def test_filter_by_project_id(self, client, tmp_path):
+        """Filter sessions by project_id."""
+        pid1, pid2 = _setup_sessions(client, tmp_path)
+
+        resp = client.get(f"/api/sessions?project_id={pid1}")
+        data = resp.json()
+        assert data["total"] == 2
+        assert all(s["project_id"] == pid1 for s in data["items"])
+
+        resp = client.get(f"/api/sessions?project_id={pid2}")
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["items"][0]["run_id"] == "run_c"
+
+    def test_filter_by_status(self, client, tmp_path):
+        """Filter sessions by status."""
+        _setup_sessions(client, tmp_path)
+
+        resp = client.get("/api/sessions?status=completed")
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["items"][0]["run_id"] == "run_a"
+
+        resp = client.get("/api/sessions?status=failed")
+        data = resp.json()
+        assert data["total"] == 2  # run_b (exit_code 1) + run_c (no trace)
+
+    def test_filter_by_since(self, client, tmp_path):
+        """Filter sessions started on or after a date."""
+        _setup_sessions(client, tmp_path)
+
+        resp = client.get("/api/sessions?since=2026-01-02T00:00:00+00:00")
+        data = resp.json()
+        assert data["total"] == 2
+        run_ids = {s["run_id"] for s in data["items"]}
+        assert run_ids == {"run_b", "run_c"}
+
+    def test_filter_by_until(self, client, tmp_path):
+        """Filter sessions started on or before a date."""
+        _setup_sessions(client, tmp_path)
+
+        resp = client.get("/api/sessions?until=2026-01-01T23:59:59+00:00")
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["items"][0]["run_id"] == "run_a"
+
+    def test_filter_combined(self, client, tmp_path):
+        """Multiple filters are ANDed together."""
+        pid1, _ = _setup_sessions(client, tmp_path)
+
+        resp = client.get(
+            f"/api/sessions?project_id={pid1}&status=completed"
+        )
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["items"][0]["run_id"] == "run_a"
+
+    def test_pagination_page_size(self, client, tmp_path):
+        """per_page limits results per page."""
+        _setup_sessions(client, tmp_path)
+
+        resp = client.get("/api/sessions?per_page=2")
+        data = resp.json()
+        assert data["total"] == 3
+        assert len(data["items"]) == 2
+        assert data["page"] == 1
+
+    def test_pagination_page_2(self, client, tmp_path):
+        """Second page returns remaining items."""
+        _setup_sessions(client, tmp_path)
+
+        resp = client.get("/api/sessions?per_page=2&page=2")
+        data = resp.json()
+        assert data["total"] == 3
+        assert len(data["items"]) == 1
+        assert data["page"] == 2
+
+    def test_pagination_beyond_last_page(self, client, tmp_path):
+        """Page beyond total returns empty items."""
+        _setup_sessions(client, tmp_path)
+
+        resp = client.get("/api/sessions?page=99")
+        data = resp.json()
+        assert data["total"] == 3
+        assert data["items"] == []
+        assert data["page"] == 99
+
+    def test_no_sessions(self, client):
+        """Empty database returns zero total."""
+        resp = client.get("/api/sessions")
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["items"] == []
+
+    def test_session_dir_not_exposed(self, client, tmp_path):
+        """session_dir field is not included in response items."""
+        _setup_sessions(client, tmp_path)
+
+        items = client.get("/api/sessions").json()["items"]
+        for item in items:
+            assert "session_dir" not in item


### PR DESCRIPTION
## Summary
- Add `GET /api/sessions` endpoint for listing sessions across all projects
- Optional filters: `project_id`, `status`, `since`, `until` (ANDed together)
- Pagination via `page` (default 1) and `per_page` (default 20, max 100)
- Returns `{items, total, page, per_page}` response shape

## Test plan
- [x] Returns all sessions without filters
- [x] Ordered by `started_at` descending
- [x] Filter by `project_id`, `status`, `since`, `until`
- [x] Combined filters (AND logic)
- [x] Pagination: page size, page 2, beyond last page
- [x] Empty database returns zero total
- [x] `session_dir` not exposed in response
- [x] Full suite: 79/79 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)