### PR TITLE
Implement dashboard with live data and fix SQLite threading

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -1,0 +1,29 @@
+export interface Project {
+  id: number;
+  display_name: string;
+  working_dir: string;
+  created_at: string;
+  dir_exists: boolean;
+}
+
+export interface Session {
+  run_id: string;
+  project_id: number;
+  role: string;
+  runtime: string;
+  isolation: string;
+  status: string;
+  started_at: string;
+  ended_at: string | null;
+  duration_ms: number | null;
+  exit_code: number | null;
+  task: string | null;
+  summary: string | null;
+}
+
+export interface SessionList {
+  items: Session[];
+  total: number;
+  page: number;
+  per_page: number;
+}

--- a/gui/frontend/src/hooks/useApi.ts
+++ b/gui/frontend/src/hooks/useApi.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { api } from "../api/client";
+
+interface UseApiResult<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useApi<T>(path: string): UseApiResult<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    api
+      .get<T>(path)
+      .then((result) => {
+        if (!cancelled) setData(result);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message ?? "Unknown error");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [path]);
+
+  return { data, loading, error };
+}

--- a/gui/frontend/src/index.css
+++ b/gui/frontend/src/index.css
@@ -62,3 +62,138 @@
   flex: 1;
   padding: 2rem;
 }
+
+/* Dashboard */
+
+.dashboard h1 {
+  margin-bottom: 1.5rem;
+}
+
+.dashboard-section {
+  margin-bottom: 2rem;
+}
+
+.dashboard-section h2 {
+  font-size: 1.1rem;
+  margin-bottom: 0.75rem;
+  color: #555;
+}
+
+.empty {
+  color: #888;
+  font-style: italic;
+}
+
+.error {
+  color: #c0392b;
+}
+
+/* Cards */
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
+}
+
+.card {
+  display: block;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 1rem;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s;
+}
+
+.card:hover {
+  border-color: #999;
+}
+
+.card-title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.card-meta {
+  font-size: 0.85rem;
+  color: #888;
+  word-break: break-all;
+}
+
+/* Badges */
+
+.badge {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 10px;
+  margin-top: 0.5rem;
+  margin-right: 0.25rem;
+}
+
+.badge-running {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.badge-success {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.badge-error {
+  background: #fbe9e7;
+  color: #c62828;
+}
+
+.badge-warning {
+  background: #fff3e0;
+  color: #e65100;
+}
+
+.badge-default {
+  background: #f5f5f5;
+  color: #616161;
+}
+
+/* Tables */
+
+.session-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.session-table th,
+.session-table td {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #eee;
+}
+
+.session-table th {
+  font-weight: 600;
+  color: #666;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.session-table a {
+  color: #1565c0;
+  text-decoration: none;
+}
+
+.session-table a:hover {
+  text-decoration: underline;
+}
+
+.cell-task {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/gui/frontend/src/pages/Dashboard.tsx
+++ b/gui/frontend/src/pages/Dashboard.tsx
@@ -1,8 +1,145 @@
+import { Link } from "react-router-dom";
+import { useApi } from "../hooks/useApi";
+import type { Project, Session, SessionList } from "../api/types";
+
 export default function Dashboard() {
+  const projects = useApi<Project[]>("/projects");
+  const running = useApi<SessionList>("/sessions?status=running&per_page=50");
+  const recent = useApi<SessionList>(
+    "/sessions?per_page=10",
+  );
+
+  const loading = projects.loading || running.loading || recent.loading;
+  const error = projects.error || running.error || recent.error;
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p className="error">Error: {error}</p>;
+
+  const projectList = projects.data ?? [];
+  const runningSessions = running.data?.items ?? [];
+  const recentSessions = recent.data?.items ?? [];
+
+  // Count running sessions per project
+  const runningByProject = new Map<number, number>();
+  for (const s of runningSessions) {
+    runningByProject.set(s.project_id, (runningByProject.get(s.project_id) ?? 0) + 1);
+  }
+
   return (
-    <div>
+    <div className="dashboard">
       <h1>Dashboard</h1>
-      <p>Active projects, running sessions, and recent activity will appear here.</p>
+
+      <section className="dashboard-section">
+        <h2>Projects ({projectList.length})</h2>
+        {projectList.length === 0 ? (
+          <p className="empty">No projects registered.</p>
+        ) : (
+          <div className="card-grid">
+            {projectList.map((p) => (
+              <Link
+                key={p.id}
+                to={`/projects/${p.id}`}
+                className="card"
+              >
+                <div className="card-title">{p.display_name}</div>
+                <div className="card-meta">{p.working_dir}</div>
+                {!p.dir_exists && (
+                  <span className="badge badge-warning">Directory missing</span>
+                )}
+                {(runningByProject.get(p.id) ?? 0) > 0 && (
+                  <span className="badge badge-running">
+                    {runningByProject.get(p.id)} running
+                  </span>
+                )}
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {runningSessions.length > 0 && (
+        <section className="dashboard-section">
+          <h2>Running Sessions ({runningSessions.length})</h2>
+          <SessionTable sessions={runningSessions} />
+        </section>
+      )}
+
+      <section className="dashboard-section">
+        <h2>Recent Sessions</h2>
+        {recentSessions.length === 0 ? (
+          <p className="empty">No sessions yet.</p>
+        ) : (
+          <SessionTable sessions={recentSessions} />
+        )}
+      </section>
     </div>
   );
+}
+
+function SessionTable({ sessions }: { sessions: Session[] }) {
+  return (
+    <table className="session-table">
+      <thead>
+        <tr>
+          <th>Run ID</th>
+          <th>Role</th>
+          <th>Status</th>
+          <th>Started</th>
+          <th>Duration</th>
+          <th>Task</th>
+        </tr>
+      </thead>
+      <tbody>
+        {sessions.map((s) => (
+          <tr key={s.run_id}>
+            <td>
+              <Link to={`/projects/${s.project_id}/sessions/${s.run_id}`}>
+                {s.run_id.slice(0, 16)}
+              </Link>
+            </td>
+            <td>{s.role}</td>
+            <td>
+              <span className={`badge badge-${statusColor(s.status)}`}>
+                {s.status}
+              </span>
+            </td>
+            <td>{formatTime(s.started_at)}</td>
+            <td>{formatDuration(s.duration_ms)}</td>
+            <td className="cell-task">{s.task ?? "—"}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function statusColor(status: string): string {
+  switch (status) {
+    case "running":
+    case "starting":
+      return "running";
+    case "completed":
+      return "success";
+    case "failed":
+      return "error";
+    default:
+      return "default";
+  }
+}
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms == null) return "—";
+  const secs = Math.round(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const rem = secs % 60;
+  return `${mins}m ${rem}s`;
 }

--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -54,7 +54,7 @@ CREATE TABLE IF NOT EXISTS trigger_instances (
 
 def _connect(db_path: str) -> sqlite3.Connection:
     """Open a connection with recommended settings."""
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path, check_same_thread=False)
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA foreign_keys=ON")
     conn.row_factory = sqlite3.Row


### PR DESCRIPTION
## Summary
- Dashboard fetches real data: project cards with running session badges, running sessions section, recent sessions table
- New `api/types.ts` with TypeScript interfaces for `Project`, `Session`, `SessionList`
- New `useApi` hook for data fetching with loading/error states
- Styles for cards, badges, session tables
- Fix `sqlite3.ProgrammingError` by adding `check_same_thread=False` — safe since each request gets its own connection via `get_db` context manager with WAL mode

## Test plan
- [x] `npm run build` compiles cleanly
- [x] 79/79 Python tests pass
- [x] Dashboard renders with project cards and session tables when served by FastAPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)