### PR TITLE
Implement project detail page and extract SessionTable (Phase 3.4)

### DIFF
--- a/gui/frontend/src/components/SessionTable.tsx
+++ b/gui/frontend/src/components/SessionTable.tsx
@@ -1,0 +1,70 @@
+import { Link } from "react-router-dom";
+import type { Session } from "../api/types";
+
+export default function SessionTable({ sessions }: { sessions: Session[] }) {
+  return (
+    <table className="session-table">
+      <thead>
+        <tr>
+          <th>Run ID</th>
+          <th>Role</th>
+          <th>Status</th>
+          <th>Started</th>
+          <th>Duration</th>
+          <th>Task</th>
+        </tr>
+      </thead>
+      <tbody>
+        {sessions.map((s) => (
+          <tr key={s.run_id}>
+            <td>
+              <Link to={`/projects/${s.project_id}/sessions/${s.run_id}`}>
+                {s.run_id.slice(0, 16)}
+              </Link>
+            </td>
+            <td>{s.role}</td>
+            <td>
+              <span className={`badge badge-${statusColor(s.status)}`}>
+                {s.status}
+              </span>
+            </td>
+            <td>{formatTime(s.started_at)}</td>
+            <td>{formatDuration(s.duration_ms)}</td>
+            <td className="cell-task">{s.task ?? "—"}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export function statusColor(status: string): string {
+  switch (status) {
+    case "running":
+    case "starting":
+      return "running";
+    case "completed":
+      return "success";
+    case "failed":
+      return "error";
+    default:
+      return "default";
+  }
+}
+
+export function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+export function formatDuration(ms: number | null): string {
+  if (ms == null) return "—";
+  const secs = Math.round(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const rem = secs % 60;
+  return `${mins}m ${rem}s`;
+}

--- a/gui/frontend/src/index.css
+++ b/gui/frontend/src/index.css
@@ -413,3 +413,32 @@
 .dir-entry:hover {
   background: #e3f2fd;
 }
+
+/* Project info */
+
+.project-info {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.project-info-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+}
+
+.project-info-label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #666;
+  min-width: 80px;
+}
+
+.project-info-value {
+  font-size: 0.9rem;
+  word-break: break-all;
+}

--- a/gui/frontend/src/pages/Dashboard.tsx
+++ b/gui/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
+import SessionTable from "../components/SessionTable";
 import { useApi } from "../hooks/useApi";
-import type { Project, Session, SessionList } from "../api/types";
+import type { Project, SessionList } from "../api/types";
 
 export default function Dashboard() {
   const projects = useApi<Project[]>("/projects");
@@ -74,72 +75,4 @@ export default function Dashboard() {
       </section>
     </div>
   );
-}
-
-function SessionTable({ sessions }: { sessions: Session[] }) {
-  return (
-    <table className="session-table">
-      <thead>
-        <tr>
-          <th>Run ID</th>
-          <th>Role</th>
-          <th>Status</th>
-          <th>Started</th>
-          <th>Duration</th>
-          <th>Task</th>
-        </tr>
-      </thead>
-      <tbody>
-        {sessions.map((s) => (
-          <tr key={s.run_id}>
-            <td>
-              <Link to={`/projects/${s.project_id}/sessions/${s.run_id}`}>
-                {s.run_id.slice(0, 16)}
-              </Link>
-            </td>
-            <td>{s.role}</td>
-            <td>
-              <span className={`badge badge-${statusColor(s.status)}`}>
-                {s.status}
-              </span>
-            </td>
-            <td>{formatTime(s.started_at)}</td>
-            <td>{formatDuration(s.duration_ms)}</td>
-            <td className="cell-task">{s.task ?? "—"}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
-}
-
-function statusColor(status: string): string {
-  switch (status) {
-    case "running":
-    case "starting":
-      return "running";
-    case "completed":
-      return "success";
-    case "failed":
-      return "error";
-    default:
-      return "default";
-  }
-}
-
-function formatTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString();
-  } catch {
-    return iso;
-  }
-}
-
-function formatDuration(ms: number | null): string {
-  if (ms == null) return "—";
-  const secs = Math.round(ms / 1000);
-  if (secs < 60) return `${secs}s`;
-  const mins = Math.floor(secs / 60);
-  const rem = secs % 60;
-  return `${mins}m ${rem}s`;
 }

--- a/gui/frontend/src/pages/ProjectDetail.tsx
+++ b/gui/frontend/src/pages/ProjectDetail.tsx
@@ -1,12 +1,59 @@
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
+import SessionTable from "../components/SessionTable";
+import { useApi } from "../hooks/useApi";
+import type { Project, Session } from "../api/types";
 
 export default function ProjectDetail() {
   const { projectId } = useParams();
+  const { data: project, loading: pLoading, error: pError } =
+    useApi<Project>(`/projects/${projectId}`);
+  const { data: sessions, loading: sLoading, error: sError } =
+    useApi<Session[]>(`/projects/${projectId}/sessions`);
+
+  const loading = pLoading || sLoading;
+  const error = pError || sError;
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p className="error">Error: {error}</p>;
+  if (!project) return <p className="error">Project not found</p>;
+
+  const sessionList = sessions ?? [];
 
   return (
     <div>
-      <h1>Project {projectId}</h1>
-      <p>Sessions, Config, Files, and Registry tabs will appear here.</p>
+      <div className="page-header">
+        <h1>{project.display_name}</h1>
+        <Link to="/projects" className="btn">
+          Back to Projects
+        </Link>
+      </div>
+
+      <div className="project-info">
+        <div className="project-info-row">
+          <span className="project-info-label">Directory</span>
+          <span className="project-info-value">{project.working_dir}</span>
+          {project.dir_exists ? (
+            <span className="badge badge-success">OK</span>
+          ) : (
+            <span className="badge badge-warning">Missing</span>
+          )}
+        </div>
+        <div className="project-info-row">
+          <span className="project-info-label">Created</span>
+          <span className="project-info-value">
+            {new Date(project.created_at).toLocaleString()}
+          </span>
+        </div>
+      </div>
+
+      <section className="dashboard-section">
+        <h2>Sessions ({sessionList.length})</h2>
+        {sessionList.length === 0 ? (
+          <p className="empty">No sessions yet.</p>
+        ) : (
+          <SessionTable sessions={sessionList} />
+        )}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Extract `SessionTable` and helpers (`statusColor`, `formatTime`, `formatDuration`) from Dashboard into shared `components/SessionTable.tsx`
- Replace `ProjectDetail` placeholder with project info card (name, directory, status, created date) and session list
- Add `.project-info` CSS styles

## Test plan
- [ ] `npm run build` passes
- [ ] All 79 Python tests pass
- [ ] Navigate to `/projects/:id` — shows project info and session table
- [ ] Dashboard still renders correctly with shared SessionTable
- [ ] "Back to Projects" link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)