### PR TITLE
Implement session detail page with agents and trace timeline (Phase 3.5)

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -27,3 +27,25 @@ export interface SessionList {
   page: number;
   per_page: number;
 }
+
+export interface AgentInfo {
+  role: string;
+  runtime: string;
+  parent: string | null;
+  started_at: string;
+  pid: number | null;
+}
+
+export interface TraceEvent {
+  ts: string;
+  event: string;
+  trace_id: string;
+  span_id: string;
+  parent_span: string | null;
+  data: Record<string, unknown>;
+}
+
+export interface SessionDetail extends Session {
+  agents: Record<string, AgentInfo>;
+  events: TraceEvent[];
+}

--- a/gui/frontend/src/index.css
+++ b/gui/frontend/src/index.css
@@ -442,3 +442,53 @@
   font-size: 0.9rem;
   word-break: break-all;
 }
+
+/* Detail grid (reuses project-info-row styles) */
+
+.detail-grid {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.detail-block {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 1rem;
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Agent tree */
+
+.agent-tree {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+}
+
+.agent-node {
+  padding: 0.25rem 0;
+}
+
+.agent-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.agent-role {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.agent-meta {
+  font-size: 0.78rem;
+  color: #888;
+  font-family: monospace;
+}

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -1,13 +1,170 @@
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
+import { statusColor, formatTime, formatDuration } from "../components/SessionTable";
+import { useApi } from "../hooks/useApi";
+import type { AgentInfo, SessionDetail as SessionDetailType, TraceEvent } from "../api/types";
 
 export default function SessionDetail() {
   const { projectId, runId } = useParams();
+  const { data: session, loading, error } = useApi<SessionDetailType>(
+    `/projects/${projectId}/sessions/${runId}`,
+  );
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p className="error">Error: {error}</p>;
+  if (!session) return <p className="error">Session not found</p>;
 
   return (
     <div>
-      <h1>Session {runId}</h1>
-      <p>Project: {projectId}</p>
-      <p>Agent tree, logs, trace timeline, and artifacts will appear here.</p>
+      <div className="page-header">
+        <h1>Session {session.run_id.slice(0, 16)}</h1>
+        <Link to={`/projects/${projectId}`} className="btn">
+          Back to Project
+        </Link>
+      </div>
+
+      <div className="detail-grid">
+        <DetailRow label="Status">
+          <span className={`badge badge-${statusColor(session.status)}`}>
+            {session.status}
+          </span>
+        </DetailRow>
+        <DetailRow label="Role">{session.role}</DetailRow>
+        <DetailRow label="Runtime">{session.runtime}</DetailRow>
+        <DetailRow label="Isolation">{session.isolation}</DetailRow>
+        <DetailRow label="Started">{formatTime(session.started_at)}</DetailRow>
+        {session.ended_at && (
+          <DetailRow label="Ended">{formatTime(session.ended_at)}</DetailRow>
+        )}
+        <DetailRow label="Duration">{formatDuration(session.duration_ms)}</DetailRow>
+        {session.exit_code !== null && (
+          <DetailRow label="Exit Code">{session.exit_code}</DetailRow>
+        )}
+      </div>
+
+      {session.task && (
+        <section className="dashboard-section">
+          <h2>Task</h2>
+          <div className="detail-block">{session.task}</div>
+        </section>
+      )}
+
+      {session.summary && (
+        <section className="dashboard-section">
+          <h2>Summary</h2>
+          <div className="detail-block">{session.summary}</div>
+        </section>
+      )}
+
+      {Object.keys(session.agents).length > 0 && (
+        <section className="dashboard-section">
+          <h2>Agents ({Object.keys(session.agents).length})</h2>
+          <AgentTree agents={session.agents} />
+        </section>
+      )}
+
+      {session.events.length > 0 && (
+        <section className="dashboard-section">
+          <h2>Trace Events ({session.events.length})</h2>
+          <EventTimeline events={session.events} />
+        </section>
+      )}
     </div>
   );
+}
+
+function DetailRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="project-info-row">
+      <span className="project-info-label">{label}</span>
+      <span className="project-info-value">{children}</span>
+    </div>
+  );
+}
+
+function AgentTree({ agents }: { agents: Record<string, AgentInfo> }) {
+  // Find root agents (no parent), then render children recursively
+  const entries = Object.entries(agents);
+  const roots = entries.filter(([, a]) => !a.parent);
+
+  const renderAgent = (id: string, agent: AgentInfo, depth: number) => {
+    const children = entries.filter(([, a]) => a.parent === id);
+    return (
+      <div key={id} className="agent-node" style={{ marginLeft: depth * 20 }}>
+        <div className="agent-header">
+          <span className="agent-role">{agent.role}</span>
+          <span className="agent-meta">{agent.runtime}</span>
+          {agent.pid && <span className="agent-meta">PID {agent.pid}</span>}
+        </div>
+        {children.map(([cId, cAgent]) => renderAgent(cId, cAgent, depth + 1))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="agent-tree">
+      {roots.map(([id, agent]) => renderAgent(id, agent, 0))}
+    </div>
+  );
+}
+
+function EventTimeline({ events }: { events: TraceEvent[] }) {
+  return (
+    <table className="session-table">
+      <thead>
+        <tr>
+          <th>Time</th>
+          <th>Event</th>
+          <th>Span</th>
+          <th>Details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {events.map((e, i) => (
+          <tr key={i}>
+            <td>{formatTime(e.ts)}</td>
+            <td>
+              <span className={`badge badge-${eventColor(e.event)}`}>
+                {e.event}
+              </span>
+            </td>
+            <td className="agent-meta">{e.span_id.slice(0, 8)}</td>
+            <td className="cell-task">{formatEventData(e)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function eventColor(event: string): string {
+  if (event.endsWith("_start") || event === "agent_spawn") return "running";
+  if (event.endsWith("_end")) return "success";
+  if (event.includes("denied") || event.includes("error")) return "error";
+  return "default";
+}
+
+function formatEventData(e: TraceEvent): string {
+  const parts: string[] = [];
+  const d = e.data;
+  if (d.role) parts.push(`role=${d.role}`);
+  if (d.runtime) parts.push(`runtime=${d.runtime}`);
+  if (d.exit_code !== undefined) parts.push(`exit=${d.exit_code}`);
+  if (d.duration_ms !== undefined) parts.push(`${formatDuration(d.duration_ms as number)}`);
+  if (d.summary) parts.push(String(d.summary).slice(0, 80));
+  if (d.reason) parts.push(String(d.reason));
+  if (d.card_count !== undefined) parts.push(`${d.card_count} cards`);
+  if (d.entry_count !== undefined) parts.push(`${d.entry_count} entries`);
+  if (parts.length === 0 && Object.keys(d).length > 0) {
+    return Object.entries(d)
+      .filter(([k]) => !k.endsWith("_ref"))
+      .map(([k, v]) => `${k}=${v}`)
+      .join(", ");
+  }
+  return parts.join(", ");
 }


### PR DESCRIPTION
## Summary
- Add `AgentInfo`, `TraceEvent`, `SessionDetail` TypeScript interfaces
- Replace `SessionDetail` placeholder with full implementation: metadata grid (status, role, runtime, isolation, timing), task/summary blocks, hierarchical agent tree, and trace event timeline
- Add CSS for detail grid, detail block, and agent tree components

## Test plan
- [ ] `npm run build` passes
- [ ] All 79 Python tests pass
- [ ] Navigate to `/projects/:id/sessions/:runId` — shows session metadata, agents, and events
- [ ] "Back to Project" link works
- [ ] Status badges render correct colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)