### PR TITLE
Add launch session dialog with config-aware dropdowns (Phase 3.6)

### DIFF
--- a/gui/frontend/src/index.css
+++ b/gui/frontend/src/index.css
@@ -211,6 +211,11 @@
   margin: 0;
 }
 
+.page-header-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 /* Buttons */
 
 .btn {
@@ -297,17 +302,37 @@
   flex: 1;
 }
 
-.form-row input {
+.form-row input,
+.form-row select {
   padding: 0.4rem 0.6rem;
   border: 1px solid #ccc;
   border-radius: 4px;
   font-size: 0.9rem;
 }
 
-.form-row input:focus {
+.form-row select {
+  background: #fff;
+}
+
+.form-row input:focus,
+.form-row textarea:focus,
+.form-row select:focus {
   outline: none;
   border-color: #1565c0;
   box-shadow: 0 0 0 2px rgba(21, 101, 192, 0.15);
+}
+
+.form-row textarea {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.required {
+  color: #c62828;
 }
 
 .form-actions {

--- a/gui/frontend/src/pages/ProjectDetail.tsx
+++ b/gui/frontend/src/pages/ProjectDetail.tsx
@@ -1,4 +1,6 @@
-import { Link, useParams } from "react-router-dom";
+import { useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { api } from "../api/client";
 import SessionTable from "../components/SessionTable";
 import { useApi } from "../hooks/useApi";
 import type { Project, Session } from "../api/types";
@@ -7,8 +9,13 @@ export default function ProjectDetail() {
   const { projectId } = useParams();
   const { data: project, loading: pLoading, error: pError } =
     useApi<Project>(`/projects/${projectId}`);
-  const { data: sessions, loading: sLoading, error: sError } =
-    useApi<Session[]>(`/projects/${projectId}/sessions`);
+  const {
+    data: sessions,
+    loading: sLoading,
+    error: sError,
+    refetch,
+  } = useApi<Session[]>(`/projects/${projectId}/sessions`);
+  const [showLaunch, setShowLaunch] = useState(false);
 
   const loading = pLoading || sLoading;
   const error = pError || sError;
@@ -23,9 +30,18 @@ export default function ProjectDetail() {
     <div>
       <div className="page-header">
         <h1>{project.display_name}</h1>
-        <Link to="/projects" className="btn">
-          Back to Projects
-        </Link>
+        <div className="page-header-actions">
+          <button
+            className="btn btn-primary"
+            onClick={() => setShowLaunch(true)}
+            disabled={!project.dir_exists}
+          >
+            Launch Session
+          </button>
+          <Link to="/projects" className="btn">
+            Back to Projects
+          </Link>
+        </div>
       </div>
 
       <div className="project-info">
@@ -46,6 +62,17 @@ export default function ProjectDetail() {
         </div>
       </div>
 
+      {showLaunch && (
+        <LaunchForm
+          projectId={Number(projectId)}
+          onLaunched={() => {
+            setShowLaunch(false);
+            refetch();
+          }}
+          onCancel={() => setShowLaunch(false)}
+        />
+      )}
+
       <section className="dashboard-section">
         <h2>Sessions ({sessionList.length})</h2>
         {sessionList.length === 0 ? (
@@ -55,5 +82,182 @@ export default function ProjectDetail() {
         )}
       </section>
     </div>
+  );
+}
+
+interface ProjectConfig {
+  merged: {
+    orchestrator_role: string;
+    runtime: string;
+    isolation: string;
+    merge_strategy: string;
+    [key: string]: unknown;
+  };
+}
+
+function LaunchForm({
+  projectId,
+  onLaunched,
+  onCancel,
+}: {
+  projectId: number;
+  onLaunched: () => void;
+  onCancel: () => void;
+}) {
+  const navigate = useNavigate();
+  const { data: config } = useApi<ProjectConfig>(
+    `/projects/${projectId}/config`,
+  );
+  const { data: installedRoles } = useApi<string[]>("/roles");
+  const defaults = config?.merged;
+
+  const [task, setTask] = useState("");
+  const [role, setRole] = useState("");
+  const [showOverrides, setShowOverrides] = useState(false);
+  const [runtime, setRuntime] = useState("");
+  const [isolation, setIsolation] = useState("");
+  const [mergeStrategy, setMergeStrategy] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const body: Record<string, unknown> = {
+        project_id: projectId,
+        task: task.trim(),
+      };
+      if (role.trim()) body.role = role.trim();
+
+      const overrides: Record<string, string> = {};
+      if (runtime.trim()) overrides.runtime = runtime.trim();
+      if (isolation.trim()) overrides.isolation = isolation.trim();
+      if (mergeStrategy.trim()) overrides.merge_strategy = mergeStrategy.trim();
+      if (Object.keys(overrides).length > 0) body.overrides = overrides;
+
+      const result = await api.post<{ run_id: string }>("/sessions", body);
+      onLaunched();
+      navigate(`/projects/${projectId}/sessions/${result.run_id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to launch");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="inline-form" onSubmit={handleSubmit}>
+      <h3 style={{ marginBottom: "0.75rem" }}>Launch Session</h3>
+      <div className="form-row">
+        <label>
+          Task <span className="required">*</span>
+          <textarea
+            value={task}
+            onChange={(e) => setTask(e.target.value)}
+            placeholder="Describe what the agent should do..."
+            required
+            autoFocus
+            rows={3}
+          />
+        </label>
+      </div>
+      <div className="form-row">
+        <label>
+          Role
+          <select
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+          >
+            <option value="">
+              {defaults?.orchestrator_role ?? "orchestrator"}
+            </option>
+            {(installedRoles ?? [])
+              .filter((v) => v !== (defaults?.orchestrator_role ?? "orchestrator"))
+              .map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+          </select>
+        </label>
+      </div>
+      <div style={{ marginBottom: "0.75rem" }}>
+        <button
+          className="btn btn-sm"
+          type="button"
+          onClick={() => setShowOverrides(!showOverrides)}
+        >
+          {showOverrides ? "Hide" : "Show"} Advanced Options
+        </button>
+      </div>
+      {showOverrides && (
+        <div className="form-row">
+          <label>
+            Runtime
+            <select
+              value={runtime}
+              onChange={(e) => setRuntime(e.target.value)}
+            >
+              <option value="">
+                {defaults?.runtime ?? "claude_code"}
+              </option>
+              {["claude_code"]
+                .filter((v) => v !== (defaults?.runtime ?? "claude_code"))
+                .map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+            </select>
+          </label>
+          <label>
+            Isolation
+            <select
+              value={isolation}
+              onChange={(e) => setIsolation(e.target.value)}
+            >
+              <option value="">
+                {defaults?.isolation ?? "none"}
+              </option>
+              {defaults?.isolation !== "none" && (
+                <option value="none">none</option>
+              )}
+              {defaults?.isolation !== "worktree" && (
+                <option value="worktree">worktree</option>
+              )}
+            </select>
+          </label>
+          <label>
+            Merge Strategy
+            <select
+              value={mergeStrategy}
+              onChange={(e) => setMergeStrategy(e.target.value)}
+            >
+              <option value="">
+                {defaults?.merge_strategy ?? "auto"}
+              </option>
+              {["auto", "local", "pr"]
+                .filter((v) => v !== (defaults?.merge_strategy ?? "auto"))
+                .map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+            </select>
+          </label>
+        </div>
+      )}
+      {error && <p className="error">{error}</p>}
+      <div className="form-actions">
+        <button className="btn btn-primary" type="submit" disabled={submitting}>
+          {submitting ? "Launching..." : "Launch"}
+        </button>
+        <button className="btn" type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
   );
 }

--- a/gui/src/strawpot_gui/routers/config.py
+++ b/gui/src/strawpot_gui/routers/config.py
@@ -14,6 +14,28 @@ router = APIRouter(prefix="/api", tags=["config"])
 
 
 # ---------------------------------------------------------------------------
+# Installed roles
+# ---------------------------------------------------------------------------
+
+
+@router.get("/roles")
+def list_roles():
+    """List installed role slugs from ~/.strawpot/roles/."""
+    roles_dir = get_strawpot_home() / "roles"
+    if not roles_dir.is_dir():
+        return []
+    slugs: list[str] = []
+    for entry in sorted(roles_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        # Skip hidden dirs
+        if entry.name.startswith("."):
+            continue
+        slugs.append(entry.name)
+    return slugs
+
+
+# ---------------------------------------------------------------------------
 # Global config
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add "Launch Session" button and inline form to Project Detail page
- Task (required textarea), Role, Runtime, Isolation, and Merge Strategy fields — all as dropdowns
- Dropdowns fetch actual project config defaults via `GET /api/projects/:id/config` and show them as the default option
- Role dropdown populated from new `GET /api/roles` endpoint that lists installed roles from `~/.strawpot/roles/`
- On submit, POSTs to `/sessions` and navigates to the new session detail page
- Advanced options (Runtime, Isolation, Merge Strategy) hidden behind toggle

## Test plan
- [x] `npm run build` passes
- [x] `python -m pytest tests/ -v` — 79 tests pass
- [ ] Verify Launch Session form appears on project detail page
- [ ] Verify dropdowns show config defaults and installed roles
- [ ] Verify session launch creates a new session and navigates to detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)