### PR TITLE
Add stop session button, live status refresh, and project column (Phase 3.7)

### DIFF
--- a/gui/frontend/src/components/SessionTable.tsx
+++ b/gui/frontend/src/components/SessionTable.tsx
@@ -1,12 +1,19 @@
 import { Link } from "react-router-dom";
 import type { Session } from "../api/types";
 
-export default function SessionTable({ sessions }: { sessions: Session[] }) {
+export default function SessionTable({
+  sessions,
+  projectNames,
+}: {
+  sessions: Session[];
+  projectNames?: Map<number, string>;
+}) {
   return (
     <table className="session-table">
       <thead>
         <tr>
           <th>Run ID</th>
+          {projectNames && <th>Project</th>}
           <th>Role</th>
           <th>Status</th>
           <th>Started</th>
@@ -22,6 +29,13 @@ export default function SessionTable({ sessions }: { sessions: Session[] }) {
                 {s.run_id.slice(0, 16)}
               </Link>
             </td>
+            {projectNames && (
+              <td>
+                <Link to={`/projects/${s.project_id}`}>
+                  {projectNames.get(s.project_id) ?? `#${s.project_id}`}
+                </Link>
+              </td>
+            )}
             <td>{s.role}</td>
             <td>
               <span className={`badge badge-${statusColor(s.status)}`}>
@@ -47,6 +61,8 @@ export function statusColor(status: string): string {
       return "success";
     case "failed":
       return "error";
+    case "stopped":
+      return "warning";
     default:
       return "default";
   }

--- a/gui/frontend/src/pages/Dashboard.tsx
+++ b/gui/frontend/src/pages/Dashboard.tsx
@@ -20,6 +20,12 @@ export default function Dashboard() {
   const runningSessions = running.data?.items ?? [];
   const recentSessions = recent.data?.items ?? [];
 
+  // Build project name lookup
+  const projectNames = new Map<number, string>();
+  for (const p of projectList) {
+    projectNames.set(p.id, p.display_name);
+  }
+
   // Count running sessions per project
   const runningByProject = new Map<number, number>();
   for (const s of runningSessions) {
@@ -61,7 +67,7 @@ export default function Dashboard() {
       {runningSessions.length > 0 && (
         <section className="dashboard-section">
           <h2>Running Sessions ({runningSessions.length})</h2>
-          <SessionTable sessions={runningSessions} />
+          <SessionTable sessions={runningSessions} projectNames={projectNames} />
         </section>
       )}
 
@@ -70,7 +76,7 @@ export default function Dashboard() {
         {recentSessions.length === 0 ? (
           <p className="empty">No sessions yet.</p>
         ) : (
-          <SessionTable sessions={recentSessions} />
+          <SessionTable sessions={recentSessions} projectNames={projectNames} />
         )}
       </section>
     </div>

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -1,13 +1,16 @@
+import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { api } from "../api/client";
 import { statusColor, formatTime, formatDuration } from "../components/SessionTable";
 import { useApi } from "../hooks/useApi";
 import type { AgentInfo, SessionDetail as SessionDetailType, TraceEvent } from "../api/types";
 
 export default function SessionDetail() {
   const { projectId, runId } = useParams();
-  const { data: session, loading, error } = useApi<SessionDetailType>(
+  const { data: session, loading, error, refetch } = useApi<SessionDetailType>(
     `/projects/${projectId}/sessions/${runId}`,
   );
+  const [confirming, setConfirming] = useState(false);
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p className="error">Error: {error}</p>;
@@ -17,9 +20,39 @@ export default function SessionDetail() {
     <div>
       <div className="page-header">
         <h1>Session {session.run_id.slice(0, 16)}</h1>
-        <Link to={`/projects/${projectId}`} className="btn">
-          Back to Project
-        </Link>
+        <div className="page-header-actions">
+          {(session.status === "starting" || session.status === "running") &&
+            (confirming ? (
+              <span className="confirm-group">
+                <button
+                  className="btn btn-danger btn-sm"
+                  onClick={async () => {
+                    await api.post(`/sessions/${runId}/stop`);
+                    setConfirming(false);
+                    refetch();
+                  }}
+                >
+                  Confirm
+                </button>
+                <button
+                  className="btn btn-sm"
+                  onClick={() => setConfirming(false)}
+                >
+                  Cancel
+                </button>
+              </span>
+            ) : (
+              <button
+                className="btn btn-danger"
+                onClick={() => setConfirming(true)}
+              >
+                Stop Session
+              </button>
+            ))}
+          <Link to={`/projects/${projectId}`} className="btn">
+            Back to Project
+          </Link>
+        </div>
       </div>
 
       <div className="detail-grid">

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -13,9 +13,76 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, field_validator
 
 from strawpot.config import load_config
-from strawpot_gui.db import get_db_conn
+from strawpot_gui.db import _parse_trace, get_db_conn
 
 router = APIRouter(prefix="/api", tags=["sessions"])
+
+
+def _refresh_session_status(conn, run_id: str) -> None:
+    """Re-check status for a starting/running session from disk.
+
+    Reads session.json for PID liveness and trace.jsonl for completion.
+    Updates the DB row if the status has changed.
+    """
+    row = conn.execute(
+        "SELECT status, session_dir FROM sessions WHERE run_id = ?",
+        (run_id,),
+    ).fetchone()
+    if not row or row["status"] not in ("starting", "running"):
+        return
+
+    session_dir = row["session_dir"]
+    session_json = os.path.join(session_dir, "session.json")
+
+    # Try to read session.json
+    try:
+        with open(session_json, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        # session.json not yet written — still starting
+        return
+
+    # Check trace for completion
+    trace_path = os.path.join(session_dir, "trace.jsonl")
+    trace_info = _parse_trace(trace_path)
+
+    if trace_info.get("exit_code") is not None or "ended_at" in trace_info:
+        # Session has ended
+        exit_code = trace_info.get("exit_code")
+        status = "completed" if exit_code == 0 else "failed"
+        conn.execute(
+            """UPDATE sessions
+               SET status = ?, ended_at = ?, duration_ms = ?,
+                   exit_code = ?, summary = ?
+               WHERE run_id = ?""",
+            (
+                status,
+                trace_info.get("ended_at"),
+                trace_info.get("duration_ms"),
+                exit_code,
+                trace_info.get("summary"),
+                run_id,
+            ),
+        )
+        return
+
+    # Check PID liveness
+    pid = data.get("pid")
+    if pid is not None:
+        try:
+            os.kill(pid, 0)
+            # Process alive — mark running if still starting
+            if row["status"] == "starting":
+                conn.execute(
+                    "UPDATE sessions SET status = 'running' WHERE run_id = ?",
+                    (run_id,),
+                )
+        except (ProcessLookupError, OSError):
+            # Process gone without trace end — mark failed
+            conn.execute(
+                "UPDATE sessions SET status = 'failed' WHERE run_id = ?",
+                (run_id,),
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -133,6 +200,13 @@ def list_all_sessions(
     conn=Depends(get_db_conn),
 ):
     """List sessions across all projects with optional filters and pagination."""
+    # Refresh active sessions before listing
+    active = conn.execute(
+        "SELECT run_id FROM sessions WHERE status IN ('starting', 'running')"
+    ).fetchall()
+    for r in active:
+        _refresh_session_status(conn, r["run_id"])
+
     clauses: list[str] = []
     params: list = []
 
@@ -180,6 +254,14 @@ def list_sessions(project_id: int, conn=Depends(get_db_conn)):
     if not project:
         raise HTTPException(404, "Project not found")
 
+    # Refresh active sessions for this project
+    active = conn.execute(
+        "SELECT run_id FROM sessions WHERE project_id = ? AND status IN ('starting', 'running')",
+        (project_id,),
+    ).fetchall()
+    for r in active:
+        _refresh_session_status(conn, r["run_id"])
+
     rows = conn.execute(
         "SELECT run_id, project_id, role, runtime, isolation, status,"
         "       started_at, ended_at, duration_ms, exit_code, task, summary"
@@ -191,6 +273,9 @@ def list_sessions(project_id: int, conn=Depends(get_db_conn)):
 
 @router.get("/projects/{project_id}/sessions/{run_id}")
 def get_session(project_id: int, run_id: str, conn=Depends(get_db_conn)):
+    # Refresh status for active sessions before returning
+    _refresh_session_status(conn, run_id)
+
     row = conn.execute(
         "SELECT run_id, project_id, role, runtime, isolation, status,"
         "       started_at, ended_at, duration_ms, exit_code, task, summary,"
@@ -255,31 +340,45 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
     try:
         data = json.loads(session_json.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        raise HTTPException(500, "Cannot read session.json")
+        # session.json not created yet — session never fully started
+        conn.execute(
+            "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
+            (run_id,),
+        )
+        return {"run_id": run_id, "status": "stopped"}
 
     pid = data.get("pid")
     if pid is None:
-        raise HTTPException(500, "No PID found in session.json")
+        # No PID recorded — mark as stopped
+        conn.execute(
+            "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
+            (run_id,),
+        )
+        return {"run_id": run_id, "status": "stopped"}
 
     # Check liveness and send SIGTERM
     try:
         os.kill(pid, 0)
     except (ProcessLookupError, OSError):
-        # Process already gone — mark as failed
+        # Process already gone
         conn.execute(
-            "UPDATE sessions SET status = 'failed' WHERE run_id = ?",
+            "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
             (run_id,),
         )
-        return {"run_id": run_id, "status": "failed"}
+        return {"run_id": run_id, "status": "stopped"}
 
     try:
         os.kill(pid, signal.SIGTERM)
     except (ProcessLookupError, OSError):
         # Race: died between check and kill
         conn.execute(
-            "UPDATE sessions SET status = 'failed' WHERE run_id = ?",
+            "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
             (run_id,),
         )
-        return {"run_id": run_id, "status": "failed"}
+        return {"run_id": run_id, "status": "stopped"}
 
-    return {"run_id": run_id, "status": "stopping"}
+    conn.execute(
+        "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
+        (run_id,),
+    )
+    return {"run_id": run_id, "status": "stopped"}

--- a/gui/tests/test_session_stop.py
+++ b/gui/tests/test_session_stop.py
@@ -34,7 +34,7 @@ class TestStopSession:
             resp = client.post("/api/sessions/run_stop/stop")
 
         assert resp.status_code == 200
-        assert resp.json() == {"run_id": "run_stop", "status": "stopping"}
+        assert resp.json() == {"run_id": "run_stop", "status": "stopped"}
         # First call: liveness check (signal 0), second call: SIGTERM
         assert mock_kill.call_count == 2
         mock_kill.assert_any_call(os.getpid(), 0)
@@ -80,7 +80,7 @@ class TestStopSession:
             resp = client.post("/api/sessions/run_start/stop")
 
         assert resp.status_code == 200
-        assert resp.json()["status"] == "stopping"
+        assert resp.json()["status"] == "stopped"
 
     def test_stop_already_dead_marks_failed(self, client, tmp_path):
         """If process is already gone, marks session as failed."""
@@ -95,7 +95,7 @@ class TestStopSession:
             resp = client.post("/api/sessions/run_dead/stop")
 
         assert resp.status_code == 200
-        assert resp.json() == {"run_id": "run_dead", "status": "failed"}
+        assert resp.json() == {"run_id": "run_dead", "status": "stopped"}
 
         # Verify DB was updated
         with get_db(client.app.state.db_path) as conn:
@@ -103,10 +103,10 @@ class TestStopSession:
                 "SELECT status FROM sessions WHERE run_id = ?",
                 ("run_dead",),
             ).fetchone()
-        assert row["status"] == "failed"
+        assert row["status"] == "stopped"
 
-    def test_stop_missing_session_json_returns_500(self, client, tmp_path):
-        """If session.json is missing, returns 500."""
+    def test_stop_missing_session_json_marks_failed(self, client, tmp_path):
+        """If session.json is missing, marks session as failed."""
         project_dir = tmp_path / "proj"
         project_dir.mkdir()
         _, session_dir = _insert_session(
@@ -117,10 +117,11 @@ class TestStopSession:
         os.remove(os.path.join(session_dir, "session.json"))
 
         resp = client.post("/api/sessions/run_nofile/stop")
-        assert resp.status_code == 500
+        assert resp.status_code == 200
+        assert resp.json() == {"run_id": "run_nofile", "status": "stopped"}
 
-    def test_stop_no_pid_in_session_json_returns_500(self, client, tmp_path):
-        """If session.json has no pid field, returns 500."""
+    def test_stop_no_pid_in_session_json_marks_failed(self, client, tmp_path):
+        """If session.json has no pid field, marks session as failed."""
         project_dir = tmp_path / "proj"
         project_dir.mkdir()
         _, session_dir = _insert_session(
@@ -136,4 +137,5 @@ class TestStopSession:
             json.dump(data, f)
 
         resp = client.post("/api/sessions/run_nopid/stop")
-        assert resp.status_code == 500
+        assert resp.status_code == 200
+        assert resp.json() == {"run_id": "run_nopid", "status": "stopped"}


### PR DESCRIPTION
## Summary
- **Stop Session button** on session detail page with inline confirm/cancel, only visible for starting/running sessions
- **Live status refresh**: `_refresh_session_status()` re-checks session.json + trace.jsonl on every list/detail API call, fixing sessions stuck in "starting"
- **"stopped" status**: user-initiated stops now return `stopped` (yellow badge) instead of `failed` (red); gracefully handles missing session.json
- **Project column** in Dashboard session tables (Running + Recent) with clickable links to project detail

## Test plan
- [x] `npm run build` passes
- [x] `python -m pytest tests/ -v` — 79 tests pass
- [ ] Launch a session → verify status transitions from starting → running → completed/failed
- [ ] Stop a running session → verify status shows "stopped" (yellow)
- [ ] Dashboard shows Project column in session tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)