### PR TITLE
Add SSE endpoint for real-time agent tree (Phase 4.1)

### DIFF
--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -11,7 +11,7 @@ from fastapi.staticfiles import StaticFiles
 from strawpot.config import get_strawpot_home
 
 from strawpot_gui.db import init_db, sync_sessions
-from strawpot_gui.routers import config, fs, health, projects, sessions
+from strawpot_gui.routers import config, fs, health, projects, sessions, sse
 
 
 def create_app(db_path: str | None = None) -> FastAPI:
@@ -48,6 +48,7 @@ def create_app(db_path: str | None = None) -> FastAPI:
     app.include_router(projects.router)
     app.include_router(config.router)
     app.include_router(sessions.router)
+    app.include_router(sse.router)
     app.include_router(fs.router)
 
     # Serve built frontend — check installed package path then dev path

--- a/gui/src/strawpot_gui/routers/sse.py
+++ b/gui/src/strawpot_gui/routers/sse.py
@@ -1,0 +1,178 @@
+"""SSE streaming endpoints for real-time session monitoring."""
+
+import asyncio
+import json
+import os
+
+from fastapi import APIRouter, Request
+from fastapi.responses import StreamingResponse
+
+from strawpot_gui.db import get_db
+from strawpot_gui.sse import TreeState, format_sse, sse_retry
+
+router = APIRouter(prefix="/api", tags=["sse"])
+
+_POLL_INTERVAL = 1.5  # seconds
+
+
+def _resolve_session_dir(db_path: str, run_id: str) -> tuple[str | None, str | None]:
+    """Look up session_dir and status from the database."""
+    with get_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT session_dir, status FROM sessions WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+    if not row:
+        return None, None
+    return row["session_dir"], row["status"]
+
+
+def _read_session_json(session_dir: str) -> dict | None:
+    """Read and parse session.json, returning None on failure."""
+    path = os.path.join(session_dir, "session.json")
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _read_trace_lines(trace_path: str, offset: int) -> tuple[list[dict], int]:
+    """Read new lines from trace.jsonl starting at byte offset."""
+    events: list[dict] = []
+    try:
+        with open(trace_path, "r", encoding="utf-8") as f:
+            f.seek(offset)
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+            new_offset = f.tell()
+    except OSError:
+        return [], offset
+    return events, new_offset
+
+
+def _safe_mtime(path: str) -> float:
+    """Return file mtime or 0.0 if the file doesn't exist."""
+    try:
+        return os.stat(path).st_mtime
+    except OSError:
+        return 0.0
+
+
+def _build_full_state(session_dir: str) -> tuple[TreeState, int]:
+    """Build complete TreeState from disk."""
+    state = TreeState()
+
+    session_data = _read_session_json(session_dir)
+    if session_data:
+        state.load_session_json(session_data)
+
+    trace_path = os.path.join(session_dir, "trace.jsonl")
+    events, offset = _read_trace_lines(trace_path, 0)
+    for event in events:
+        state.process_event(event)
+
+    return state, offset
+
+
+@router.get("/sessions/{run_id}/tree")
+async def session_tree_sse(run_id: str, request: Request):
+    """SSE endpoint for real-time agent tree updates."""
+    db_path = request.app.state.db_path
+    session_dir, status = _resolve_session_dir(db_path, run_id)
+
+    if session_dir is None:
+        async def not_found():
+            yield format_sse(1, {"error": "Session not found"})
+
+        return StreamingResponse(
+            not_found(),
+            media_type="text/event-stream",
+            status_code=404,
+        )
+
+    last_event_id = request.headers.get("last-event-id")
+    start_id = int(last_event_id) if last_event_id and last_event_id.isdigit() else 0
+
+    async def event_stream():
+        event_id = start_id
+
+        yield sse_retry(3000)
+
+        state, trace_offset = _build_full_state(session_dir)
+
+        event_id += 1
+        yield format_sse(event_id, state.to_dict())
+
+        # Terminal sessions: send final state and close
+        if status in ("completed", "failed", "stopped"):
+            return
+
+        # Active sessions: poll for changes
+        session_json_path = os.path.join(session_dir, "session.json")
+        trace_path = os.path.join(session_dir, "trace.jsonl")
+        prev_sj_mtime = _safe_mtime(session_json_path)
+        prev_trace_mtime = _safe_mtime(trace_path)
+
+        while True:
+            await asyncio.sleep(_POLL_INTERVAL)
+
+            if await request.is_disconnected():
+                return
+
+            changed = False
+
+            sj_mtime = _safe_mtime(session_json_path)
+            if sj_mtime != prev_sj_mtime:
+                prev_sj_mtime = sj_mtime
+                session_data = _read_session_json(session_dir)
+                if session_data:
+                    state.load_session_json(session_data)
+                    changed = True
+
+            trace_mtime = _safe_mtime(trace_path)
+            if trace_mtime != prev_trace_mtime:
+                prev_trace_mtime = trace_mtime
+                new_events, trace_offset = _read_trace_lines(
+                    trace_path, trace_offset
+                )
+                for ev in new_events:
+                    state.process_event(ev)
+                if new_events:
+                    changed = True
+
+            if changed:
+                event_id += 1
+                yield format_sse(event_id, state.to_dict())
+
+            if state.is_terminal:
+                return
+
+            # Check DB status for user-initiated stops
+            _, current_status = _resolve_session_dir(db_path, run_id)
+            if current_status in ("completed", "failed", "stopped"):
+                new_events, trace_offset = _read_trace_lines(
+                    trace_path, trace_offset
+                )
+                for ev in new_events:
+                    state.process_event(ev)
+                if new_events:
+                    event_id += 1
+                    yield format_sse(event_id, state.to_dict())
+                return
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/gui/src/strawpot_gui/sse.py
+++ b/gui/src/strawpot_gui/sse.py
@@ -1,0 +1,188 @@
+"""SSE utilities and agent tree state builder."""
+
+import json
+from dataclasses import dataclass, field
+
+
+def format_sse(event_id: int, data: dict) -> str:
+    """Format a single SSE event string."""
+    payload = json.dumps(data, separators=(",", ":"))
+    return f"id: {event_id}\ndata: {payload}\n\n"
+
+
+def sse_retry(ms: int = 3000) -> str:
+    """Format an SSE retry directive."""
+    return f"retry: {ms}\n\n"
+
+
+@dataclass
+class TreeNode:
+    agent_id: str
+    role: str
+    runtime: str
+    status: str  # "running" | "completed" | "failed"
+    exit_code: int | None = None
+    started_at: str | None = None
+    duration_ms: int | None = None
+    parent: str | None = None
+
+
+@dataclass
+class PendingDelegation:
+    role: str
+    requested_by: str | None
+    span_id: str
+
+
+@dataclass
+class DeniedDelegation:
+    role: str
+    reason: str
+    span_id: str
+
+
+class TreeState:
+    """Accumulates agent tree state from session.json + trace.jsonl."""
+
+    def __init__(self) -> None:
+        self.nodes: dict[str, TreeNode] = {}
+        self.pending: dict[str, PendingDelegation] = {}
+        self.denied: list[DeniedDelegation] = []
+        # Correlation maps
+        self._span_to_agent: dict[str, str] = {}
+        self._span_to_parent_agent: dict[str, str | None] = {}
+        self._session_span: str | None = None
+        self._session_ended: bool = False
+
+    def load_session_json(self, data: dict) -> None:
+        """Merge root agent info from session.json."""
+        for agent_id, info in data.get("agents", {}).items():
+            if agent_id not in self.nodes:
+                self.nodes[agent_id] = TreeNode(
+                    agent_id=agent_id,
+                    role=info.get("role", "unknown"),
+                    runtime=info.get("runtime", "unknown"),
+                    status="running",
+                    started_at=info.get("started_at"),
+                    parent=info.get("parent"),
+                )
+
+    def process_event(self, event: dict) -> None:
+        """Process a single trace event and update state."""
+        etype = event.get("event")
+        data = event.get("data", {})
+        span_id = event.get("span_id")
+        parent_span = event.get("parent_span")
+
+        if etype == "session_start":
+            self._session_span = span_id
+
+        elif etype == "delegate_start":
+            parent_agent_id = self._find_agent_for_span(parent_span)
+            self.pending[span_id] = PendingDelegation(
+                role=data.get("role", "unknown"),
+                requested_by=parent_agent_id,
+                span_id=span_id,
+            )
+            self._span_to_parent_agent[span_id] = parent_agent_id
+
+        elif etype == "agent_spawn":
+            agent_id = data.get("agent_id", "")
+            runtime = data.get("runtime", "unknown")
+            parent_agent_id = self._span_to_parent_agent.get(span_id)
+            pending = self.pending.pop(span_id, None)
+            role = pending.role if pending else "unknown"
+            self.nodes[agent_id] = TreeNode(
+                agent_id=agent_id,
+                role=role,
+                runtime=runtime,
+                status="running",
+                started_at=event.get("ts"),
+                parent=parent_agent_id,
+            )
+            self._span_to_agent[span_id] = agent_id
+
+        elif etype == "agent_end":
+            agent_id = self._span_to_agent.get(span_id)
+            if agent_id and agent_id in self.nodes:
+                node = self.nodes[agent_id]
+                exit_code = data.get("exit_code", 1)
+                node.exit_code = exit_code
+                node.duration_ms = data.get("duration_ms")
+                node.status = "completed" if exit_code == 0 else "failed"
+
+        elif etype == "delegate_end":
+            agent_id = self._span_to_agent.get(span_id)
+            if agent_id and agent_id in self.nodes:
+                node = self.nodes[agent_id]
+                exit_code = data.get("exit_code", 1)
+                node.exit_code = exit_code
+                node.duration_ms = data.get("duration_ms")
+                node.status = "completed" if exit_code == 0 else "failed"
+            self.pending.pop(span_id, None)
+
+        elif etype == "delegate_denied":
+            self.denied.append(DeniedDelegation(
+                role=data.get("role", "unknown"),
+                reason=data.get("reason", "unknown"),
+                span_id=span_id or "",
+            ))
+
+        elif etype == "session_end":
+            self._session_ended = True
+            for node in self.nodes.values():
+                if node.parent is None and node.status == "running":
+                    node.status = "completed"
+                    node.duration_ms = data.get("duration_ms")
+
+    def _find_agent_for_span(self, span_id: str | None) -> str | None:
+        """Find the agent_id that owns a given span_id."""
+        if span_id is None:
+            return None
+        agent_id = self._span_to_agent.get(span_id)
+        if agent_id:
+            return agent_id
+        if span_id == self._session_span:
+            for aid, node in self.nodes.items():
+                if node.parent is None:
+                    return aid
+        return None
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether the session has ended."""
+        return self._session_ended
+
+    def to_dict(self) -> dict:
+        """Serialize to the SSE payload format."""
+        return {
+            "nodes": [
+                {
+                    "agent_id": n.agent_id,
+                    "role": n.role,
+                    "runtime": n.runtime,
+                    "status": n.status,
+                    "exit_code": n.exit_code,
+                    "started_at": n.started_at,
+                    "duration_ms": n.duration_ms,
+                    "parent": n.parent,
+                }
+                for n in self.nodes.values()
+            ],
+            "pending_delegations": [
+                {
+                    "role": p.role,
+                    "requested_by": p.requested_by,
+                    "span_id": p.span_id,
+                }
+                for p in self.pending.values()
+            ],
+            "denied_delegations": [
+                {
+                    "role": d.role,
+                    "reason": d.reason,
+                    "span_id": d.span_id,
+                }
+                for d in self.denied
+            ],
+        }

--- a/gui/tests/test_session_tree_sse.py
+++ b/gui/tests/test_session_tree_sse.py
@@ -1,0 +1,167 @@
+"""Integration tests for the SSE agent tree endpoint."""
+
+import json
+
+from test_sessions_sync import _register_project, _write_session, _write_trace
+
+from strawpot_gui.db import sync_sessions
+
+
+def _parse_sse_events(body: str) -> list[dict]:
+    """Parse SSE data events from a response body string."""
+    events = []
+    for line in body.splitlines():
+        if line.startswith("data: "):
+            try:
+                events.append(json.loads(line[6:]))
+            except json.JSONDecodeError:
+                pass
+    return events
+
+
+class TestTreeSSETerminalSession:
+    """Tests for completed/failed sessions — single event then close."""
+
+    def test_completed_session_returns_tree(self, client, tmp_path):
+        """Completed session sends one event with final tree and closes."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        session_dir = _write_session(project_dir, "run_tree1", archived=True)
+        _write_trace(session_dir, [
+            {"ts": "T1", "event": "session_start", "trace_id": "run_tree1",
+             "span_id": "s0", "data": {"run_id": "run_tree1",
+                                        "role": "orchestrator",
+                                        "runtime": "claude_code",
+                                        "isolation": "none"}},
+            {"ts": "T2", "event": "delegate_end", "trace_id": "run_tree1",
+             "span_id": "s0", "parent_span": None,
+             "data": {"exit_code": 0, "summary": "Done",
+                       "duration_ms": 5000}},
+            {"ts": "T3", "event": "session_end", "trace_id": "run_tree1",
+             "span_id": "s0", "data": {"duration_ms": 5100}},
+        ])
+
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get("/api/sessions/run_tree1/tree")
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+
+        events = _parse_sse_events(resp.text)
+        assert len(events) >= 1
+        data = events[0]
+        assert "nodes" in data
+        assert "pending_delegations" in data
+        assert "denied_delegations" in data
+        # Root agent from session.json
+        assert len(data["nodes"]) >= 1
+
+    def test_tree_with_sub_agents(self, client, tmp_path):
+        """Tree includes sub-agents from trace events."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        session_dir = _write_session(project_dir, "run_tree2", archived=True)
+        _write_trace(session_dir, [
+            {"ts": "T1", "event": "session_start", "trace_id": "run_tree2",
+             "span_id": "s0", "data": {}},
+            {"ts": "T2", "event": "delegate_start", "trace_id": "run_tree2",
+             "span_id": "s1", "parent_span": "s0",
+             "data": {"role": "implementer"}},
+            {"ts": "T3", "event": "agent_spawn", "trace_id": "run_tree2",
+             "span_id": "s1", "parent_span": "s0",
+             "data": {"agent_id": "agent_impl", "runtime": "cc",
+                       "pid": 999}},
+            {"ts": "T4", "event": "agent_end", "trace_id": "run_tree2",
+             "span_id": "s1",
+             "data": {"exit_code": 0, "duration_ms": 10000}},
+            {"ts": "T5", "event": "delegate_end", "trace_id": "run_tree2",
+             "span_id": "s1", "parent_span": None,
+             "data": {"exit_code": 0, "summary": "Done",
+                       "duration_ms": 10000}},
+            {"ts": "T6", "event": "session_end", "trace_id": "run_tree2",
+             "span_id": "s0", "data": {"duration_ms": 11000}},
+        ])
+
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get("/api/sessions/run_tree2/tree")
+        events = _parse_sse_events(resp.text)
+        data = events[0]
+
+        agent_ids = [n["agent_id"] for n in data["nodes"]]
+        assert "agent_abc" in agent_ids  # root from session.json
+        assert "agent_impl" in agent_ids  # sub-agent from trace
+
+        impl = next(n for n in data["nodes"] if n["agent_id"] == "agent_impl")
+        assert impl["status"] == "completed"
+        assert impl["parent"] == "agent_abc"
+
+    def test_tree_with_denied_delegation(self, client, tmp_path):
+        """Denied delegations appear in the response."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        session_dir = _write_session(project_dir, "run_tree3", archived=True)
+        _write_trace(session_dir, [
+            {"ts": "T1", "event": "session_start", "trace_id": "run_tree3",
+             "span_id": "s0", "data": {}},
+            {"ts": "T2", "event": "delegate_denied", "trace_id": "run_tree3",
+             "span_id": "s1", "parent_span": "s0",
+             "data": {"role": "admin", "reason": "DENY_DEPTH_LIMIT"}},
+            {"ts": "T3", "event": "session_end", "trace_id": "run_tree3",
+             "span_id": "s0", "data": {"duration_ms": 1000}},
+        ])
+
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get("/api/sessions/run_tree3/tree")
+        events = _parse_sse_events(resp.text)
+        data = events[0]
+
+        assert len(data["denied_delegations"]) == 1
+        assert data["denied_delegations"][0]["role"] == "admin"
+        assert data["denied_delegations"][0]["reason"] == "DENY_DEPTH_LIMIT"
+
+
+class TestTreeSSENotFound:
+    def test_unknown_session_returns_404(self, client):
+        """Non-existent session returns 404."""
+        resp = client.get("/api/sessions/run_nonexistent/tree")
+        assert resp.status_code == 404
+
+
+class TestTreeSSEActiveSession:
+    def test_active_session_with_session_end_terminates(self, client, tmp_path):
+        """Active session that ends via trace terminates the SSE stream."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        # Write session as active (not archived) but include session_end
+        # so the SSE loop terminates after reading all events
+        session_dir = _write_session(project_dir, "run_active")
+        _write_trace(session_dir, [
+            {"ts": "T1", "event": "session_start", "trace_id": "run_active",
+             "span_id": "s0", "data": {}},
+            {"ts": "T2", "event": "session_end", "trace_id": "run_active",
+             "span_id": "s0", "data": {"duration_ms": 1000}},
+        ])
+
+        sync_sessions(client.app.state.db_path)
+
+        # Even though DB status is "running", the trace has session_end
+        # so the SSE stream should send the state and terminate
+        resp = client.get("/api/sessions/run_active/tree")
+        assert resp.status_code == 200
+
+        events = _parse_sse_events(resp.text)
+        assert len(events) >= 1
+        data = events[0]
+        assert "nodes" in data
+        # Root agent from session.json
+        assert len(data["nodes"]) >= 1

--- a/gui/tests/test_sse_unit.py
+++ b/gui/tests/test_sse_unit.py
@@ -1,0 +1,278 @@
+"""Unit tests for SSE utilities and TreeState builder."""
+
+from strawpot_gui.sse import TreeState, format_sse, sse_retry
+
+
+class TestFormatSSE:
+    def test_basic_format(self):
+        result = format_sse(1, {"hello": "world"})
+        assert result == 'id: 1\ndata: {"hello":"world"}\n\n'
+
+    def test_retry_format(self):
+        result = sse_retry(5000)
+        assert result == "retry: 5000\n\n"
+
+    def test_default_retry(self):
+        result = sse_retry()
+        assert result == "retry: 3000\n\n"
+
+
+class TestTreeStateSessionJson:
+    def test_load_root_agent(self):
+        state = TreeState()
+        state.load_session_json({
+            "agents": {
+                "agent_root": {
+                    "role": "orchestrator",
+                    "runtime": "claude_code",
+                    "parent": None,
+                    "started_at": "T0",
+                }
+            }
+        })
+        result = state.to_dict()
+        assert len(result["nodes"]) == 1
+        assert result["nodes"][0]["agent_id"] == "agent_root"
+        assert result["nodes"][0]["status"] == "running"
+
+    def test_load_ignores_existing_agents(self):
+        state = TreeState()
+        state.load_session_json({
+            "agents": {
+                "agent_root": {
+                    "role": "orchestrator",
+                    "runtime": "claude_code",
+                    "parent": None,
+                    "started_at": "T0",
+                }
+            }
+        })
+        # Loading again shouldn't overwrite
+        state.load_session_json({
+            "agents": {
+                "agent_root": {
+                    "role": "different",
+                    "runtime": "different",
+                    "parent": None,
+                    "started_at": "T1",
+                }
+            }
+        })
+        assert state.to_dict()["nodes"][0]["role"] == "orchestrator"
+
+    def test_empty_agents(self):
+        state = TreeState()
+        state.load_session_json({"agents": {}})
+        assert state.to_dict()["nodes"] == []
+
+
+class TestTreeStateTraceEvents:
+    def test_delegate_start_creates_pending(self):
+        state = TreeState()
+        state.load_session_json({
+            "agents": {
+                "agent_root": {
+                    "role": "orchestrator",
+                    "runtime": "cc",
+                    "parent": None,
+                    "started_at": "T0",
+                }
+            }
+        })
+        state.process_event({
+            "event": "session_start", "span_id": "s0", "data": {},
+        })
+        state.process_event({
+            "event": "delegate_start", "span_id": "s1",
+            "parent_span": "s0",
+            "data": {"role": "implementer"},
+        })
+        result = state.to_dict()
+        assert len(result["pending_delegations"]) == 1
+        assert result["pending_delegations"][0]["role"] == "implementer"
+        assert result["pending_delegations"][0]["requested_by"] == "agent_root"
+
+    def test_agent_spawn_promotes_pending(self):
+        state = TreeState()
+        state.load_session_json({
+            "agents": {
+                "agent_root": {
+                    "role": "orchestrator",
+                    "runtime": "cc",
+                    "parent": None,
+                    "started_at": "T0",
+                }
+            }
+        })
+        state.process_event({
+            "event": "session_start", "span_id": "s0", "data": {},
+        })
+        state.process_event({
+            "event": "delegate_start", "span_id": "s1",
+            "parent_span": "s0",
+            "data": {"role": "implementer"},
+        })
+        state.process_event({
+            "event": "agent_spawn", "span_id": "s1", "ts": "T2",
+            "data": {"agent_id": "agent_impl", "runtime": "cc", "pid": 999},
+        })
+        result = state.to_dict()
+        assert len(result["pending_delegations"]) == 0
+        agent_ids = [n["agent_id"] for n in result["nodes"]]
+        assert "agent_impl" in agent_ids
+        impl = next(n for n in result["nodes"] if n["agent_id"] == "agent_impl")
+        assert impl["parent"] == "agent_root"
+        assert impl["status"] == "running"
+
+    def test_agent_end_marks_completed(self):
+        state = TreeState()
+        state.process_event({
+            "event": "session_start", "span_id": "s0", "data": {},
+        })
+        state.process_event({
+            "event": "delegate_start", "span_id": "s1",
+            "parent_span": "s0",
+            "data": {"role": "impl"},
+        })
+        state.process_event({
+            "event": "agent_spawn", "span_id": "s1", "ts": "T1",
+            "data": {"agent_id": "a1", "runtime": "cc", "pid": 1},
+        })
+        state.process_event({
+            "event": "agent_end", "span_id": "s1",
+            "data": {"exit_code": 0, "duration_ms": 5000},
+        })
+        node = state.nodes["a1"]
+        assert node.status == "completed"
+        assert node.exit_code == 0
+        assert node.duration_ms == 5000
+
+    def test_agent_end_nonzero_marks_failed(self):
+        state = TreeState()
+        state.process_event({
+            "event": "delegate_start", "span_id": "s1",
+            "parent_span": None,
+            "data": {"role": "impl"},
+        })
+        state.process_event({
+            "event": "agent_spawn", "span_id": "s1", "ts": "T1",
+            "data": {"agent_id": "a1", "runtime": "cc", "pid": 1},
+        })
+        state.process_event({
+            "event": "agent_end", "span_id": "s1",
+            "data": {"exit_code": 1, "duration_ms": 3000},
+        })
+        assert state.nodes["a1"].status == "failed"
+
+    def test_delegate_denied_recorded(self):
+        state = TreeState()
+        state.process_event({
+            "event": "delegate_denied", "span_id": "s2",
+            "parent_span": "s0",
+            "data": {"role": "admin", "reason": "DENY_DEPTH_LIMIT"},
+        })
+        result = state.to_dict()
+        assert len(result["denied_delegations"]) == 1
+        assert result["denied_delegations"][0]["role"] == "admin"
+        assert result["denied_delegations"][0]["reason"] == "DENY_DEPTH_LIMIT"
+
+    def test_session_end_marks_terminal(self):
+        state = TreeState()
+        state.process_event({
+            "event": "session_end", "span_id": "s0",
+            "data": {"duration_ms": 1000},
+        })
+        assert state.is_terminal
+
+    def test_session_end_completes_root(self):
+        state = TreeState()
+        state.load_session_json({
+            "agents": {
+                "agent_root": {
+                    "role": "orchestrator",
+                    "runtime": "cc",
+                    "parent": None,
+                    "started_at": "T0",
+                }
+            }
+        })
+        state.process_event({
+            "event": "session_end", "span_id": "s0",
+            "data": {"duration_ms": 5000},
+        })
+        assert state.nodes["agent_root"].status == "completed"
+        assert state.nodes["agent_root"].duration_ms == 5000
+
+
+class TestTreeStateFullLifecycle:
+    def test_full_scenario(self):
+        state = TreeState()
+        state.load_session_json({
+            "agents": {
+                "agent_root": {
+                    "role": "orchestrator",
+                    "runtime": "claude_code",
+                    "parent": None,
+                    "started_at": "T0",
+                    "pid": 100,
+                }
+            }
+        })
+        events = [
+            {"event": "session_start", "span_id": "s0",
+             "data": {"run_id": "r1", "role": "orchestrator"}},
+            {"event": "delegate_start", "span_id": "s1", "parent_span": "s0",
+             "data": {"role": "implementer"}},
+            {"event": "agent_spawn", "span_id": "s1", "ts": "T1",
+             "data": {"agent_id": "agent_impl", "runtime": "cc", "pid": 200}},
+            {"event": "delegate_start", "span_id": "s2", "parent_span": "s1",
+             "data": {"role": "reviewer"}},
+            {"event": "delegate_denied", "span_id": "s3", "parent_span": "s1",
+             "data": {"role": "admin", "reason": "DENY_DEPTH_LIMIT"}},
+            {"event": "agent_spawn", "span_id": "s2", "ts": "T2",
+             "data": {"agent_id": "agent_rev", "runtime": "cc", "pid": 300}},
+            {"event": "agent_end", "span_id": "s2",
+             "data": {"exit_code": 0, "duration_ms": 10000}},
+            {"event": "delegate_end", "span_id": "s2",
+             "data": {"exit_code": 0, "summary": "Review done",
+                       "duration_ms": 10000}},
+            {"event": "agent_end", "span_id": "s1",
+             "data": {"exit_code": 0, "duration_ms": 30000}},
+            {"event": "delegate_end", "span_id": "s1", "parent_span": None,
+             "data": {"exit_code": 0, "summary": "Implemented",
+                       "duration_ms": 30000}},
+            {"event": "session_end", "span_id": "s0",
+             "data": {"duration_ms": 35000}},
+        ]
+        for ev in events:
+            state.process_event(ev)
+
+        result = state.to_dict()
+
+        # 3 nodes: root, implementer, reviewer
+        assert len(result["nodes"]) == 3
+        ids = {n["agent_id"] for n in result["nodes"]}
+        assert ids == {"agent_root", "agent_impl", "agent_rev"}
+
+        # All completed
+        for node in result["nodes"]:
+            assert node["status"] == "completed"
+
+        # Reviewer's parent is implementer
+        rev = next(n for n in result["nodes"] if n["agent_id"] == "agent_rev")
+        assert rev["parent"] == "agent_impl"
+
+        # Implementer's parent is root
+        impl = next(
+            n for n in result["nodes"] if n["agent_id"] == "agent_impl"
+        )
+        assert impl["parent"] == "agent_root"
+
+        # No pending delegations
+        assert len(result["pending_delegations"]) == 0
+
+        # 1 denied delegation
+        assert len(result["denied_delegations"]) == 1
+        assert result["denied_delegations"][0]["role"] == "admin"
+
+        assert state.is_terminal


### PR DESCRIPTION
## Summary

- Add `GET /api/sessions/:run_id/tree` SSE endpoint that streams real-time agent tree state
- `TreeState` builder correlates trace events (`delegate_start`, `agent_spawn`, `agent_end`, `delegate_end`, `delegate_denied`) into a tree with nodes, pending delegations, and denied delegations
- Polls `session.json` mtime and tail-follows `trace.jsonl` every 1.5s for active sessions; sends single event for terminal sessions
- Supports `Last-Event-ID` reconnection protocol
- No new dependencies — uses FastAPI `StreamingResponse` with `text/event-stream`

## Test plan

- [x] 14 unit tests for `TreeState` and SSE formatting (`test_sse_unit.py`)
- [x] 5 integration tests for SSE endpoint (`test_session_tree_sse.py`)
- [x] All 98 tests pass
- [x] Frontend build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)