### PR TITLE
Make --headless non-interactive and fix package kind consistency

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -34,7 +34,7 @@ def cli():
 # ---------------------------------------------------------------------------
 
 
-def _ensure_agent_installed(name: str, working_dir: str) -> None:
+def _ensure_agent_installed(name: str, working_dir: str, *, auto_setup: bool = False) -> None:
     """Prompt to install an agent from StrawHub if it is not found locally."""
     try:
         resolve_agent(name, working_dir)
@@ -69,10 +69,11 @@ def _ensure_agent_installed(name: str, working_dir: str) -> None:
             click.echo(f"Agent '{name}' binary is missing and no install script found.", err=True)
             return
 
-    if not click.confirm(
-        f"Agent '{name}' is not installed. Install from StrawHub?", default=True
-    ):
-        return
+    if not auto_setup:
+        if not click.confirm(
+            f"Agent '{name}' is not installed. Install from StrawHub?", default=True
+        ):
+            return
 
     cmd = shutil.which("strawhub")
     if cmd is None:
@@ -107,7 +108,7 @@ def _ensure_agent_installed(name: str, working_dir: str) -> None:
             click.echo(f"Install script failed for '{name}'.", err=True)
 
 
-def _ensure_skill_installed(name: str, working_dir: str) -> None:
+def _ensure_skill_installed(name: str, working_dir: str, *, auto_setup: bool = False) -> None:
     """Prompt to install a skill from StrawHub if it is not found locally."""
     candidates = [
         Path(working_dir) / ".strawpot" / "skills" / name,
@@ -117,10 +118,11 @@ def _ensure_skill_installed(name: str, working_dir: str) -> None:
         if (candidate / "SKILL.md").is_file():
             return  # already installed
 
-    if not click.confirm(
-        f"Skill '{name}' is not installed. Install from StrawHub?", default=True
-    ):
-        return
+    if not auto_setup:
+        if not click.confirm(
+            f"Skill '{name}' is not installed. Install from StrawHub?", default=True
+        ):
+            return
 
     cmd = shutil.which("strawhub")
     if cmd is None:
@@ -138,7 +140,7 @@ def _ensure_skill_installed(name: str, working_dir: str) -> None:
         click.echo(f"Failed to install skill '{name}'.", err=True)
 
 
-def _ensure_memory_installed(name: str, working_dir: str) -> None:
+def _ensure_memory_installed(name: str, working_dir: str, *, auto_setup: bool = False) -> None:
     """Prompt to install a memory provider from StrawHub if not found locally."""
     try:
         resolve_memory(name, working_dir)
@@ -147,11 +149,12 @@ def _ensure_memory_installed(name: str, working_dir: str) -> None:
     else:
         return  # already available
 
-    if not click.confirm(
-        f"Memory provider '{name}' is not installed. Install from StrawHub?",
-        default=True,
-    ):
-        return
+    if not auto_setup:
+        if not click.confirm(
+            f"Memory provider '{name}' is not installed. Install from StrawHub?",
+            default=True,
+        ):
+            return
 
     cmd = shutil.which("strawhub")
     if cmd is None:
@@ -235,10 +238,10 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task, head
         click.echo(f"Recovered stale session: {run_id}")
 
     # 0b. Auto-install default dependencies if not found
-    _ensure_agent_installed(config.runtime, working_dir)
-    _ensure_skill_installed("denden", working_dir)
+    _ensure_agent_installed(config.runtime, working_dir, auto_setup=headless)
+    _ensure_skill_installed("denden", working_dir, auto_setup=headless)
     if config.memory:
-        _ensure_memory_installed(config.memory, working_dir)
+        _ensure_memory_installed(config.memory, working_dir, auto_setup=headless)
 
     # 1. Resolve agent spec
     try:
@@ -260,9 +263,16 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task, head
             click.echo(msg, err=True)
         sys.exit(1)
 
-    for var in validation.missing_env:
-        value = click.prompt(f"Enter value for {var}")
-        os.environ[var] = value
+    if validation.missing_env:
+        if headless:
+            click.echo(
+                f"Error: missing environment variables: {', '.join(validation.missing_env)}",
+                err=True,
+            )
+            sys.exit(1)
+        for var in validation.missing_env:
+            value = click.prompt(f"Enter value for {var}")
+            os.environ[var] = value
 
     # 2b. Validate skill env requirements for orchestrator role
     try:
@@ -281,13 +291,21 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task, head
         saved_env = _collect_saved_env(config, resolved, global_skills=global_skills or None)
         skill_validation = validate_skill_env(skill_env, saved_env=saved_env)
 
-        for var in skill_validation.missing_env:
-            desc = skill_env[var].get("description", "")
-            prompt_text = f"Enter value for {var}"
-            if desc:
-                prompt_text += f" ({desc})"
-            value = click.prompt(prompt_text)
-            os.environ[var] = value
+        if skill_validation.missing_env:
+            if headless:
+                click.echo(
+                    f"Error: missing skill environment variables: "
+                    f"{', '.join(skill_validation.missing_env)}",
+                    err=True,
+                )
+                sys.exit(1)
+            for var in skill_validation.missing_env:
+                desc = skill_env[var].get("description", "")
+                prompt_text = f"Enter value for {var}"
+                if desc:
+                    prompt_text += f" ({desc})"
+                value = click.prompt(prompt_text)
+                os.environ[var] = value
     except Exception:
         pass  # Role resolution failures handled by Session.start()
 
@@ -337,6 +355,7 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task, head
         resolve_role_dirs=_resolve_role_dirs,
         task=task or "",
         run_id=run_id,
+        headless=headless,
     )
     session.start(working_dir)
 
@@ -516,20 +535,20 @@ def _make_passthrough(strawhub_cmd: str, help_text: str):
 
 
 # Package management
-cli.add_command(_make_passthrough("install", "Install skills or roles from StrawHub."))
-cli.add_command(_make_passthrough("uninstall", "Uninstall a skill or role."))
+cli.add_command(_make_passthrough("install", "Install a skill, role, agent, or memory from StrawHub."))
+cli.add_command(_make_passthrough("uninstall", "Remove an installed skill, role, agent, or memory."))
 cli.add_command(_make_passthrough("update", "Update installed packages to latest versions."))
 cli.add_command(_make_passthrough("init", "Create strawpot.toml from installed packages."))
 cli.add_command(_make_passthrough("install-tools", "Install system tools declared by packages."))
 
 # Discovery
 cli.add_command(_make_passthrough("search", "Search the StrawHub registry."))
-cli.add_command(_make_passthrough("list", "Browse skills and roles on the registry."))
+cli.add_command(_make_passthrough("list", "Browse skills, roles, agents, and memories on the registry."))
 cli.add_command(_make_passthrough("info", "Show detailed information about a package."))
 cli.add_command(_make_passthrough("resolve", "Resolve a slug to its installed path."))
 
 # Publishing
-cli.add_command(_make_passthrough("publish", "Publish a skill or role to StrawHub."))
+cli.add_command(_make_passthrough("publish", "Publish a skill, role, agent, or memory to StrawHub."))
 
 # Authentication
 cli.add_command(_make_passthrough("login", "Authenticate with the StrawHub registry."))

--- a/cli/src/strawpot/context.py
+++ b/cli/src/strawpot/context.py
@@ -26,14 +26,14 @@ def validate_frontmatter_slug(
     """Validate that the frontmatter ``name`` matches the expected slug.
 
     Args:
-        package_path: Directory containing the SKILL.md or ROLE.md file.
+        package_path: Directory containing the package's main markdown file.
         expected_slug: The slug derived from the directory name.
-        kind: ``"skill"`` or ``"role"``.
+        kind: ``"skill"``, ``"role"``, ``"agent"``, or ``"memory"``.
 
     Raises:
         ValueError: If the ``name`` field is missing or does not match *expected_slug*.
     """
-    filename = "SKILL.md" if kind == "skill" else "ROLE.md"
+    filename = {"skill": "SKILL.md", "role": "ROLE.md", "agent": "AGENT.md", "memory": "MEMORY.md"}[kind]
     filepath = Path(package_path) / filename
     if not filepath.exists():
         return
@@ -186,8 +186,8 @@ def read_role_description(role_path: str) -> str:
 
 
 def _read_body(package_path: str, kind: str) -> str:
-    """Read the markdown body from a SKILL.md or ROLE.md, stripping frontmatter."""
-    filename = "SKILL.md" if kind == "skill" else "ROLE.md"
+    """Read the markdown body from a package's main file, stripping frontmatter."""
+    filename = {"skill": "SKILL.md", "role": "ROLE.md", "agent": "AGENT.md", "memory": "MEMORY.md"}[kind]
     filepath = Path(package_path) / filename
     text = filepath.read_text(encoding="utf-8")
     parsed = parse_frontmatter(text)

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -273,6 +273,7 @@ class Session:
         task: str = "",
         run_id: str | None = None,
         ask_user_handler: Callable[[AskUserRequest], AskUserResponse] | None = None,
+        headless: bool = False,
     ) -> None:
         self.config = config
         self.wrapper = wrapper
@@ -283,6 +284,7 @@ class Session:
         self._resolve_role_dirs = resolve_role_dirs
         self._ask_user_handler = ask_user_handler or _default_ask_user_handler
         self._provided_run_id = run_id
+        self._headless = headless
 
         self._run_id: str | None = None
         self._env: IsolatedEnv | None = None
@@ -595,11 +597,13 @@ class Session:
 
         try:
             if strategy == "local":
+                prompt_fn = (lambda *a, **kw: "d") if self._headless else None
                 result = merge_local(
                     base_branch=base_branch,
                     session_branch=session_branch,
                     worktree_dir=self._env.path,
                     base_dir=self._working_dir,
+                    prompt=prompt_fn,
                 )
                 logger.info("Local merge: %s", result.message)
                 return True  # always delete branch for local strategy

--- a/cli/tests/test_cli_bootstrap.py
+++ b/cli/tests/test_cli_bootstrap.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
-from strawpot.cli import _ensure_agent_installed, _ensure_skill_installed
+from strawpot.cli import (
+    _ensure_agent_installed,
+    _ensure_memory_installed,
+    _ensure_skill_installed,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -162,3 +166,50 @@ def test_ensure_skill_install_fails(mock_confirm, mock_which, mock_run, mock_ech
 
     calls = [str(c) for c in mock_echo.call_args_list]
     assert any("Failed to install skill" in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# auto_setup=True (headless mode)
+# ---------------------------------------------------------------------------
+
+
+@patch("strawpot.cli.subprocess.run")
+@patch("strawpot.cli.shutil.which", return_value="/usr/bin/strawhub")
+@patch("strawpot.cli.click.confirm")
+@patch("strawpot.cli.resolve_agent", side_effect=FileNotFoundError("not found"))
+def test_ensure_agent_auto_setup_skips_confirm(mock_resolve, mock_confirm, mock_which, mock_run):
+    """auto_setup=True installs without prompting."""
+    mock_run.return_value = MagicMock(returncode=0)
+
+    _ensure_agent_installed("claude_code", "/tmp/project", auto_setup=True)
+
+    mock_confirm.assert_not_called()
+    mock_run.assert_called_once()
+
+
+@patch("strawpot.cli.subprocess.run")
+@patch("strawpot.cli.shutil.which", return_value="/usr/bin/strawhub")
+@patch("strawpot.cli.click.confirm")
+def test_ensure_skill_auto_setup_skips_confirm(mock_confirm, mock_which, mock_run, tmp_path, monkeypatch):
+    """auto_setup=True installs skill without prompting."""
+    monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "global_home"))
+    mock_run.return_value = MagicMock(returncode=0)
+
+    _ensure_skill_installed("denden", str(tmp_path / "project"), auto_setup=True)
+
+    mock_confirm.assert_not_called()
+    mock_run.assert_called_once()
+
+
+@patch("strawpot.cli.subprocess.run")
+@patch("strawpot.cli.shutil.which", return_value="/usr/bin/strawhub")
+@patch("strawpot.cli.click.confirm")
+@patch("strawpot.cli.resolve_memory", side_effect=FileNotFoundError("not found"))
+def test_ensure_memory_auto_setup_skips_confirm(mock_resolve, mock_confirm, mock_which, mock_run):
+    """auto_setup=True installs memory provider without prompting."""
+    mock_run.return_value = MagicMock(returncode=0)
+
+    _ensure_memory_installed("semantic", "/tmp/project", auto_setup=True)
+
+    mock_confirm.assert_not_called()
+    mock_run.assert_called_once()

--- a/cli/tests/test_cli_headless.py
+++ b/cli/tests/test_cli_headless.py
@@ -1,0 +1,130 @@
+"""Tests for headless mode non-interactive behavior."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from strawpot.cli import cli
+
+
+@patch("strawpot.cli.Session")
+@patch("strawpot.cli.resolve_isolator")
+@patch("strawpot.cli.WrapperRuntime")
+@patch("strawpot.cli.validate_agent")
+@patch("strawpot.cli.resolve_agent")
+@patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_skill_installed")
+@patch("strawpot.cli._ensure_agent_installed")
+@patch("strawpot.cli.recover_stale_sessions", return_value=[])
+@patch("strawpot.cli.load_config")
+def test_headless_missing_env_exits(
+    mock_config,
+    mock_recover,
+    mock_agent_install,
+    mock_skill_install,
+    mock_memory_install,
+    mock_resolve,
+    mock_validate,
+    mock_wrapper,
+    mock_isolator,
+    mock_session,
+):
+    """Headless mode exits with error when agent has missing env vars."""
+    mock_config.return_value = MagicMock(
+        orchestrator_role="orchestrator",
+        runtime="claude_code",
+        isolation="none",
+        merge_strategy="auto",
+        pull_before_session="never",
+        denden_addr="127.0.0.1:9700",
+        memory=None,
+        agents={},
+    )
+    mock_resolve.return_value = MagicMock()
+    mock_validate.return_value = MagicMock(
+        missing_tools=[],
+        missing_env=["ANTHROPIC_API_KEY", "OTHER_KEY"],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["start", "--headless", "--task", "test task"])
+
+    assert result.exit_code != 0
+    assert "missing environment variables" in result.output
+    assert "ANTHROPIC_API_KEY" in result.output
+
+
+@patch("strawpot.cli.Session")
+@patch("strawpot.cli.resolve_isolator")
+@patch("strawpot.cli.WrapperRuntime")
+@patch("strawpot.cli.validate_agent")
+@patch("strawpot.cli.resolve_agent")
+@patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_skill_installed")
+@patch("strawpot.cli._ensure_agent_installed")
+@patch("strawpot.cli.recover_stale_sessions", return_value=[])
+@patch("strawpot.cli.load_config")
+def test_headless_no_missing_env_proceeds(
+    mock_config,
+    mock_recover,
+    mock_agent_install,
+    mock_skill_install,
+    mock_memory_install,
+    mock_resolve,
+    mock_validate,
+    mock_wrapper,
+    mock_isolator,
+    mock_session,
+):
+    """Headless mode proceeds when no env vars are missing."""
+    mock_config.return_value = MagicMock(
+        orchestrator_role="orchestrator",
+        runtime="claude_code",
+        isolation="none",
+        merge_strategy="auto",
+        pull_before_session="never",
+        denden_addr="127.0.0.1:9700",
+        memory=None,
+        agents={},
+    )
+    mock_resolve.return_value = MagicMock()
+    mock_validate.return_value = MagicMock(
+        missing_tools=[],
+        missing_env=[],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["start", "--headless", "--task", "test task"])
+
+    # Should reach session creation (may fail later but not on env vars)
+    assert "missing environment variables" not in (result.output or "")
+
+
+@patch("strawpot.cli._ensure_agent_installed")
+@patch("strawpot.cli.recover_stale_sessions", return_value=[])
+@patch("strawpot.cli.load_config")
+def test_headless_passes_auto_setup_to_bootstrap(
+    mock_config,
+    mock_recover,
+    mock_agent_install,
+):
+    """Headless mode passes auto_setup=True to bootstrap helpers."""
+    mock_config.return_value = MagicMock(
+        orchestrator_role="orchestrator",
+        runtime="claude_code",
+        isolation="none",
+        merge_strategy="auto",
+        pull_before_session="never",
+        denden_addr="127.0.0.1:9700",
+        memory=None,
+        agents={},
+    )
+    # Make it fail after agent install so we don't need to mock everything
+    mock_agent_install.side_effect = SystemExit(1)
+
+    runner = CliRunner()
+    runner.invoke(cli, ["start", "--headless", "--task", "test task"])
+
+    mock_agent_install.assert_called_once()
+    _, kwargs = mock_agent_install.call_args
+    assert kwargs.get("auto_setup") is True


### PR DESCRIPTION
## Summary
- Add `auto_setup` parameter to bootstrap helpers (`_ensure_agent_installed`, `_ensure_skill_installed`, `_ensure_memory_installed`) so `--headless` mode auto-installs without prompting
- Fail fast with `sys.exit(1)` on missing env vars in headless mode instead of hanging on `click.prompt()`
- Pass `headless` flag to `Session` for non-interactive merge conflict resolution (auto-discard)
- Fix help text for `install`, `uninstall`, `list`, `publish` passthrough commands to mention all 4 package kinds (skill, role, agent, memory)
- Fix `context.py` to handle agent/memory main files (`AGENT.md`, `MEMORY.md`) in `validate_frontmatter_slug` and `_read_body`

## Test plan
- [x] 3 new `auto_setup` tests in `test_cli_bootstrap.py` verify install without prompting
- [x] 3 new headless tests in `test_cli_headless.py` verify env var failure + auto_setup passthrough
- [x] All 484 CLI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)