### PR TITLE
Add ai-ceo as default orchestrator role with auto-install

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -172,6 +172,38 @@ def _ensure_memory_installed(name: str, working_dir: str, *, auto_setup: bool = 
         click.echo(f"Failed to install memory provider '{name}'.", err=True)
 
 
+def _ensure_role_installed(name: str, working_dir: str, *, auto_setup: bool = False) -> None:
+    """Prompt to install a role from StrawHub if it is not found locally."""
+    candidates = [
+        Path(working_dir) / ".strawpot" / "roles" / name,
+        get_strawpot_home() / "roles" / name,
+    ]
+    for candidate in candidates:
+        if (candidate / "ROLE.md").is_file():
+            return  # already installed
+
+    if not auto_setup:
+        if not click.confirm(
+            f"Role '{name}' is not installed. Install from StrawHub?", default=True
+        ):
+            return
+
+    cmd = shutil.which("strawhub")
+    if cmd is None:
+        click.echo("Error: strawhub CLI not found on PATH.", err=True)
+        click.echo("Install it with: pip install strawhub", err=True)
+        return
+
+    result = subprocess.run(
+        [cmd, "install", "role", name, "--global"],
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+    if result.returncode != 0:
+        click.echo(f"Failed to install role '{name}'.", err=True)
+
+
 # ---------------------------------------------------------------------------
 # Session commands
 # ---------------------------------------------------------------------------
@@ -240,6 +272,7 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task, head
     # 0b. Auto-install default dependencies if not found
     _ensure_agent_installed(config.runtime, working_dir, auto_setup=headless)
     _ensure_skill_installed("denden", working_dir, auto_setup=headless)
+    _ensure_role_installed(config.orchestrator_role, working_dir, auto_setup=headless)
     if config.memory:
         _ensure_memory_installed(config.memory, working_dir, auto_setup=headless)
 

--- a/cli/src/strawpot/config.py
+++ b/cli/src/strawpot/config.py
@@ -25,7 +25,7 @@ class StrawPotConfig:
     runtime: str = "strawpot-claude-code"
     isolation: str = "none"
     denden_addr: str = "127.0.0.1:9700"
-    orchestrator_role: str = "orchestrator"
+    orchestrator_role: str = "ai-ceo"
     max_depth: int = 3
     permission_mode: str = "default"
     agent_timeout: int | None = None

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -28,6 +28,7 @@ def _make_spec(**overrides):
 
 
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.Session")
@@ -38,7 +39,7 @@ def _make_spec(**overrides):
 @patch("strawpot.cli.load_config")
 def test_start_resolves_agent(
     mock_load, mock_resolve, mock_validate, mock_wrapper, mock_isolator,
-    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory
 ):
     """start() calls resolve_agent with config.runtime."""
     from strawpot.config import StrawPotConfig
@@ -56,6 +57,7 @@ def test_start_resolves_agent(
 
 
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.Session")
@@ -66,7 +68,7 @@ def test_start_resolves_agent(
 @patch("strawpot.cli.load_config")
 def test_start_resolves_agent_with_runtime_override(
     mock_load, mock_resolve, mock_validate, mock_wrapper, mock_isolator,
-    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory
 ):
     """start --runtime overrides the agent name passed to resolve_agent."""
     from strawpot.config import StrawPotConfig
@@ -83,11 +85,12 @@ def test_start_resolves_agent_with_runtime_override(
 
 
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.resolve_agent")
 @patch("strawpot.cli.load_config")
-def test_start_agent_not_found(mock_load, mock_resolve, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory):
+def test_start_agent_not_found(mock_load, mock_resolve, mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory):
     """FileNotFoundError from resolve_agent prints error and exits 1."""
     from strawpot.config import StrawPotConfig
 
@@ -107,13 +110,14 @@ def test_start_agent_not_found(mock_load, mock_resolve, mock_ensure_agent, mock_
 
 
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.resolve_agent")
 @patch("strawpot.cli.validate_agent")
 @patch("strawpot.cli.load_config")
 def test_start_missing_tools_exits(
-    mock_load, mock_validate, mock_resolve, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+    mock_load, mock_validate, mock_resolve, mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory
 ):
     """Missing tools prints error with hints and exits 1."""
     from strawpot.config import StrawPotConfig
@@ -135,6 +139,7 @@ def test_start_missing_tools_exits(
 
 
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.Session")
@@ -145,7 +150,7 @@ def test_start_missing_tools_exits(
 @patch("strawpot.cli.load_config")
 def test_start_missing_env_prompts(
     mock_load, mock_validate, mock_resolve, mock_wrapper, mock_isolator,
-    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory
 ):
     """Missing env vars are prompted and set in os.environ."""
     from strawpot.config import StrawPotConfig
@@ -170,6 +175,7 @@ def test_start_missing_env_prompts(
 
 
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.Session")
@@ -181,7 +187,7 @@ def test_start_missing_env_prompts(
 @patch("strawpot.cli.shutil.which")
 def test_start_uses_tmux_when_available(
     mock_which, mock_load, mock_resolve, mock_validate,
-    mock_wrapper, mock_isolator, mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+    mock_wrapper, mock_isolator, mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory
 ):
     """InteractiveWrapperRuntime is used when tmux is on PATH."""
     from strawpot.config import StrawPotConfig
@@ -199,6 +205,7 @@ def test_start_uses_tmux_when_available(
 
 
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.Session")
@@ -210,7 +217,7 @@ def test_start_uses_tmux_when_available(
 @patch("strawpot.cli.shutil.which")
 def test_start_falls_back_to_direct(
     mock_which, mock_load, mock_resolve, mock_validate,
-    mock_wrapper, mock_isolator, mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+    mock_wrapper, mock_isolator, mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory
 ):
     """DirectWrapperRuntime is used when tmux is not on PATH."""
     from strawpot.config import StrawPotConfig
@@ -232,6 +239,7 @@ def test_start_falls_back_to_direct(
 
 
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.Session")
@@ -242,7 +250,7 @@ def test_start_falls_back_to_direct(
 @patch("strawpot.cli.load_config")
 def test_start_creates_session(
     mock_load, mock_resolve, mock_validate, mock_wrapper, mock_isolator,
-    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory
 ):
     """Session is constructed with correct args and start() is called."""
     from strawpot.config import StrawPotConfig
@@ -271,6 +279,7 @@ def test_start_creates_session(
 
 
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.Session")
@@ -281,7 +290,7 @@ def test_start_creates_session(
 @patch("strawpot.cli.load_config")
 def test_start_role_override(
     mock_load, mock_resolve, mock_validate, mock_wrapper, mock_isolator,
-    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory
 ):
     """--role overrides config.orchestrator_role."""
     from strawpot.config import StrawPotConfig
@@ -297,6 +306,7 @@ def test_start_role_override(
 
 
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.Session")
@@ -307,7 +317,7 @@ def test_start_role_override(
 @patch("strawpot.cli.load_config")
 def test_start_isolation_override(
     mock_load, mock_resolve, mock_validate, mock_wrapper, mock_isolator,
-    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory
 ):
     """--isolation overrides config.isolation."""
     from strawpot.config import StrawPotConfig
@@ -323,6 +333,7 @@ def test_start_isolation_override(
 
 
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.Session")
@@ -333,7 +344,7 @@ def test_start_isolation_override(
 @patch("strawpot.cli.load_config")
 def test_start_host_port_override(
     mock_load, mock_resolve, mock_validate, mock_wrapper, mock_isolator,
-    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory
 ):
     """--host and --port override config.denden_addr."""
     from strawpot.config import StrawPotConfig
@@ -354,6 +365,7 @@ def test_start_host_port_override(
 
 
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.Session")
@@ -364,7 +376,7 @@ def test_start_host_port_override(
 @patch("strawpot.cli.load_config")
 def test_start_run_id_override(
     mock_load, mock_resolve, mock_validate, mock_wrapper, mock_isolator,
-    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+    mock_session, mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory
 ):
     """--run-id passes the pre-assigned run ID to Session constructor."""
     from strawpot.config import StrawPotConfig
@@ -382,12 +394,13 @@ def test_start_run_id_override(
 
 
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.resolve_agent")
 @patch("strawpot.cli.load_config")
 def test_start_invalid_run_id_rejected(
-    mock_load, mock_resolve, mock_ensure_agent, mock_ensure_skill, mock_ensure_memory
+    mock_load, mock_resolve, mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory
 ):
     """--run-id without 'run_' prefix fails with error."""
     from strawpot.config import StrawPotConfig

--- a/cli/tests/test_cli_bootstrap.py
+++ b/cli/tests/test_cli_bootstrap.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner
 from strawpot.cli import (
     _ensure_agent_installed,
     _ensure_memory_installed,
+    _ensure_role_installed,
     _ensure_skill_installed,
 )
 
@@ -169,6 +170,92 @@ def test_ensure_skill_install_fails(mock_confirm, mock_which, mock_run, mock_ech
 
 
 # ---------------------------------------------------------------------------
+# _ensure_role_installed
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_role_already_installed_project_local(tmp_path):
+    """No prompt when the role exists in project-local .strawpot/roles/."""
+    role_dir = tmp_path / ".strawpot" / "roles" / "ai-ceo"
+    role_dir.mkdir(parents=True)
+    (role_dir / "ROLE.md").write_text("---\nname: ai-ceo\n---")
+
+    with patch("strawpot.cli.click.confirm") as mock_confirm:
+        _ensure_role_installed("ai-ceo", str(tmp_path))
+        mock_confirm.assert_not_called()
+
+
+def test_ensure_role_already_installed_global(tmp_path, monkeypatch):
+    """No prompt when the role exists in global ~/.strawpot/roles/."""
+    global_home = tmp_path / "global_home"
+    role_dir = global_home / "roles" / "ai-ceo"
+    role_dir.mkdir(parents=True)
+    (role_dir / "ROLE.md").write_text("---\nname: ai-ceo\n---")
+    monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
+
+    with patch("strawpot.cli.click.confirm") as mock_confirm:
+        _ensure_role_installed("ai-ceo", str(tmp_path / "project"))
+        mock_confirm.assert_not_called()
+
+
+@patch("strawpot.cli.subprocess.run")
+@patch("strawpot.cli.shutil.which", return_value="/usr/bin/strawhub")
+@patch("strawpot.cli.click.confirm", return_value=True)
+def test_ensure_role_installs_on_confirm(mock_confirm, mock_which, mock_run, tmp_path, monkeypatch):
+    """Installs role via strawhub when user confirms."""
+    monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "global_home"))
+    mock_run.return_value = MagicMock(returncode=0)
+
+    _ensure_role_installed("ai-ceo", str(tmp_path / "project"))
+
+    mock_confirm.assert_called_once()
+    mock_run.assert_called_once()
+    cmd = mock_run.call_args[0][0]
+    assert cmd == ["/usr/bin/strawhub", "install", "role", "ai-ceo", "--global"]
+
+
+@patch("strawpot.cli.subprocess.run")
+@patch("strawpot.cli.shutil.which", return_value="/usr/bin/strawhub")
+@patch("strawpot.cli.click.confirm", return_value=False)
+def test_ensure_role_skips_on_decline(mock_confirm, mock_which, mock_run, tmp_path, monkeypatch):
+    """Does nothing when user declines install."""
+    monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "global_home"))
+
+    _ensure_role_installed("ai-ceo", str(tmp_path / "project"))
+
+    mock_confirm.assert_called_once()
+    mock_run.assert_not_called()
+
+
+@patch("strawpot.cli.click.echo")
+@patch("strawpot.cli.shutil.which", return_value=None)
+@patch("strawpot.cli.click.confirm", return_value=True)
+def test_ensure_role_strawhub_not_found(mock_confirm, mock_which, mock_echo, tmp_path, monkeypatch):
+    """Shows error when strawhub CLI is not on PATH."""
+    monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "global_home"))
+
+    _ensure_role_installed("ai-ceo", str(tmp_path / "project"))
+
+    calls = [str(c) for c in mock_echo.call_args_list]
+    assert any("strawhub CLI not found" in c for c in calls)
+
+
+@patch("strawpot.cli.click.echo")
+@patch("strawpot.cli.subprocess.run")
+@patch("strawpot.cli.shutil.which", return_value="/usr/bin/strawhub")
+@patch("strawpot.cli.click.confirm", return_value=True)
+def test_ensure_role_install_fails(mock_confirm, mock_which, mock_run, mock_echo, tmp_path, monkeypatch):
+    """Shows error when install command fails."""
+    monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "global_home"))
+    mock_run.return_value = MagicMock(returncode=1)
+
+    _ensure_role_installed("ai-ceo", str(tmp_path / "project"))
+
+    calls = [str(c) for c in mock_echo.call_args_list]
+    assert any("Failed to install role" in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
 # auto_setup=True (headless mode)
 # ---------------------------------------------------------------------------
 
@@ -196,6 +283,20 @@ def test_ensure_skill_auto_setup_skips_confirm(mock_confirm, mock_which, mock_ru
     mock_run.return_value = MagicMock(returncode=0)
 
     _ensure_skill_installed("denden", str(tmp_path / "project"), auto_setup=True)
+
+    mock_confirm.assert_not_called()
+    mock_run.assert_called_once()
+
+
+@patch("strawpot.cli.subprocess.run")
+@patch("strawpot.cli.shutil.which", return_value="/usr/bin/strawhub")
+@patch("strawpot.cli.click.confirm")
+def test_ensure_role_auto_setup_skips_confirm(mock_confirm, mock_which, mock_run, tmp_path, monkeypatch):
+    """auto_setup=True installs role without prompting."""
+    monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "global_home"))
+    mock_run.return_value = MagicMock(returncode=0)
+
+    _ensure_role_installed("ai-ceo", str(tmp_path / "project"), auto_setup=True)
 
     mock_confirm.assert_not_called()
     mock_run.assert_called_once()

--- a/cli/tests/test_cli_headless.py
+++ b/cli/tests/test_cli_headless.py
@@ -13,6 +13,7 @@ from strawpot.cli import cli
 @patch("strawpot.cli.validate_agent")
 @patch("strawpot.cli.resolve_agent")
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.recover_stale_sessions", return_value=[])
@@ -22,6 +23,7 @@ def test_headless_missing_env_exits(
     mock_recover,
     mock_agent_install,
     mock_skill_install,
+    mock_role_install,
     mock_memory_install,
     mock_resolve,
     mock_validate,
@@ -60,6 +62,7 @@ def test_headless_missing_env_exits(
 @patch("strawpot.cli.validate_agent")
 @patch("strawpot.cli.resolve_agent")
 @patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
 @patch("strawpot.cli._ensure_skill_installed")
 @patch("strawpot.cli._ensure_agent_installed")
 @patch("strawpot.cli.recover_stale_sessions", return_value=[])
@@ -69,6 +72,7 @@ def test_headless_no_missing_env_proceeds(
     mock_recover,
     mock_agent_install,
     mock_skill_install,
+    mock_role_install,
     mock_memory_install,
     mock_resolve,
     mock_validate,

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -11,7 +11,7 @@ def test_defaults():
     assert config.runtime == "strawpot-claude-code"
     assert config.isolation == "none"
     assert config.denden_addr == "127.0.0.1:9700"
-    assert config.orchestrator_role == "orchestrator"
+    assert config.orchestrator_role == "ai-ceo"
     assert config.max_depth == 3
     assert config.permission_mode == "default"
     assert config.agent_timeout is None


### PR DESCRIPTION
## Summary
- Change default `orchestrator_role` from `"orchestrator"` to `"ai-ceo"` in `StrawPotConfig`
- Add `_ensure_role_installed()` bootstrap helper that checks for `ROLE.md` in project-local and global dirs, prompting to install from StrawHub if missing
- Call it during `strawpot start` bootstrap alongside existing agent/skill/memory ensure functions
- Supports `auto_setup=True` for headless mode (no interactive prompt)

## Test plan
- [x] All 54 affected tests pass (`test_config`, `test_cli`, `test_cli_bootstrap`, `test_cli_headless`)
- [ ] Verify `strawhub install role ai-ceo --global` works end-to-end with a published ai-ceo role
- [ ] Test interactive prompt flow (decline/accept)
- [ ] Test headless mode auto-installs without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)