### PR TITLE
Add React Flow agent tree with real-time SSE (Phase 4.2)

### DIFF
--- a/gui/frontend/package-lock.json
+++ b/gui/frontend/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "strawpot-gui-frontend",
       "dependencies": {
+        "@xyflow/react": "^12.10.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.0.0"
@@ -1194,6 +1195,55 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1205,7 +1255,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1240,6 +1290,38 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.1",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.1.tgz",
+      "integrity": "sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.75",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.75.tgz",
+      "integrity": "sha512-iXs+AGFLi8w/VlAoc/iSxk+CxfT6o64Uw/k0CKASOPqjqz6E0rb5jFZgJtXGZCpfQI6OQpu5EnumP5fGxQheaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1310,6 +1392,12 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1334,8 +1422,113 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1790,6 +1983,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
@@ -1871,6 +2073,34 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/gui/frontend/package.json
+++ b/gui/frontend/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@xyflow/react": "^12.10.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.0.0"

--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -49,3 +49,32 @@ export interface SessionDetail extends Session {
   agents: Record<string, AgentInfo>;
   events: TraceEvent[];
 }
+
+export interface TreeNode {
+  agent_id: string;
+  role: string;
+  runtime: string;
+  status: "running" | "completed" | "failed";
+  exit_code: number | null;
+  started_at: string | null;
+  duration_ms: number | null;
+  parent: string | null;
+}
+
+export interface PendingDelegation {
+  role: string;
+  requested_by: string | null;
+  span_id: string;
+}
+
+export interface DeniedDelegation {
+  role: string;
+  reason: string;
+  span_id: string;
+}
+
+export interface TreeData {
+  nodes: TreeNode[];
+  pending_delegations: PendingDelegation[];
+  denied_delegations: DeniedDelegation[];
+}

--- a/gui/frontend/src/components/AgentTreeFlow.tsx
+++ b/gui/frontend/src/components/AgentTreeFlow.tsx
@@ -1,0 +1,260 @@
+import { useMemo } from "react";
+import {
+  ReactFlow,
+  type Node,
+  type Edge,
+  type NodeProps,
+  Handle,
+  Position,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+
+import { useTreeSSE } from "../hooks/useTreeSSE";
+import { statusColor, formatDuration } from "./SessionTable";
+import type { TreeNode, PendingDelegation, DeniedDelegation } from "../api/types";
+
+const NODE_WIDTH = 180;
+const NODE_HEIGHT = 70;
+const H_GAP = 24;
+const V_GAP = 60;
+
+// ---- Custom node types ----
+
+type AgentNodeData = {
+  label: string;
+  role: string;
+  status: string;
+  runtime: string;
+  duration_ms: number | null;
+  exit_code: number | null;
+  pending?: boolean;
+};
+
+function AgentFlowNode({ data }: NodeProps<Node<AgentNodeData>>) {
+  const cls = data.pending
+    ? "agent-flow-node pending"
+    : `agent-flow-node ${statusColor(data.status)}`;
+
+  return (
+    <div className={cls}>
+      <Handle type="target" position={Position.Top} />
+      <div className="agent-flow-role">
+        {data.pending ? `[pending: ${data.role}]` : data.role}
+      </div>
+      {!data.pending && (
+        <div className="agent-flow-meta">
+          <span className={`status-dot ${statusColor(data.status)}`} />
+          <span>{data.status}</span>
+          {data.duration_ms != null && (
+            <span>{formatDuration(data.duration_ms)}</span>
+          )}
+          {data.exit_code != null && <span>exit {data.exit_code}</span>}
+        </div>
+      )}
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+}
+
+const nodeTypes = { agent: AgentFlowNode };
+
+// ---- Tree layout ----
+
+interface LayoutItem {
+  id: string;
+  children: LayoutItem[];
+}
+
+function buildLayoutTree(
+  nodes: TreeNode[],
+  pending: PendingDelegation[],
+): LayoutItem[] {
+  const byId = new Map(nodes.map((n) => [n.agent_id, n]));
+  const childrenOf = new Map<string | null, string[]>();
+
+  for (const n of nodes) {
+    const parent = n.parent;
+    if (!childrenOf.has(parent)) childrenOf.set(parent, []);
+    childrenOf.get(parent)!.push(n.agent_id);
+  }
+
+  // Attach pending delegations as pseudo-children
+  const pendingByParent = new Map<string, PendingDelegation[]>();
+  for (const p of pending) {
+    const parent = p.requested_by;
+    if (parent && byId.has(parent)) {
+      if (!pendingByParent.has(parent)) pendingByParent.set(parent, []);
+      pendingByParent.get(parent)!.push(p);
+    }
+  }
+
+  function build(id: string): LayoutItem {
+    const kids = (childrenOf.get(id) || []).map(build);
+    const pends = (pendingByParent.get(id) || []).map((p) => ({
+      id: `pending-${p.span_id}`,
+      children: [],
+    }));
+    return { id, children: [...kids, ...pends] };
+  }
+
+  const roots = childrenOf.get(null) || [];
+  return roots.map(build);
+}
+
+function subtreeWidth(item: LayoutItem): number {
+  if (item.children.length === 0) return NODE_WIDTH;
+  return item.children.reduce(
+    (sum, c) => sum + subtreeWidth(c) + H_GAP,
+    -H_GAP,
+  );
+}
+
+function assignPositions(
+  item: LayoutItem,
+  cx: number,
+  y: number,
+  positions: Map<string, { x: number; y: number }>,
+) {
+  positions.set(item.id, { x: cx - NODE_WIDTH / 2, y });
+  if (item.children.length === 0) return;
+
+  const totalW = subtreeWidth(item);
+  let startX = cx - totalW / 2;
+
+  for (const child of item.children) {
+    const w = subtreeWidth(child);
+    const childCx = startX + w / 2;
+    assignPositions(child, childCx, y + NODE_HEIGHT + V_GAP, positions);
+    startX += w + H_GAP;
+  }
+}
+
+// ---- Main component ----
+
+export default function AgentTreeFlow({ runId }: { runId: string }) {
+  const { tree, connected } = useTreeSSE(runId);
+
+  const { flowNodes, flowEdges } = useMemo(() => {
+    if (!tree) return { flowNodes: [], flowEdges: [] };
+
+    const layoutRoots = buildLayoutTree(tree.nodes, tree.pending_delegations);
+
+    // Compute positions
+    const positions = new Map<string, { x: number; y: number }>();
+    let offsetX = 0;
+    for (const root of layoutRoots) {
+      const w = subtreeWidth(root);
+      const cx = offsetX + w / 2;
+      assignPositions(root, cx, 0, positions);
+      offsetX += w + H_GAP * 2;
+    }
+
+    // Build flow nodes
+    const nodeMap = new Map(tree.nodes.map((n) => [n.agent_id, n]));
+    const pendingMap = new Map(
+      tree.pending_delegations.map((p) => [`pending-${p.span_id}`, p]),
+    );
+
+    const flowNodes: Node<AgentNodeData>[] = [];
+
+    for (const [id, pos] of positions) {
+      const agent = nodeMap.get(id);
+      const pend = pendingMap.get(id);
+
+      if (agent) {
+        flowNodes.push({
+          id,
+          type: "agent",
+          position: pos,
+          data: {
+            label: agent.role,
+            role: agent.role,
+            status: agent.status,
+            runtime: agent.runtime,
+            duration_ms: agent.duration_ms,
+            exit_code: agent.exit_code,
+          },
+        });
+      } else if (pend) {
+        flowNodes.push({
+          id,
+          type: "agent",
+          position: pos,
+          data: {
+            label: pend.role,
+            role: pend.role,
+            status: "running",
+            runtime: "",
+            duration_ms: null,
+            exit_code: null,
+            pending: true,
+          },
+        });
+      }
+    }
+
+    // Build edges
+    const flowEdges: Edge[] = [];
+    for (const n of tree.nodes) {
+      if (n.parent) {
+        flowEdges.push({
+          id: `e-${n.parent}-${n.agent_id}`,
+          source: n.parent,
+          target: n.agent_id,
+          type: "smoothstep",
+        });
+      }
+    }
+    for (const p of tree.pending_delegations) {
+      if (p.requested_by) {
+        flowEdges.push({
+          id: `e-${p.requested_by}-pending-${p.span_id}`,
+          source: p.requested_by,
+          target: `pending-${p.span_id}`,
+          type: "smoothstep",
+          style: { strokeDasharray: "5 3" },
+        });
+      }
+    }
+
+    return { flowNodes, flowEdges };
+  }, [tree]);
+
+  if (!tree) {
+    return (
+      <div className="agent-tree">
+        <p className="agent-meta">
+          {connected ? "Loading tree..." : "Connecting..."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="react-flow-wrapper">
+        <ReactFlow
+          nodes={flowNodes}
+          edges={flowEdges}
+          nodeTypes={nodeTypes}
+          fitView
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          proOptions={{ hideAttribution: true }}
+        />
+      </div>
+
+      {tree.denied_delegations.length > 0 && (
+        <div className="denied-list">
+          <strong>Denied delegations:</strong>
+          {tree.denied_delegations.map((d: DeniedDelegation) => (
+            <span key={d.span_id} className="denied-item">
+              {d.role} ({d.reason})
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gui/frontend/src/hooks/useTreeSSE.ts
+++ b/gui/frontend/src/hooks/useTreeSSE.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from "react";
+import type { TreeData } from "../api/types";
+
+export function useTreeSSE(runId: string): {
+  tree: TreeData | null;
+  connected: boolean;
+} {
+  const [tree, setTree] = useState<TreeData | null>(null);
+  const [connected, setConnected] = useState(false);
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    const es = new EventSource(`/api/sessions/${runId}/tree`);
+    esRef.current = es;
+
+    es.onopen = () => setConnected(true);
+
+    es.onmessage = (event) => {
+      try {
+        const data: TreeData = JSON.parse(event.data);
+        setTree(data);
+      } catch {
+        // ignore malformed data
+      }
+    };
+
+    es.onerror = () => {
+      setConnected(false);
+      // EventSource auto-reconnects
+    };
+
+    return () => {
+      es.close();
+      esRef.current = null;
+    };
+  }, [runId]);
+
+  return { tree, connected };
+}

--- a/gui/frontend/src/index.css
+++ b/gui/frontend/src/index.css
@@ -488,7 +488,7 @@
   word-break: break-word;
 }
 
-/* Agent tree */
+/* Agent tree (fallback / loading) */
 
 .agent-tree {
   background: #fff;
@@ -497,23 +497,108 @@
   padding: 0.75rem 1rem;
 }
 
-.agent-node {
-  padding: 0.25rem 0;
-}
-
-.agent-header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.agent-role {
-  font-weight: 600;
-  font-size: 0.9rem;
-}
-
 .agent-meta {
   font-size: 0.78rem;
   color: #888;
   font-family: monospace;
+}
+
+/* React Flow agent tree */
+
+.react-flow-wrapper {
+  height: 400px;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+}
+
+.agent-flow-node {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-left: 3px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  min-width: 150px;
+  font-size: 0.85rem;
+}
+
+.agent-flow-node.running {
+  border-left-color: #2e7d32;
+}
+
+.agent-flow-node.success {
+  border-left-color: #2e7d32;
+}
+
+.agent-flow-node.error {
+  border-left-color: #c62828;
+}
+
+.agent-flow-node.warning {
+  border-left-color: #e65100;
+}
+
+.agent-flow-node.pending {
+  border: 1px dashed #bbb;
+  border-left: 3px dashed #bbb;
+  color: #999;
+  background: #fafafa;
+}
+
+.agent-flow-role {
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-bottom: 0.15rem;
+}
+
+.agent-flow-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  color: #888;
+}
+
+.status-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #bbb;
+}
+
+.status-dot.running {
+  background: #2e7d32;
+}
+
+.status-dot.success {
+  background: #2e7d32;
+}
+
+.status-dot.error {
+  background: #c62828;
+}
+
+.status-dot.warning {
+  background: #e65100;
+}
+
+/* Denied delegations list */
+
+.denied-list {
+  margin-top: 0.5rem;
+  font-size: 0.82rem;
+  color: #888;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.denied-item {
+  background: #fbe9e7;
+  color: #c62828;
+  padding: 0.15rem 0.5rem;
+  border-radius: 10px;
+  font-size: 0.75rem;
 }

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { api } from "../api/client";
+import AgentTreeFlow from "../components/AgentTreeFlow";
 import { statusColor, formatTime, formatDuration } from "../components/SessionTable";
 import { useApi } from "../hooks/useApi";
-import type { AgentInfo, SessionDetail as SessionDetailType, TraceEvent } from "../api/types";
+import type { SessionDetail as SessionDetailType, TraceEvent } from "../api/types";
 
 export default function SessionDetail() {
   const { projectId, runId } = useParams();
@@ -88,12 +89,10 @@ export default function SessionDetail() {
         </section>
       )}
 
-      {Object.keys(session.agents).length > 0 && (
-        <section className="dashboard-section">
-          <h2>Agents ({Object.keys(session.agents).length})</h2>
-          <AgentTree agents={session.agents} />
-        </section>
-      )}
+      <section className="dashboard-section">
+        <h2>Agent Tree</h2>
+        <AgentTreeFlow runId={session.run_id} />
+      </section>
 
       {session.events.length > 0 && (
         <section className="dashboard-section">
@@ -116,32 +115,6 @@ function DetailRow({
     <div className="project-info-row">
       <span className="project-info-label">{label}</span>
       <span className="project-info-value">{children}</span>
-    </div>
-  );
-}
-
-function AgentTree({ agents }: { agents: Record<string, AgentInfo> }) {
-  // Find root agents (no parent), then render children recursively
-  const entries = Object.entries(agents);
-  const roots = entries.filter(([, a]) => !a.parent);
-
-  const renderAgent = (id: string, agent: AgentInfo, depth: number) => {
-    const children = entries.filter(([, a]) => a.parent === id);
-    return (
-      <div key={id} className="agent-node" style={{ marginLeft: depth * 20 }}>
-        <div className="agent-header">
-          <span className="agent-role">{agent.role}</span>
-          <span className="agent-meta">{agent.runtime}</span>
-          {agent.pid && <span className="agent-meta">PID {agent.pid}</span>}
-        </div>
-        {children.map(([cId, cAgent]) => renderAgent(cId, cAgent, depth + 1))}
-      </div>
-    );
-  };
-
-  return (
-    <div className="agent-tree">
-      {roots.map(([id, agent]) => renderAgent(id, agent, 0))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace static div-based agent tree with interactive React Flow visualization on SessionDetail page
- Add `useTreeSSE` hook connecting to the SSE endpoint (`GET /api/sessions/:id/tree`) for real-time agent lifecycle updates
- Custom tree layout algorithm (no dagre dependency) with status-colored nodes, pending delegation indicators (dashed borders), and denied delegation pills
- Add `@xyflow/react` dependency and `TreeData` types matching the backend SSE payload

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `python -m pytest gui/tests/ -v` — 98 backend tests pass
- [ ] Manual: open a session detail page → agent tree renders with nodes, edges, status colors
- [ ] Manual: verify real-time SSE updates when agents spawn/complete/fail
- [ ] Manual: verify pending delegations appear as dashed nodes, denied delegations as pills below tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)