### PR TITLE
Add ai-employee as default role to auto-install

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -273,6 +273,7 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task, head
     _ensure_agent_installed(config.runtime, working_dir, auto_setup=headless)
     _ensure_skill_installed("denden", working_dir, auto_setup=headless)
     _ensure_role_installed(config.orchestrator_role, working_dir, auto_setup=headless)
+    _ensure_role_installed("ai-employee", working_dir, auto_setup=headless)
     if config.memory:
         _ensure_memory_installed(config.memory, working_dir, auto_setup=headless)
 


### PR DESCRIPTION
## Summary
- Auto-install the `ai-employee` worker role alongside `ai-ceo` on first run
- Follows the existing bootstrap pattern in `_ensure_role_installed()`

## Test plan
- [x] All 37 existing CLI tests pass (bootstrap, cli, headless)
- [ ] Manual: run `strawpot start` in a fresh environment and verify both `ai-ceo` and `ai-employee` roles are installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)