### PR TITLE
Auto-poll session detail while status is active

### DIFF
--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { api } from "../api/client";
 import AgentTreeFlow from "../components/AgentTreeFlow";
@@ -12,6 +12,14 @@ export default function SessionDetail() {
     `/projects/${projectId}/sessions/${runId}`,
   );
   const [confirming, setConfirming] = useState(false);
+
+  // Auto-poll while session is active
+  const isActive = session?.status === "starting" || session?.status === "running";
+  useEffect(() => {
+    if (!isActive) return;
+    const id = setInterval(refetch, 2000);
+    return () => clearInterval(id);
+  }, [isActive, refetch]);
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p className="error">Error: {error}</p>;


### PR DESCRIPTION
## Summary
- SessionDetail page now auto-polls the API every 2s while session status is `starting` or `running`
- Polling stops automatically once the session reaches a terminal state (`completed`/`failed`/`stopped`)
- Fixes bug where status badge was stuck at "starting" and summary/duration never appeared

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `python -m pytest gui/tests/ -v` — 98 backend tests pass
- [ ] Manual: launch a session → status transitions from starting → running → completed automatically
- [ ] Manual: summary, exit code, duration, and trace events populate when session completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)