### PR TITLE
Fix SPA routing, polling flicker, and spawn role display

### DIFF
--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -851,6 +851,7 @@ def handle_delegate(
             tracer.agent_spawn(
                 span_id=delegate_span_id,
                 agent_id=agent_id,
+                role=request.role_slug,
                 runtime=runtime.name,
                 pid=handle.pid,
             )

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -417,6 +417,7 @@ class Session:
                 self._tracer.agent_spawn(
                     span_id=self._session_span_id,
                     agent_id=agent_id,
+                    role=self.config.orchestrator_role,
                     runtime=self.config.runtime,
                     pid=handle.pid,
                 )

--- a/cli/src/strawpot/trace.py
+++ b/cli/src/strawpot/trace.py
@@ -214,6 +214,7 @@ class Tracer:
         *,
         span_id: str,
         agent_id: str,
+        role: str,
         runtime: str,
         pid: int | None,
     ) -> None:
@@ -222,6 +223,7 @@ class Tracer:
             "agent_spawn",
             span_id,
             agent_id=agent_id,
+            role=role,
             runtime=runtime,
             pid=pid,
         )

--- a/cli/tests/test_trace.py
+++ b/cli/tests/test_trace.py
@@ -298,11 +298,12 @@ class TestAgentEvents:
         tracer, session_dir = _make_tracer(tmp_path)
         tracer.agent_spawn(
             span_id="s1", agent_id="agent_abc",
-            runtime="claude_code", pid=12345,
+            role="ai-ceo", runtime="claude_code", pid=12345,
         )
         events = _read_events(session_dir)
         assert events[0]["event"] == "agent_spawn"
         assert events[0]["data"]["agent_id"] == "agent_abc"
+        assert events[0]["data"]["role"] == "ai-ceo"
         assert events[0]["data"]["pid"] == 12345
 
     def test_agent_end_stores_output_artifact(self, tmp_path):

--- a/gui/frontend/src/hooks/useApi.ts
+++ b/gui/frontend/src/hooks/useApi.ts
@@ -18,7 +18,8 @@ export function useApi<T>(path: string): UseApiResult<T> {
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
+    // Only show loading spinner on initial fetch, not on refetches
+    if (tick === 0) setLoading(true);
     setError(null);
 
     api

--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -5,7 +5,8 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from strawpot.config import get_strawpot_home
@@ -56,9 +57,15 @@ def create_app(db_path: str | None = None) -> FastAPI:
     dev_dir = Path(__file__).resolve().parent.parent.parent / "frontend" / "dist"
     frontend_dir = static_dir if static_dir.is_dir() else dev_dir
     if frontend_dir.is_dir():
-        app.mount(
-            "/", StaticFiles(directory=str(frontend_dir), html=True),
-            name="frontend",
-        )
+        index_html = frontend_dir / "index.html"
+
+        # SPA catch-all: serve index.html for non-API, non-file routes
+        @app.get("/{full_path:path}")
+        async def spa_fallback(request: Request, full_path: str):
+            # Let static files (js, css, assets) be served directly
+            file_path = frontend_dir / full_path
+            if full_path and file_path.is_file():
+                return FileResponse(str(file_path))
+            return FileResponse(str(index_html))
 
     return app


### PR DESCRIPTION
## Summary
- **SPA catch-all route**: Browser refresh on deep paths (e.g. `/projects/1/sessions/run_abc`) no longer returns `{"detail":"Not Found"}` — serves `index.html` for all non-file routes
- **Polling flicker fix**: `useApi` only shows loading spinner on initial fetch, not on refetches — prevents page unmounting every 2 seconds during auto-poll
- **Spawn role in trace**: `agent_spawn` trace event now includes `role` field so the timeline shows which role was spawned

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `python -m pytest gui/tests/` — 98 tests pass
- [x] `python -m pytest cli/tests/test_trace.py` — 27 tests pass
- [ ] Manual: refresh browser on session detail page — page loads correctly
- [ ] Manual: session detail auto-polls without flashing/unmounting
- [ ] Manual: agent_spawn events in trace timeline show role name

🤖 Generated with [Claude Code](https://claude.com/claude-code)