### PR TITLE
Rename default agent from claude_code to strawpot-claude-code

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -15,7 +15,7 @@ strawpot start          ← CLI entry point, CWD = working dir
  ├─ DenDen gRPC server  ← listens on 127.0.0.1:9700
  │
  └─ Orchestrator agent   ← "hive mind" (Claude Code / Codex / OpenHands)
-      │                     runtime is user's choice, default: claude_code
+      │                     runtime is user's choice, default: strawpot-claude-code
       │  denden send '{"delegate": ...}'
       ▼
     StrawPot handles delegate:
@@ -391,7 +391,7 @@ Implementations:
 ```python
 @dataclass
 class StrawPotConfig:
-    runtime: str = "claude_code"
+    runtime: str = "strawpot-claude-code"
     isolation: str = "none"
     denden_addr: str = "127.0.0.1:9700"
     orchestrator_role: str = "orchestrator"
@@ -517,7 +517,7 @@ The span tree enables call-tree reconstruction:
 
 ```toml
 # strawpot.toml (project root)
-runtime = "claude_code"
+runtime = "strawpot-claude-code"
 isolation = "none"               # none | worktree | docker
 
 [denden]
@@ -538,7 +538,7 @@ pr_command = "gh pr create --base {base_branch} --head {session_branch}"
 
 # Agent-specific extras — keyed by agent name.
 # Only for config beyond the standard protocol args.
-[agents.claude_code]
+[agents."strawpot-claude-code"]
 model = "claude-sonnet-4-6"
 
 [agents.my_custom_agent]
@@ -551,7 +551,7 @@ GITHUB_TOKEN = "ghp_..."
 
 # Role overrides — override ROLE.md frontmatter settings.
 [roles.implementer]
-default_agent = "claude_code"
+default_agent = "strawpot-claude-code"
 
 # Tracing — JSONL events + content-addressed artifacts per session.
 # Default: enabled. Set to false to disable.
@@ -944,7 +944,7 @@ Agents install to `$STRAWPOT_HOME/agents/<name>/` (default: `~/.strawpot/agents/
 
 ```
 ~/.strawpot/agents/
-  claude_code/
+  strawpot-claude-code/
     AGENT.md               # manifest: wrapper config, params, env, install prereqs
     strawpot_claude_code   # compiled wrapper binary (bin.<os> mode)
   codex/
@@ -961,8 +961,8 @@ precedence over global installs.
 When an agent is installed, its manifest `metadata.strawpot.tools` is validated:
 
 ```
-Agent install example (claude_code):
-  1. Agent package downloaded to ~/.strawpot/agents/claude_code/
+Agent install example (strawpot-claude-code):
+  1. Agent package downloaded to ~/.strawpot/agents/strawpot-claude-code/
   2. Read AGENT.md metadata.strawpot.tools
   3. Detect current OS (platform.system() → macos/linux)
   4. For each command: shutil.which(cmd)
@@ -992,7 +992,7 @@ $ strawpot install-tools
 Scanning installed packages for required tools...
 
 Missing tools:
-  ✗ claude (required by: claude_code)
+  ✗ claude (required by: strawpot-claude-code)
     Install: npm install -g @anthropic-ai/claude-code
 
 Install missing tools? [y/N]
@@ -1031,7 +1031,7 @@ the process, tracking PIDs, waiting for completion, and cleanup.
 
 ---
 
-## Default Agent: claude_code
+## Default Agent: strawpot-claude-code
 
 Installed from StrawHub (`strawhub install agent strawpot_claude_code --global`).
 Serves as the default runtime and as a reference implementation for wrapper authors.
@@ -1375,7 +1375,7 @@ the same session directory:
   "run_id": "run_abc123",
   "working_dir": "/home/user/project",
   "isolation": "worktree",
-  "runtime": "claude_code",
+  "runtime": "strawpot-claude-code",
   "denden_addr": "127.0.0.1:9700",
   "worktree": "~/.strawpot/worktrees/<project_hash>/run_abc123",
   "worktree_branch": "strawpot/run_abc123",
@@ -1385,14 +1385,14 @@ the same session directory:
   "agents": {
     "agent_xyz": {
       "role": "orchestrator",
-      "runtime": "claude_code",
+      "runtime": "strawpot-claude-code",
       "parent": null,
       "started_at": "2026-02-27T10:00:01Z",
       "pid": 54322
     },
     "agent_abc": {
       "role": "implementer",
-      "runtime": "claude_code",
+      "runtime": "strawpot-claude-code",
       "parent": "agent_xyz",
       "started_at": "2026-02-27T10:01:00Z",
       "pid": 54330
@@ -1422,7 +1422,7 @@ One file per session: `.strawpot/sessions/<run_id>/session.jsonl`
 Each line is a JSON object:
 
 ```json
-{"ts": "2026-02-27T10:00:00Z", "level": "info", "event": "session_started", "run_id": "run_abc123", "msg": "Session started", "data": {"isolation": "worktree", "runtime": "claude_code"}}
+{"ts": "2026-02-27T10:00:00Z", "level": "info", "event": "session_started", "run_id": "run_abc123", "msg": "Session started", "data": {"isolation": "worktree", "runtime": "strawpot-claude-code"}}
 {"ts": "2026-02-27T10:00:01Z", "level": "info", "event": "agent_spawned", "run_id": "run_abc123", "agent_id": "agent_xyz", "msg": "Spawned orchestrator", "data": {"role": "orchestrator"}}
 {"ts": "2026-02-27T10:01:00Z", "level": "info", "event": "delegate_request", "run_id": "run_abc123", "agent_id": "agent_xyz", "msg": "Delegation requested", "data": {"role": "implementer", "task": "implement auth"}}
 {"ts": "2026-02-27T10:05:00Z", "level": "error", "event": "agent_timeout", "run_id": "run_abc123", "agent_id": "agent_abc", "msg": "Agent timed out after 300s"}
@@ -1499,7 +1499,7 @@ metadata:
         - code-review
       roles:
         - fixer
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ---
 
 # Implementer

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ metadata:
   strawpot:
     dependencies:
       roles: [pm, implementer, reviewer]
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ---
 
 # CEO
@@ -85,7 +85,7 @@ No Python. No orchestration code. One file.
 User task → StrawPot → Role (ai-ceo)
                          ├─ Sub-role (implementer)
                          │   ├─ Skills (git-workflow, python-dev)
-                         │   └─ Agent (claude_code)
+                         │   └─ Agent (strawpot-claude-code)
                          └─ Sub-role (reviewer)
                              ├─ Skills (code-review, security-baseline)
                              └─ Agent (gemini)
@@ -131,7 +131,7 @@ Role: implementer
 ```bash
 # Start a session
 strawpot start
-strawpot start --role ai-ceo --runtime claude_code
+strawpot start --role ai-ceo --runtime strawpot-claude-code
 
 # Install skills and roles from StrawHub
 strawpot install skill git-workflow
@@ -151,7 +151,7 @@ Global: `$STRAWPOT_HOME/strawpot.toml` (default `~/.strawpot/strawpot.toml`)
 Project: `strawpot.toml` (project root)
 
 ```toml
-runtime = "claude_code"       # claude_code | codex | gemini
+runtime = "strawpot-claude-code"       # strawpot-claude-code | codex | gemini
 isolation = "worktree"        # worktree | docker
 
 [denden]

--- a/cli/README.md
+++ b/cli/README.md
@@ -16,7 +16,7 @@ pip install strawpot
 ```bash
 # Start a session (foreground, interactive)
 strawpot start
-strawpot start --role team-lead --runtime claude_code
+strawpot start --role team-lead --runtime strawpot-claude-code
 
 # Install skills and roles from StrawHub
 strawpot install skill git-workflow
@@ -36,7 +36,7 @@ Global: `$STRAWPOT_HOME/strawpot.toml` (default `~/.strawpot/strawpot.toml`)
 Project: `strawpot.toml` (project root)
 
 ```toml
-runtime = "claude_code"       # claude_code | codex | openhands
+runtime = "strawpot-claude-code"       # strawpot-claude-code | codex | openhands
 isolation = "worktree"        # worktree | docker
 
 [denden]

--- a/cli/src/strawpot/agents/registry.py
+++ b/cli/src/strawpot/agents/registry.py
@@ -147,7 +147,7 @@ def resolve_agent(
         2. ``~/.strawpot/agents/<name>/AGENT.md`` (global install)
 
     Args:
-        name: Agent name (e.g. ``"claude_code"``).
+        name: Agent name (e.g. ``"strawpot-claude-code"``).
         project_dir: Project root directory.
         user_config: Per-agent config from ``[agents.<name>]`` in strawpot.toml.
 

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -11,7 +11,7 @@ from strawpot.cli import cli
 
 def _make_spec(**overrides):
     defaults = {
-        "name": "claude_code",
+        "name": "strawpot-claude-code",
         "version": "1.0.0",
         "wrapper_cmd": ["/usr/bin/test-wrapper"],
         "config": {},

--- a/cli/tests/test_cli_bootstrap.py
+++ b/cli/tests/test_cli_bootstrap.py
@@ -22,9 +22,9 @@ def test_ensure_agent_already_installed(mock_resolve):
     """No prompt when the agent is already installed."""
     mock_resolve.return_value = MagicMock()  # resolve succeeds
 
-    _ensure_agent_installed("claude_code", "/tmp/project")
+    _ensure_agent_installed("strawpot-claude-code", "/tmp/project")
 
-    mock_resolve.assert_called_once_with("claude_code", "/tmp/project")
+    mock_resolve.assert_called_once_with("strawpot-claude-code", "/tmp/project")
 
 
 @patch("strawpot.cli.subprocess.run")
@@ -35,12 +35,12 @@ def test_ensure_agent_installs_on_confirm(mock_resolve, mock_confirm, mock_which
     """Installs agent via strawhub when user confirms."""
     mock_run.return_value = MagicMock(returncode=0)
 
-    _ensure_agent_installed("claude_code", "/tmp/project")
+    _ensure_agent_installed("strawpot-claude-code", "/tmp/project")
 
     mock_confirm.assert_called_once()
     mock_run.assert_called_once()
     cmd = mock_run.call_args[0][0]
-    assert cmd == ["/usr/bin/strawhub", "install", "agent", "claude_code", "--global"]
+    assert cmd == ["/usr/bin/strawhub", "install", "agent", "strawpot-claude-code", "--global"]
 
 
 @patch("strawpot.cli.subprocess.run")
@@ -49,7 +49,7 @@ def test_ensure_agent_installs_on_confirm(mock_resolve, mock_confirm, mock_which
 @patch("strawpot.cli.resolve_agent", side_effect=FileNotFoundError("not found"))
 def test_ensure_agent_skips_on_decline(mock_resolve, mock_confirm, mock_which, mock_run):
     """Does nothing when user declines install."""
-    _ensure_agent_installed("claude_code", "/tmp/project")
+    _ensure_agent_installed("strawpot-claude-code", "/tmp/project")
 
     mock_confirm.assert_called_once()
     mock_run.assert_not_called()
@@ -61,7 +61,7 @@ def test_ensure_agent_skips_on_decline(mock_resolve, mock_confirm, mock_which, m
 @patch("strawpot.cli.resolve_agent", side_effect=FileNotFoundError("not found"))
 def test_ensure_agent_strawhub_not_found(mock_resolve, mock_confirm, mock_which, mock_echo):
     """Shows error when strawhub CLI is not on PATH."""
-    _ensure_agent_installed("claude_code", "/tmp/project")
+    _ensure_agent_installed("strawpot-claude-code", "/tmp/project")
 
     # Should print error about missing strawhub
     calls = [str(c) for c in mock_echo.call_args_list]
@@ -77,7 +77,7 @@ def test_ensure_agent_install_fails(mock_resolve, mock_confirm, mock_which, mock
     """Shows error when install command fails."""
     mock_run.return_value = MagicMock(returncode=1)
 
-    _ensure_agent_installed("claude_code", "/tmp/project")
+    _ensure_agent_installed("strawpot-claude-code", "/tmp/project")
 
     calls = [str(c) for c in mock_echo.call_args_list]
     assert any("Failed to install agent" in c for c in calls)
@@ -268,7 +268,7 @@ def test_ensure_agent_auto_setup_skips_confirm(mock_resolve, mock_confirm, mock_
     """auto_setup=True installs without prompting."""
     mock_run.return_value = MagicMock(returncode=0)
 
-    _ensure_agent_installed("claude_code", "/tmp/project", auto_setup=True)
+    _ensure_agent_installed("strawpot-claude-code", "/tmp/project", auto_setup=True)
 
     mock_confirm.assert_not_called()
     mock_run.assert_called_once()

--- a/cli/tests/test_cli_headless.py
+++ b/cli/tests/test_cli_headless.py
@@ -34,7 +34,7 @@ def test_headless_missing_env_exits(
     """Headless mode exits with error when agent has missing env vars."""
     mock_config.return_value = MagicMock(
         orchestrator_role="orchestrator",
-        runtime="claude_code",
+        runtime="strawpot-claude-code",
         isolation="none",
         merge_strategy="auto",
         pull_before_session="never",
@@ -83,7 +83,7 @@ def test_headless_no_missing_env_proceeds(
     """Headless mode proceeds when no env vars are missing."""
     mock_config.return_value = MagicMock(
         orchestrator_role="orchestrator",
-        runtime="claude_code",
+        runtime="strawpot-claude-code",
         isolation="none",
         merge_strategy="auto",
         pull_before_session="never",
@@ -115,7 +115,7 @@ def test_headless_passes_auto_setup_to_bootstrap(
     """Headless mode passes auto_setup=True to bootstrap helpers."""
     mock_config.return_value = MagicMock(
         orchestrator_role="orchestrator",
-        runtime="claude_code",
+        runtime="strawpot-claude-code",
         isolation="none",
         merge_strategy="auto",
         pull_before_session="never",

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -47,12 +47,12 @@ def test_load_config_global(tmp_path, monkeypatch):
     global_dir = tmp_path / "global"
     global_dir.mkdir()
     (global_dir / "strawpot.toml").write_text(
-        '[agents.claude_code]\nmodel = "claude-opus-4-6"\n'
+        '[agents."strawpot-claude-code"]\nmodel = "claude-opus-4-6"\n'
     )
     monkeypatch.setenv("STRAWPOT_HOME", str(global_dir))
 
     config = load_config(tmp_path / "project")
-    assert config.agents == {"claude_code": {"model": "claude-opus-4-6"}}
+    assert config.agents == {"strawpot-claude-code": {"model": "claude-opus-4-6"}}
     assert config.runtime == "strawpot-claude-code"  # default preserved
 
 
@@ -102,7 +102,7 @@ def test_load_config_full(tmp_path, monkeypatch):
         "[memory_config]\n"
         'storage_dir = "/custom/mem"\n'
         "\n"
-        "[agents.claude_code]\n"
+        '[agents."strawpot-claude-code"]\n'
         'model = "claude-sonnet-4-6"\n'
     )
 
@@ -115,7 +115,7 @@ def test_load_config_full(tmp_path, monkeypatch):
     assert config.permission_mode == "plan"
     assert config.agent_timeout == 300
     assert config.max_delegate_retries == 2
-    assert config.agents == {"claude_code": {"model": "claude-sonnet-4-6"}}
+    assert config.agents == {"strawpot-claude-code": {"model": "claude-sonnet-4-6"}}
     assert config.memory == "test-provider"
     assert config.memory_config == {"storage_dir": "/custom/mem"}
     assert config.merge_strategy == "pr"
@@ -151,19 +151,19 @@ def test_load_config_agents_merge(tmp_path, monkeypatch):
     global_dir = tmp_path / "global"
     global_dir.mkdir()
     (global_dir / "strawpot.toml").write_text(
-        '[agents.claude_code]\nmodel = "claude-opus-4-6"\ntimeout = 300\n'
+        '[agents."strawpot-claude-code"]\nmodel = "claude-opus-4-6"\ntimeout = 300\n'
     )
     monkeypatch.setenv("STRAWPOT_HOME", str(global_dir))
 
     project_dir = tmp_path / "project"
     project_dir.mkdir(parents=True)
     (project_dir / "strawpot.toml").write_text(
-        '[agents.claude_code]\nmodel = "claude-sonnet-4-6"\n'
+        '[agents."strawpot-claude-code"]\nmodel = "claude-sonnet-4-6"\n'
     )
 
     config = load_config(project_dir)
     assert config.agents == {
-        "claude_code": {"model": "claude-sonnet-4-6", "timeout": 300}
+        "strawpot-claude-code": {"model": "claude-sonnet-4-6", "timeout": 300}
     }
 
 
@@ -216,11 +216,11 @@ def test_load_config_roles(tmp_path, monkeypatch):
     project_dir.mkdir(parents=True)
     (project_dir / "strawpot.toml").write_text(
         "[roles.implementer]\n"
-        'default_agent = "claude_code"\n'
+        'default_agent = "strawpot-claude-code"\n'
     )
 
     config = load_config(project_dir)
-    assert config.roles == {"implementer": {"default_agent": "claude_code"}}
+    assert config.roles == {"implementer": {"default_agent": "strawpot-claude-code"}}
 
 
 def test_skills_env_merge_global_project(tmp_path, monkeypatch):
@@ -261,11 +261,11 @@ def test_roles_merge_global_project(tmp_path, monkeypatch):
     project_dir.mkdir(parents=True)
     (project_dir / "strawpot.toml").write_text(
         "[roles.implementer]\n"
-        'default_agent = "claude_code"\n'
+        'default_agent = "strawpot-claude-code"\n'
     )
 
     config = load_config(project_dir)
-    assert config.roles == {"implementer": {"default_agent": "claude_code"}}
+    assert config.roles == {"implementer": {"default_agent": "strawpot-claude-code"}}
 
 
 def test_trace_disabled_via_toml(tmp_path, monkeypatch):

--- a/cli/tests/test_trace.py
+++ b/cli/tests/test_trace.py
@@ -173,7 +173,7 @@ class TestSessionEvents:
         tracer, _ = _make_tracer(tmp_path)
         span_id = tracer.session_start(
             run_id="run_1", role="orchestrator",
-            runtime="claude_code", isolation="none",
+            runtime="strawpot-claude-code", isolation="none",
         )
         assert isinstance(span_id, str)
         assert len(span_id) == 12
@@ -182,7 +182,7 @@ class TestSessionEvents:
         tracer, session_dir = _make_tracer(tmp_path)
         tracer.session_start(
             run_id="run_1", role="orchestrator",
-            runtime="claude_code", isolation="worktree",
+            runtime="strawpot-claude-code", isolation="worktree",
         )
         events = _read_events(session_dir)
         assert len(events) == 1
@@ -298,7 +298,7 @@ class TestAgentEvents:
         tracer, session_dir = _make_tracer(tmp_path)
         tracer.agent_spawn(
             span_id="s1", agent_id="agent_abc",
-            role="ai-ceo", runtime="claude_code", pid=12345,
+            role="ai-ceo", runtime="strawpot-claude-code", pid=12345,
         )
         events = _read_events(session_dir)
         assert events[0]["event"] == "agent_spawn"

--- a/docs/agents/claude-code.mdx
+++ b/docs/agents/claude-code.mdx
@@ -17,9 +17,9 @@ Claude Code is the default agent runtime in StrawPot. It is installed from Straw
 
 ```toml
 # strawpot.toml (project root)
-runtime = "claude_code"
+runtime = "strawpot-claude-code"
 
-[agents.claude_code]
+[agents."strawpot-claude-code"]
 model = "claude-sonnet-4-6"
 ```
 
@@ -84,6 +84,6 @@ strawpot start
 
 # Start with a specific model
 strawpot start  # then set in config:
-# [agents.claude_code]
+# [agents."strawpot-claude-code"]
 # model = "claude-opus-4-6"
 ```

--- a/docs/cli/commands.mdx
+++ b/docs/cli/commands.mdx
@@ -20,7 +20,7 @@ strawpot start [options]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--role ROLE` | Orchestrator role slug | From config or `orchestrator` |
-| `--runtime RUNTIME` | Agent runtime name | From config or `claude_code` |
+| `--runtime RUNTIME` | Agent runtime name | From config or `strawpot-claude-code` |
 | `--isolation MODE` | Isolation strategy: `none`, `worktree`, `docker` | From config or `none` |
 | `--task TEXT` | Task for non-interactive mode (empty = interactive) | — |
 

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -20,8 +20,8 @@ Settings are merged in order (later overrides earlier):
 # strawpot.toml (project root)
 
 # Agent runtime to use for the orchestrator
-# Options: claude_code, codex, openhands, or any custom agent name
-runtime = "claude_code"
+# Options: strawpot-claude-code, codex, openhands, or any custom agent name
+runtime = "strawpot-claude-code"
 
 # Isolation strategy
 # Options: none, worktree, docker
@@ -77,7 +77,7 @@ em_tail_count = 20
 
 # ── Agent-Specific Config ────────────────────────────────
 # Keyed by agent name. Passed as --config JSON to the wrapper.
-[agents.claude_code]
+[agents."strawpot-claude-code"]
 model = "claude-sonnet-4-6"
 
 [agents.my_custom_agent]
@@ -95,7 +95,7 @@ SCANNER_API_KEY = "sk-..."
 # ── Role Overrides ───────────────────────────────────────
 # Override role settings from ROLE.md frontmatter.
 [roles.implementer]
-default_agent = "claude_code"
+default_agent = "strawpot-claude-code"
 
 # ── Tracing ──────────────────────────────────────────────
 # JSONL event stream + content-addressed artifacts per session.
@@ -129,7 +129,7 @@ Common examples:
 
 ```toml
 # Claude Code
-[agents.claude_code]
+[agents."strawpot-claude-code"]
 model = "claude-sonnet-4-6"
 
 # Custom agent with API endpoint
@@ -168,7 +168,7 @@ Override role settings from `ROLE.md` frontmatter via `[roles.<slug>]` sections.
 
 ```toml
 [roles.implementer]
-default_agent = "claude_code"
+default_agent = "strawpot-claude-code"
 ```
 
 This takes precedence over the `default_agent` field in the role's `ROLE.md` frontmatter. The same global/project merge hierarchy applies.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -48,7 +48,7 @@ strawpot start --role team-lead
 strawpot start --isolation worktree
 
 # Use a specific agent runtime
-strawpot start --runtime claude_code
+strawpot start --runtime strawpot-claude-code
 
 # Non-interactive mode with a task
 strawpot start --task "Fix the failing tests in src/auth.py"
@@ -75,7 +75,7 @@ Create a project-level config file:
 
 ```toml
 # strawpot.toml (project root)
-runtime = "claude_code"
+runtime = "strawpot-claude-code"
 isolation = "worktree"
 
 [orchestrator]
@@ -84,7 +84,7 @@ role = "team-lead"
 [policy]
 max_depth = 3
 
-[agents.claude_code]
+[agents."strawpot-claude-code"]
 model = "claude-sonnet-4-6"
 
 [memory]

--- a/docs/strawhub/concepts/roles.mdx
+++ b/docs/strawhub/concepts/roles.mdx
@@ -22,7 +22,7 @@ metadata:
         - python-testing
       roles:
         - reviewer
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ---
 
 # Implementer
@@ -71,7 +71,7 @@ Roles can specify a default agent runtime:
 ```yaml
 metadata:
   strawpot:
-    default_agent: claude_code
+    default_agent: strawpot-claude-code
 ```
 
 This can be overridden by the user's `runtime` config in their StrawPot configuration.

--- a/docs/strawhub/publishing/frontmatter.mdx
+++ b/docs/strawhub/publishing/frontmatter.mdx
@@ -60,7 +60,7 @@ metadata:
         - code-review
       roles:                                #   role dependencies
         - reviewer
-    default_agent: claude_code               # Optional: default agent runtime
+    default_agent: strawpot-claude-code               # Optional: default agent runtime
 ---
 
 # Role Title

--- a/gui/DESIGN.md
+++ b/gui/DESIGN.md
@@ -103,7 +103,7 @@ Location: `.strawpot/sessions/<run_id>/session.json`
   "run_id": "a1b2c3d4e5f6",
   "working_dir": "/path/to/project",
   "isolation": "none | worktree",
-  "runtime": "claude_code",
+  "runtime": "strawpot-claude-code",
   "denden_addr": "127.0.0.1:9700",
   "started_at": "2026-01-01T12:00:00+00:00",
   "pid": 12345,
@@ -113,7 +113,7 @@ Location: `.strawpot/sessions/<run_id>/session.json`
   "agents": {
     "agent_abc123": {
       "role": "orchestrator",
-      "runtime": "claude_code",
+      "runtime": "strawpot-claude-code",
       "parent": null,
       "started_at": "2026-01-01T12:00:01+00:00",
       "pid": 12346
@@ -176,7 +176,7 @@ Project: `<project>/strawpot.toml` (overrides global)
 
 | Field | Type | Default |
 |-------|------|---------|
-| `runtime` | str | `"claude_code"` |
+| `runtime` | str | `"strawpot-claude-code"` |
 | `isolation` | str | `"none"` |
 | `denden_addr` | str | `"127.0.0.1:9700"` |
 | `orchestrator_role` | str | `"orchestrator"` |
@@ -377,7 +377,7 @@ All SSE endpoints follow the same reconnection protocol:
     {
       "agent_id": "agent_abc123",
       "role": "orchestrator",
-      "runtime": "claude_code",
+      "runtime": "strawpot-claude-code",
       "status": "running",
       "exit_code": null,
       "started_at": "2026-01-01T12:00:01+00:00",
@@ -387,7 +387,7 @@ All SSE endpoints follow the same reconnection protocol:
     {
       "agent_id": "agent_def456",
       "role": "implementer",
-      "runtime": "claude_code",
+      "runtime": "strawpot-claude-code",
       "status": "completed",
       "exit_code": 0,
       "started_at": "2026-01-01T12:00:10+00:00",

--- a/gui/frontend/src/pages/ProjectDetail.tsx
+++ b/gui/frontend/src/pages/ProjectDetail.tsx
@@ -201,10 +201,10 @@ function LaunchForm({
               onChange={(e) => setRuntime(e.target.value)}
             >
               <option value="">
-                {defaults?.runtime ?? "claude_code"}
+                {defaults?.runtime ?? "strawpot-claude-code"}
               </option>
-              {["claude_code"]
-                .filter((v) => v !== (defaults?.runtime ?? "claude_code"))
+              {["strawpot-claude-code"]
+                .filter((v) => v !== (defaults?.runtime ?? "strawpot-claude-code"))
                 .map((v) => (
                   <option key={v} value={v}>
                     {v}

--- a/gui/tests/test_session_tree_sse.py
+++ b/gui/tests/test_session_tree_sse.py
@@ -33,7 +33,7 @@ class TestTreeSSETerminalSession:
             {"ts": "T1", "event": "session_start", "trace_id": "run_tree1",
              "span_id": "s0", "data": {"run_id": "run_tree1",
                                         "role": "orchestrator",
-                                        "runtime": "claude_code",
+                                        "runtime": "strawpot-claude-code",
                                         "isolation": "none"}},
             {"ts": "T2", "event": "delegate_end", "trace_id": "run_tree1",
              "span_id": "s0", "parent_span": None,

--- a/gui/tests/test_sessions_sync.py
+++ b/gui/tests/test_sessions_sync.py
@@ -31,14 +31,14 @@ def _write_session(base_dir, run_id, *, archived=False, **overrides):
         "run_id": run_id,
         "working_dir": str(base_dir),
         "isolation": "none",
-        "runtime": "claude_code",
+        "runtime": "strawpot-claude-code",
         "denden_addr": "127.0.0.1:9700",
         "started_at": "2026-01-01T12:00:00+00:00",
         "pid": 999999,
         "agents": {
             "agent_abc": {
                 "role": "orchestrator",
-                "runtime": "claude_code",
+                "runtime": "strawpot-claude-code",
                 "parent": None,
                 "started_at": "2026-01-01T12:00:01+00:00",
                 "pid": 999998,
@@ -151,7 +151,7 @@ class TestSyncSessions:
         assert row is not None
         assert row["project_id"] == pid
         assert row["role"] == "orchestrator"
-        assert row["runtime"] == "claude_code"
+        assert row["runtime"] == "strawpot-claude-code"
         assert row["isolation"] == "none"
         assert row["status"] == "failed"  # no trace → failed
 
@@ -169,7 +169,7 @@ class TestSyncSessions:
                 "trace_id": "run_traced",
                 "span_id": "s1",
                 "data": {"run_id": "run_traced", "role": "orchestrator",
-                         "runtime": "claude_code", "isolation": "none"},
+                         "runtime": "strawpot-claude-code", "isolation": "none"},
             },
             {
                 "ts": "2026-01-01T12:05:00+00:00",

--- a/gui/tests/test_sse_unit.py
+++ b/gui/tests/test_sse_unit.py
@@ -24,7 +24,7 @@ class TestTreeStateSessionJson:
             "agents": {
                 "agent_root": {
                     "role": "orchestrator",
-                    "runtime": "claude_code",
+                    "runtime": "strawpot-claude-code",
                     "parent": None,
                     "started_at": "T0",
                 }
@@ -41,7 +41,7 @@ class TestTreeStateSessionJson:
             "agents": {
                 "agent_root": {
                     "role": "orchestrator",
-                    "runtime": "claude_code",
+                    "runtime": "strawpot-claude-code",
                     "parent": None,
                     "started_at": "T0",
                 }
@@ -211,7 +211,7 @@ class TestTreeStateFullLifecycle:
             "agents": {
                 "agent_root": {
                     "role": "orchestrator",
-                    "runtime": "claude_code",
+                    "runtime": "strawpot-claude-code",
                     "parent": None,
                     "started_at": "T0",
                     "pid": 100,


### PR DESCRIPTION
## Summary
- Rename all occurrences of `claude_code` (agent/runtime identifier) to `strawpot-claude-code` across docs, tests, and GUI
- Aligns with the actual default value already set in `config.py`
- The compiled binary `strawpot_claude_code` is unchanged

**20 files updated:** DESIGN.md, README, docs (7 files), CLI tests (5 files), GUI frontend + tests (3 files), registry docstring, cli/README

## Test plan
- [ ] Run `pytest cli/tests/` to verify test string updates are correct
- [ ] Run `pytest gui/tests/` to verify GUI test updates
- [ ] Verify `strawpot start` still defaults to the correct agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)