### PR TITLE
Fix SSE, add artifacts viewer, fix delegation role discovery

### DIFF
--- a/cli/src/strawpot/agents/wrapper.py
+++ b/cli/src/strawpot/agents/wrapper.py
@@ -7,6 +7,7 @@ WrapperRuntime — wrappers never manage processes.
 """
 
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -15,6 +16,8 @@ import time
 from strawpot._process import is_pid_alive, kill_process_tree
 from strawpot.agents.protocol import AgentHandle, AgentResult
 from strawpot.agents.registry import AgentSpec
+
+logger = logging.getLogger(__name__)
 
 
 class WrapperRuntime:
@@ -175,9 +178,18 @@ class WrapperRuntime:
         for rd in roles_dirs:
             args.extend(["--roles-dir", rd])
 
+        logger.debug(
+            "spawn agent_id=%s working_dir=%s agent_workspace_dir=%s "
+            "skills_dir=%s roles_dirs=%s task_len=%d role_prompt_len=%d",
+            agent_id, working_dir, agent_workspace_dir,
+            skills_dir, roles_dirs, len(task), len(role_prompt),
+        )
+
         data = self._run_subcommand(args, extra_env=env)
         agent_cmd = data["cmd"]
         cwd = data.get("cwd", working_dir)
+
+        logger.debug("wrapper build returned cmd=%s cwd=%s", agent_cmd, cwd)
 
         # 2. Launch via Popen
         log_path = self._log_file(agent_id)

--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -241,10 +241,11 @@ def discover_global_skills(
     for entry in sorted(skills_dir.iterdir()):
         if not entry.is_dir():
             continue
-        parsed = parse_dir_name(entry.name)
-        if parsed is None:
+        skill_md = entry / "SKILL.md"
+        if not skill_md.is_file():
             continue
-        slug, _version = parsed
+        parsed = parse_dir_name(entry.name)
+        slug = parsed[0] if parsed else entry.name
         if slug in resolved_slugs:
             continue
         validate_frontmatter_slug(str(entry), slug, "skill")
@@ -258,6 +259,8 @@ def _discover_all_roles() -> list[tuple[str, str]]:
     """Discover all globally installed roles.
 
     Scans ``~/.strawpot/roles/`` for installed role directories.
+    Accepts both plain slug directories (``ai-ceo``) and versioned
+    directories (``ai-ceo-1.0.0``).
 
     Returns:
         List of (slug, path) tuples for each installed role.
@@ -272,10 +275,11 @@ def _discover_all_roles() -> list[tuple[str, str]]:
     for entry in sorted(roles_dir.iterdir()):
         if not entry.is_dir():
             continue
-        parsed = parse_dir_name(entry.name)
-        if parsed is None:
+        role_md = entry / "ROLE.md"
+        if not role_md.is_file():
             continue
-        slug, _version = parsed
+        parsed = parse_dir_name(entry.name)
+        slug = parsed[0] if parsed else entry.name
         roles.append((slug, str(entry)))
     return roles
 

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -28,7 +28,10 @@ from strawpot.context import build_prompt
 from strawpot.delegation import (
     DelegateRequest,
     PolicyDenied,
+    _build_delegatable_roles,
+    _discover_all_roles,
     _format_memory_prompt,
+    _parse_role_deps,
     create_agent_workspace,
     discover_global_skills,
     handle_delegate,
@@ -332,6 +335,7 @@ class Session:
                 role=self.config.orchestrator_role,
                 runtime=self.config.runtime,
                 isolation=self.config.isolation,
+                task=self.task or "",
             )
             self._session_start_time = time.monotonic()
 
@@ -359,8 +363,20 @@ class Session:
                 self.config.orchestrator_role, kind="role"
             )
             global_skills = discover_global_skills(resolved)
+
+            # Build delegatable roles so the orchestrator prompt lists them
+            _, role_dep_slugs, wildcard = _parse_role_deps(resolved["path"])
+            if wildcard:
+                role_dep_slugs = [slug for slug, _ in _discover_all_roles()]
+            delegatable = _build_delegatable_roles(
+                role_dep_slugs,
+                self.config.orchestrator_role,
+                self._resolve_role_dirs,
+            )
+
             role_prompt = build_prompt(
                 resolved,
+                delegatable_roles=delegatable or None,
                 global_skills=[(s, d) for s, d, _ in global_skills] or None,
             )
 
@@ -415,12 +431,16 @@ class Session:
             )
             self._orchestrator_handle = handle
             if self._tracer is not None:
+                agent_context = role_prompt
+                if memory_prompt:
+                    agent_context += "\n\n" + memory_prompt
                 self._tracer.agent_spawn(
                     span_id=self._session_span_id,
                     agent_id=agent_id,
                     role=self.config.orchestrator_role,
                     runtime=self.config.runtime,
                     pid=handle.pid,
+                    context=agent_context,
                 )
                 self._agent_spans[agent_id] = self._session_span_id
             self._register_agent(
@@ -475,10 +495,15 @@ class Session:
                 except Exception:
                     logger.debug("Orchestrator memory.dump failed", exc_info=True)
                 if self._tracer is not None and self._session_span_id is not None:
+                    dump_summary = (
+                        f"task: {self.task or ''}\n"
+                        f"status: {status}\n"
+                        f"output:\n{output}"
+                    )
                     self._tracer.memory_dump(
                         span_id=self._session_span_id,
                         provider=self._memory_provider.name,
-                        entries=output,
+                        entries=dump_summary,
                         entry_count=1,
                     )
 
@@ -487,10 +512,12 @@ class Session:
             duration_ms = int(
                 (time.monotonic() - self._session_start_time) * 1000
             )
+            result = self._orchestrator_result
             self._tracer.session_end(
                 span_id=self._session_span_id,
                 merge_strategy=self.config.merge_strategy,
                 duration_ms=duration_ms,
+                output=result.output if result else "",
             )
 
         # 1. Kill remaining sub-agents

--- a/cli/src/strawpot/trace.py
+++ b/cli/src/strawpot/trace.py
@@ -102,10 +102,12 @@ class Tracer:
     # ------------------------------------------------------------------
 
     def session_start(
-        self, *, run_id: str, role: str, runtime: str, isolation: str
+        self, *, run_id: str, role: str, runtime: str, isolation: str,
+        task: str = "",
     ) -> str:
-        """Emit ``session_start``.  Returns the root span_id."""
+        """Emit ``session_start``.  Stores task as artifact.  Returns the root span_id."""
         span_id = self._new_span_id()
+        task_ref = self.store_artifact(task)
         self.emit(
             "session_start",
             span_id,
@@ -113,18 +115,22 @@ class Tracer:
             role=role,
             runtime=runtime,
             isolation=isolation,
+            task_ref=task_ref,
         )
         return span_id
 
     def session_end(
-        self, *, span_id: str, merge_strategy: str, duration_ms: int
+        self, *, span_id: str, merge_strategy: str, duration_ms: int,
+        output: str = "",
     ) -> None:
-        """Emit ``session_end``."""
+        """Emit ``session_end``.  Stores output as artifact."""
+        output_ref = self.store_artifact(output)
         self.emit(
             "session_end",
             span_id,
             merge_strategy=merge_strategy,
             duration_ms=duration_ms,
+            output_ref=output_ref,
         )
 
     def delegate_start(
@@ -220,8 +226,10 @@ class Tracer:
         role: str,
         runtime: str,
         pid: int | None,
+        context: str = "",
     ) -> None:
-        """Emit ``agent_spawn``."""
+        """Emit ``agent_spawn``.  Stores context as artifact."""
+        context_ref = self.store_artifact(context)
         self.emit(
             "agent_spawn",
             span_id,
@@ -229,6 +237,7 @@ class Tracer:
             role=role,
             runtime=runtime,
             pid=pid,
+            context_ref=context_ref,
         )
 
     def agent_end(

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -666,12 +666,50 @@ class TestDiscoverAllRoles:
         monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "empty"))
         assert _discover_all_roles() == []
 
+    def test_discovers_unversioned_roles(self, tmp_path, monkeypatch):
+        """Finds roles installed as plain slug directories (no version)."""
+        global_home = tmp_path / "global_home"
+        roles_dir = global_home / "roles"
+        for slug in ["ai-ceo", "ai-employee"]:
+            d = roles_dir / slug
+            d.mkdir(parents=True)
+            (d / "ROLE.md").write_text(f"---\nname: {slug}\n---\nBody.\n")
+        monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
+
+        result = _discover_all_roles()
+        slugs = [s for s, _ in result]
+        assert "ai-ceo" in slugs
+        assert "ai-employee" in slugs
+
+    def test_discovers_mixed_versioned_and_unversioned(self, tmp_path, monkeypatch):
+        """Finds both versioned and unversioned role directories."""
+        global_home = tmp_path / "global_home"
+        roles_dir = global_home / "roles"
+        (roles_dir / "reviewer-1.0.0").mkdir(parents=True)
+        (roles_dir / "reviewer-1.0.0" / "ROLE.md").write_text("---\nname: reviewer\n---\n")
+        (roles_dir / "ai-employee").mkdir(parents=True)
+        (roles_dir / "ai-employee" / "ROLE.md").write_text("---\nname: ai-employee\n---\n")
+        monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
+
+        result = _discover_all_roles()
+        slugs = [s for s, _ in result]
+        assert "reviewer" in slugs
+        assert "ai-employee" in slugs
+
     def test_skips_non_dirs(self, tmp_path, monkeypatch):
         """Skips non-directory entries in roles dir."""
         global_home = tmp_path / "global_home"
         roles_dir = global_home / "roles"
         roles_dir.mkdir(parents=True)
         (roles_dir / "not-a-dir.txt").write_text("junk")
+        monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
+        assert _discover_all_roles() == []
+
+    def test_skips_dirs_without_role_md(self, tmp_path, monkeypatch):
+        """Skips directories that don't contain ROLE.md."""
+        global_home = tmp_path / "global_home"
+        roles_dir = global_home / "roles"
+        (roles_dir / "empty-dir").mkdir(parents=True)
         monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
         assert _discover_all_roles() == []
 
@@ -1776,6 +1814,26 @@ class TestDiscoverGlobalSkills:
         result = discover_global_skills(resolved)
         assert len(result) == 1
         assert result[0][0] == "formatter"
+
+    def test_discovers_unversioned_skills(self, tmp_path, monkeypatch):
+        """Finds skills installed as plain slug directories (no version)."""
+        global_dir = str(tmp_path / "global")
+        monkeypatch.setenv("STRAWPOT_HOME", global_dir)
+        d = os.path.join(global_dir, "skills", "denden")
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "SKILL.md"), "w") as f:
+            f.write("---\nname: denden\ndescription: Agent comms\n---\n# denden\n")
+
+        role_path = _write_role(str(tmp_path), "worker")
+        resolved = {
+            "slug": "worker", "kind": "role", "version": "1.0.0",
+            "path": role_path, "source": "local", "dependencies": [],
+        }
+
+        result = discover_global_skills(resolved)
+        assert len(result) == 1
+        assert result[0][0] == "denden"
+        assert result[0][1] == "Agent comms"
 
     def test_empty_when_no_dir(self, tmp_path, monkeypatch):
         """Returns empty when ~/.strawpot/skills/ doesn't exist."""

--- a/cli/tests/test_trace.py
+++ b/cli/tests/test_trace.py
@@ -3,6 +3,7 @@
 import json
 import os
 import stat
+from pathlib import Path
 
 import pytest
 
@@ -183,12 +184,17 @@ class TestSessionEvents:
         tracer.session_start(
             run_id="run_1", role="orchestrator",
             runtime="strawpot-claude-code", isolation="worktree",
+            task="Fix the bug",
         )
         events = _read_events(session_dir)
         assert len(events) == 1
         assert events[0]["event"] == "session_start"
         assert events[0]["data"]["role"] == "orchestrator"
         assert events[0]["data"]["isolation"] == "worktree"
+        assert events[0]["data"]["task_ref"] is not None
+        # Verify artifact was stored
+        artifact_path = Path(session_dir) / "artifacts" / events[0]["data"]["task_ref"]
+        assert artifact_path.read_text() == "Fix the bug"
 
     def test_session_end_event_written(self, tmp_path):
         tracer, session_dir = _make_tracer(tmp_path)
@@ -197,11 +203,15 @@ class TestSessionEvents:
         )
         tracer.session_end(
             span_id=span_id, merge_strategy="local", duration_ms=5000,
+            output="Task completed successfully.",
         )
         events = _read_events(session_dir)
         assert events[1]["event"] == "session_end"
         assert events[1]["data"]["duration_ms"] == 5000
         assert events[1]["data"]["merge_strategy"] == "local"
+        assert events[1]["data"]["output_ref"] is not None
+        artifact_path = Path(session_dir) / "artifacts" / events[1]["data"]["output_ref"]
+        assert artifact_path.read_text() == "Task completed successfully."
 
 
 # ---------------------------------------------------------------------------
@@ -305,12 +315,16 @@ class TestAgentEvents:
         tracer.agent_spawn(
             span_id="s1", agent_id="agent_abc",
             role="ai-ceo", runtime="strawpot-claude-code", pid=12345,
+            context="You are the CEO agent.",
         )
         events = _read_events(session_dir)
         assert events[0]["event"] == "agent_spawn"
         assert events[0]["data"]["agent_id"] == "agent_abc"
         assert events[0]["data"]["role"] == "ai-ceo"
         assert events[0]["data"]["pid"] == 12345
+        assert events[0]["data"]["context_ref"] is not None
+        artifact_path = Path(session_dir) / "artifacts" / events[0]["data"]["context_ref"]
+        assert artifact_path.read_text() == "You are the CEO agent."
 
     def test_agent_end_stores_output_artifact(self, tmp_path):
         tracer, session_dir = _make_tracer(tmp_path)

--- a/gui/frontend/src/hooks/useTraceSSE.ts
+++ b/gui/frontend/src/hooks/useTraceSSE.ts
@@ -8,9 +8,16 @@ export function useTraceSSE(
   const [events, setEvents] = useState<TraceEvent[]>([]);
   const [connected, setConnected] = useState(false);
   const esRef = useRef<EventSource | null>(null);
+  const prevRunIdRef = useRef<string>("");
 
   useEffect(() => {
     if (!active) return;
+
+    // Only reset events when runId changes
+    if (prevRunIdRef.current !== runId) {
+      setEvents([]);
+      prevRunIdRef.current = runId;
+    }
 
     const es = new EventSource(`/api/sessions/${runId}/events`);
     esRef.current = es;
@@ -21,7 +28,8 @@ export function useTraceSSE(
       try {
         const data = JSON.parse(msg.data);
         if (data.events && Array.isArray(data.events)) {
-          setEvents((prev) => [...prev, ...data.events]);
+          // Backend sends full snapshot each time — replace, don't append
+          setEvents(data.events);
         }
       } catch {
         // ignore malformed data
@@ -29,6 +37,9 @@ export function useTraceSSE(
     };
 
     es.onerror = () => {
+      // Server closed the stream (session ended) — stop reconnecting
+      es.close();
+      esRef.current = null;
       setConnected(false);
     };
 

--- a/gui/frontend/src/index.css
+++ b/gui/frontend/src/index.css
@@ -134,9 +134,26 @@
   margin-right: 0.25rem;
 }
 
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
 .badge-running {
   background: #e8f5e9;
   color: #2e7d32;
+}
+
+.badge-running::before {
+  content: "";
+  display: inline-block;
+  width: 0.6em;
+  height: 0.6em;
+  margin-right: 0.35em;
+  border: 1.5px solid #a5d6a7;
+  border-top-color: #2e7d32;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  vertical-align: middle;
 }
 
 .badge-success {
@@ -647,4 +664,60 @@
 .delegate-summary {
   font-style: italic;
   color: #333;
+}
+
+/* Artifact list — expandable sections */
+
+.artifact-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.artifact-item {
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.artifact-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: #f5f5f5;
+  border: none;
+  cursor: pointer;
+  font-size: 0.85rem;
+  text-align: left;
+}
+
+.artifact-toggle:hover {
+  background: #eeeeee;
+}
+
+.artifact-icon {
+  font-size: 0.7rem;
+  color: #666;
+  flex-shrink: 0;
+}
+
+.artifact-label {
+  font-weight: 500;
+  color: #1565c0;
+}
+
+.artifact-item .artifact-content {
+  border: none;
+  border-top: 1px solid #e0e0e0;
+  border-radius: 0;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.loading-text {
+  padding: 0.75rem;
+  color: #666;
+  font-size: 0.85rem;
 }

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { api } from "../api/client";
 import AgentTreeFlow from "../components/AgentTreeFlow";
@@ -18,20 +18,22 @@ export default function SessionDetail() {
   const isActive = session?.status === "starting" || session?.status === "running";
   useEffect(() => {
     if (!isActive) return;
-    const id = setInterval(refetch, 5000);
+    const id = setInterval(refetch, 2000);
     return () => clearInterval(id);
   }, [isActive, refetch]);
 
   // SSE for live trace events on active sessions
   const { events: sseEvents } = useTraceSSE(runId ?? "", isActive);
-  const displayEvents = useMemo<TraceEvent[]>(() => {
-    if (isActive && sseEvents.length > 0) return sseEvents;
-    return session?.events ?? [];
-  }, [isActive, sseEvents, session?.events]);
+  const restEvents = session?.events ?? [];
+  // SSE sends full snapshots — prefer SSE when it has data, else REST
+  const displayEvents = sseEvents.length > 0 ? sseEvents : restEvents;
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p className="error">Error: {error}</p>;
   if (!session) return <p className="error">Session not found</p>;
+
+  // Extract key artifacts from trace events
+  const artifacts = extractArtifacts(displayEvents);
 
   return (
     <div>
@@ -105,6 +107,13 @@ export default function SessionDetail() {
         </section>
       )}
 
+      {artifacts.length > 0 && (
+        <section className="dashboard-section">
+          <h2>Artifacts</h2>
+          <ArtifactList artifacts={artifacts} runId={session.run_id} />
+        </section>
+      )}
+
       <section className="dashboard-section">
         <h2>Agent Tree</h2>
         <AgentTreeFlow runId={session.run_id} />
@@ -120,6 +129,134 @@ export default function SessionDetail() {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Artifact extraction from trace events
+// ---------------------------------------------------------------------------
+
+interface ArtifactEntry {
+  label: string;
+  hash: string;
+  event: string;
+  agentId?: string;
+}
+
+function extractArtifacts(events: TraceEvent[]): ArtifactEntry[] {
+  const artifacts: ArtifactEntry[] = [];
+  for (const e of events) {
+    const d = e.data;
+    if (e.event === "agent_spawn" && d.context_ref) {
+      artifacts.push({
+        label: `Agent Context (${d.role || "agent"})`,
+        hash: String(d.context_ref),
+        event: e.event,
+        agentId: d.agent_id ? String(d.agent_id) : undefined,
+      });
+    }
+    if (e.event === "session_end" && d.output_ref) {
+      artifacts.push({
+        label: "Session Output",
+        hash: String(d.output_ref),
+        event: e.event,
+      });
+    }
+    if (e.event === "agent_end" && d.output_ref) {
+      artifacts.push({
+        label: `Agent Output (${d.agent_id || "agent"})`,
+        hash: String(d.output_ref),
+        event: e.event,
+        agentId: d.agent_id ? String(d.agent_id) : undefined,
+      });
+    }
+    if (e.event === "memory_get" && d.cards_ref) {
+      artifacts.push({
+        label: `Memory Cards (${d.provider || "memory"})`,
+        hash: String(d.cards_ref),
+        event: e.event,
+      });
+    }
+    if (e.event === "memory_dump" && d.entries_ref) {
+      artifacts.push({
+        label: `Memory Dump (${d.provider || "memory"})`,
+        hash: String(d.entries_ref),
+        event: e.event,
+      });
+    }
+    if (e.event === "delegate_start" && d.context_ref) {
+      artifacts.push({
+        label: `Delegation Context (${d.role || "delegate"})`,
+        hash: String(d.context_ref),
+        event: e.event,
+      });
+    }
+    if (e.event === "delegate_end" && d.output_ref) {
+      artifacts.push({
+        label: `Delegation Output (${d.role || "delegate"})`,
+        hash: String(d.output_ref),
+        event: e.event,
+      });
+    }
+  }
+  return artifacts;
+}
+
+// ---------------------------------------------------------------------------
+// Artifact list with expandable content
+// ---------------------------------------------------------------------------
+
+function ArtifactList({
+  artifacts,
+  runId,
+}: {
+  artifacts: ArtifactEntry[];
+  runId: string;
+}) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  return (
+    <div className="artifact-list">
+      {artifacts.map((a) => (
+        <div key={`${a.event}-${a.hash}`} className="artifact-item">
+          <button
+            className="artifact-toggle"
+            onClick={() =>
+              setExpanded(expanded === a.hash ? null : a.hash)
+            }
+          >
+            <span className="artifact-icon">{expanded === a.hash ? "▼" : "▶"}</span>
+            <span className="artifact-label">{a.label}</span>
+          </button>
+          {expanded === a.hash && (
+            <ArtifactContent runId={runId} hash={a.hash} />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ArtifactContent({ runId, hash }: { runId: string; hash: string }) {
+  const [content, setContent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/sessions/${runId}/artifacts/${hash}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+        return res.text();
+      })
+      .then(setContent)
+      .catch((err) => setError(err.message));
+  }, [runId, hash]);
+
+  if (error) return <p className="error">Error: {error}</p>;
+  if (content === null) return <p className="loading-text">Loading...</p>;
+  return <pre className="artifact-content">{content}</pre>;
+}
+
+// ---------------------------------------------------------------------------
+// Detail row
+// ---------------------------------------------------------------------------
+
 function DetailRow({
   label,
   children,
@@ -134,6 +271,10 @@ function DetailRow({
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Event timeline
+// ---------------------------------------------------------------------------
 
 function EventTimeline({ events, runId }: { events: TraceEvent[]; runId: string }) {
   const [artifact, setArtifact] = useState<{ hash: string; label: string } | null>(null);

--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -1,6 +1,8 @@
 """FastAPI application factory."""
 
+import logging
 import os
+import subprocess
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -12,7 +14,45 @@ from fastapi.staticfiles import StaticFiles
 from strawpot.config import get_strawpot_home
 
 from strawpot_gui.db import init_db, sync_sessions
+
+logger = logging.getLogger(__name__)
 from strawpot_gui.routers import config, fs, health, projects, sessions, sse
+
+
+def _auto_rebuild_frontend(dist_dir: Path) -> None:
+    """Rebuild the frontend if source files are newer than dist."""
+    frontend_dir = dist_dir.parent  # frontend/
+    src_dir = frontend_dir / "src"
+    if not src_dir.is_dir():
+        return
+
+    # Find newest source file mtime
+    src_mtime = max(
+        (f.stat().st_mtime for f in src_dir.rglob("*") if f.is_file()),
+        default=0.0,
+    )
+
+    # Find dist mtime (use index.html as marker)
+    dist_marker = dist_dir / "index.html"
+    dist_mtime = dist_marker.stat().st_mtime if dist_marker.is_file() else 0.0
+
+    if src_mtime <= dist_mtime:
+        return
+
+    logger.info("Frontend sources changed, rebuilding...")
+    try:
+        subprocess.run(
+            ["npm", "run", "build"],
+            cwd=str(frontend_dir),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        logger.info("Frontend rebuild complete")
+    except FileNotFoundError:
+        logger.debug("npm not found, skipping frontend rebuild")
+    except subprocess.CalledProcessError as exc:
+        logger.warning("Frontend rebuild failed: %s", exc.stderr[:500])
 
 
 def create_app(db_path: str | None = None) -> FastAPI:
@@ -55,6 +95,8 @@ def create_app(db_path: str | None = None) -> FastAPI:
     # Serve built frontend — check installed package path then dev path
     static_dir = Path(__file__).resolve().parent / "static"
     dev_dir = Path(__file__).resolve().parent.parent.parent / "frontend" / "dist"
+    if not static_dir.is_dir():
+        _auto_rebuild_frontend(dev_dir)
     frontend_dir = static_dir if static_dir.is_dir() else dev_dir
     if frontend_dir.is_dir():
         index_html = frontend_dir / "index.html"

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -27,13 +27,31 @@ def _refresh_session_status(conn, run_id: str) -> None:
     Updates the DB row if the status has changed.
     """
     row = conn.execute(
-        "SELECT status, session_dir FROM sessions WHERE run_id = ?",
+        "SELECT status, session_dir, started_at FROM sessions WHERE run_id = ?",
         (run_id,),
     ).fetchone()
     if not row or row["status"] not in ("starting", "running"):
         return
 
     session_dir = row["session_dir"]
+
+    # If session directory doesn't exist, give subprocess time to create it
+    if not os.path.isdir(session_dir):
+        started_at = row.get("started_at") if hasattr(row, "get") else None
+        if started_at:
+            from datetime import datetime, timezone
+
+            age = (
+                datetime.now(timezone.utc)
+                - datetime.fromisoformat(started_at)
+            ).total_seconds()
+            if age > 15:
+                conn.execute(
+                    "UPDATE sessions SET status = 'failed' WHERE run_id = ?",
+                    (run_id,),
+                )
+        return
+
     session_json = os.path.join(session_dir, "session.json")
 
     # Try to read session.json
@@ -175,6 +193,18 @@ def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
         if body.overrides.merge_strategy:
             cmd.extend(["--merge-strategy", body.overrides.merge_strategy])
 
+    # Ensure subprocess can find user-installed tools (claude, etc.)
+    # even when the server was started from a limited-PATH context.
+    env = os.environ.copy()
+    home = Path.home()
+    extra_paths = [
+        str(home / ".local" / "bin"),
+        "/usr/local/bin",
+        "/opt/homebrew/bin",
+    ]
+    existing = env.get("PATH", "")
+    env["PATH"] = ":".join(extra_paths) + ":" + existing
+
     try:
         subprocess.Popen(
             cmd,
@@ -183,6 +213,7 @@ def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
+            env=env,
         )
     except OSError:
         conn.execute("DELETE FROM sessions WHERE run_id = ?", (run_id,))

--- a/gui/src/strawpot_gui/routers/sse.py
+++ b/gui/src/strawpot_gui/routers/sse.py
@@ -203,18 +203,18 @@ async def session_events_sse(run_id: str, request: Request):
         yield sse_retry(3000)
 
         trace_path = os.path.join(session_dir, "trace.jsonl")
-        events, trace_offset = _read_trace_lines(trace_path, 0)
+        all_events, trace_offset = _read_trace_lines(trace_path, 0)
 
-        if events:
+        if all_events:
             event_id += 1
-            yield format_sse(event_id, {"events": events})
+            yield format_sse(event_id, {"events": all_events})
 
         # Terminal sessions: send all events and close
         if status in ("completed", "failed", "stopped"):
             return
 
         # Check if trace already contains session_end
-        if any(e.get("event") == "session_end" for e in events):
+        if any(e.get("event") == "session_end" for e in all_events):
             return
 
         # Active sessions: poll for new trace events
@@ -233,8 +233,9 @@ async def session_events_sse(run_id: str, request: Request):
                     trace_path, trace_offset
                 )
                 if new_events:
+                    all_events.extend(new_events)
                     event_id += 1
-                    yield format_sse(event_id, {"events": new_events})
+                    yield format_sse(event_id, {"events": all_events})
 
                     if any(e.get("event") == "session_end" for e in new_events):
                         return
@@ -246,8 +247,9 @@ async def session_events_sse(run_id: str, request: Request):
                     trace_path, trace_offset
                 )
                 if new_events:
+                    all_events.extend(new_events)
                     event_id += 1
-                    yield format_sse(event_id, {"events": new_events})
+                    yield format_sse(event_id, {"events": all_events})
                 return
 
     return StreamingResponse(


### PR DESCRIPTION
## Summary
- **SSE reliability**: Backend sends full event snapshots (not incremental), frontend replaces state instead of appending — eliminates duplicate/flickering events
- **Artifact viewer**: Expandable Artifacts section on session detail page showing agent context, session output, memory cards/dumps, delegation context/output
- **Trace enrichment**: `session_start` stores `task_ref`, `session_end` stores `output_ref`, `agent_spawn` stores `context_ref`, `memory_dump` includes task+status
- **Delegation fix**: `_discover_all_roles()` and `discover_global_skills()` now handle unversioned slug directories (e.g. `ai-ceo` not `ai-ceo-1.0.0`)
- **Orchestrator prompt**: `build_prompt()` now receives `delegatable_roles` so the orchestrator sees the "## Delegation" section listing available roles
- **Spawn logging**: `WrapperRuntime.spawn()` logs agent_id, directories, and returned command at debug level
- **GUI improvements**: Auto-rebuild frontend, PATH expansion for subprocess, session status grace period, spinning badge indicator

## Test plan
- [x] 463 CLI tests pass (excluding pre-existing `test_cli_bootstrap` failure)
- [x] 106 GUI tests pass
- [x] Frontend TypeScript compiles (`npx tsc --noEmit`)
- [x] Frontend builds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)