### PR TITLE
Improve delegation prompt and move Trace Events above Summary

### DIFF
--- a/cli/src/strawpot/context.py
+++ b/cli/src/strawpot/context.py
@@ -129,10 +129,13 @@ def _build_delegation_section(roles: list[tuple[str, str]]) -> str:
     lines.append(
         "Each role is described in `roles/<role-name>/ROLE.md`. Read the ROLE.md"
     )
+    lines.append("file to learn more about the role before delegating.")
+    lines.append("")
     lines.append(
-        "file to learn more about the role before delegating. Use the `denden`"
+        "To delegate, read `skills/denden/SKILL.md` and use the `delegate` "
+        "command documented there. This is the ONLY way to delegate work. "
+        "Never attempt tasks yourself — always delegate via the denden skill."
     )
-    lines.append("skill to request delegation.")
     return "\n".join(lines)
 
 

--- a/cli/tests/test_context.py
+++ b/cli/tests/test_context.py
@@ -208,8 +208,8 @@ def test_delegation_section_appended(tmp_path):
     assert "\n---\n\n## Delegation" in result
     assert "- **backend-engineer**: Handles backend API implementation" in result
     assert "- **test-writer**: Writes and maintains test suites" in result
-    assert "Use the `denden`" in result
-    assert "skill to request delegation." in result
+    assert "skills/denden/SKILL.md" in result
+    assert "ONLY way to delegate" in result
 
 
 def test_delegation_with_dependencies(tmp_path):
@@ -330,8 +330,11 @@ def test_delegation_section_exact_format(tmp_path):
         "- **test-writer**: Writes and maintains test suites\n"
         "\n"
         "Each role is described in `roles/<role-name>/ROLE.md`. Read the ROLE.md\n"
-        "file to learn more about the role before delegating. Use the `denden`\n"
-        "skill to request delegation."
+        "file to learn more about the role before delegating.\n"
+        "\n"
+        "To delegate, read `skills/denden/SKILL.md` and use the `delegate` "
+        "command documented there. This is the ONLY way to delegate work. "
+        "Never attempt tasks yourself — always delegate via the denden skill."
     )
 
     assert result.endswith(expected_delegation)

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -100,6 +100,13 @@ export default function SessionDetail() {
         </section>
       )}
 
+      {displayEvents.length > 0 && (
+        <section className="dashboard-section">
+          <h2>Trace Events ({displayEvents.length})</h2>
+          <EventTimeline events={displayEvents} runId={session.run_id} />
+        </section>
+      )}
+
       {session.summary && (
         <section className="dashboard-section">
           <h2>Summary</h2>
@@ -118,13 +125,6 @@ export default function SessionDetail() {
         <h2>Agent Tree</h2>
         <AgentTreeFlow runId={session.run_id} />
       </section>
-
-      {displayEvents.length > 0 && (
-        <section className="dashboard-section">
-          <h2>Trace Events ({displayEvents.length})</h2>
-          <EventTimeline events={displayEvents} runId={session.run_id} />
-        </section>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Delegation section now references `skills/denden/SKILL.md` instead of embedding an inline command example, with stronger "ONLY way to delegate" language to ensure agents use denden consistently
- Moved Trace Events section right below Task in the session detail page for better visibility during active sessions

## Test plan
- [x] `python -m pytest cli/tests/test_context.py -x -q` — 29 passed
- [ ] Manual: verify delegation section in system prompt references skill file
- [ ] Manual: verify Trace Events appears below Task in session detail GUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)