### PR TITLE
Add Agent Tree improvements and fix orchestrator memory dump

### DIFF
--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -312,6 +312,7 @@ class Session:
         self._session_start_time: float = 0.0
         self._agent_spans: dict[str, str] = {}
         self._orchestrator_result: AgentResult | None = None
+        self._orchestrator_role_prompt: str = ""
         self._shutting_down: bool = False
         self._interrupted: bool = False
         self._last_sigint_time: float = 0.0
@@ -386,6 +387,7 @@ class Session:
                 delegatable_roles=delegatable or None,
                 global_skills=[(s, d) for s, d, _ in global_skills] or None,
             )
+            self._orchestrator_role_prompt = role_prompt
 
             # 4. Stage role + create agent workspace
             agent_id = f"agent_{uuid.uuid4().hex[:12]}"
@@ -499,7 +501,7 @@ class Session:
                         session_id=self._run_id,
                         agent_id=orch_agent_id,
                         role=self.config.orchestrator_role,
-                        behavior_ref="",
+                        behavior_ref=self._orchestrator_role_prompt,
                         task=self.task,
                         status=status,
                         output=output,
@@ -513,7 +515,7 @@ class Session:
                         session_id=self._run_id,
                         agent_id=orch_agent_id,
                         role=self.config.orchestrator_role,
-                        behavior_ref="",
+                        behavior_ref=self._orchestrator_role_prompt,
                         task=self.task or "",
                         status=status,
                         output=output,

--- a/gui/frontend/src/components/AgentTreeFlow.tsx
+++ b/gui/frontend/src/components/AgentTreeFlow.tsx
@@ -1,6 +1,9 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import {
   ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
+  MarkerType,
   type Node,
   type Edge,
   type NodeProps,
@@ -132,7 +135,20 @@ function assignPositions(
 // ---- Main component ----
 
 export default function AgentTreeFlow({ runId }: { runId: string }) {
+  return (
+    <ReactFlowProvider>
+      <AgentTreeFlowInner runId={runId} />
+    </ReactFlowProvider>
+  );
+}
+
+function AgentTreeFlowInner({ runId }: { runId: string }) {
   const { tree, connected } = useTreeSSE(runId);
+  const { fitView } = useReactFlow();
+
+  const handleReset = useCallback(() => {
+    fitView({ duration: 300 });
+  }, [fitView]);
 
   const { flowNodes, flowEdges } = useMemo(() => {
     if (!tree) return { flowNodes: [], flowEdges: [] };
@@ -202,6 +218,7 @@ export default function AgentTreeFlow({ runId }: { runId: string }) {
           source: n.parent,
           target: n.agent_id,
           type: "smoothstep",
+          markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16 },
         });
       }
     }
@@ -212,6 +229,7 @@ export default function AgentTreeFlow({ runId }: { runId: string }) {
           source: p.requested_by,
           target: `pending-${p.span_id}`,
           type: "smoothstep",
+          markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16 },
           style: { strokeDasharray: "5 3" },
         });
       }
@@ -243,6 +261,9 @@ export default function AgentTreeFlow({ runId }: { runId: string }) {
           elementsSelectable={false}
           proOptions={{ hideAttribution: true }}
         />
+        <button className="btn btn-sm tree-reset-btn" onClick={handleReset}>
+          Reset View
+        </button>
       </div>
 
       {tree.denied_delegations.length > 0 && (

--- a/gui/frontend/src/index.css
+++ b/gui/frontend/src/index.css
@@ -544,10 +544,18 @@
 /* React Flow agent tree */
 
 .react-flow-wrapper {
+  position: relative;
   height: 400px;
   background: #fff;
   border: 1px solid #e0e0e0;
   border-radius: 6px;
+}
+
+.tree-reset-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 5;
 }
 
 .agent-flow-node {


### PR DESCRIPTION
## Summary
- **Agent Tree**: Add "Reset View" button (top-right) to re-center and fit all nodes with smooth animation
- **Agent Tree**: Add directed arrow markers on edges showing parent → child delegation flow
- **Orchestrator memory dump**: Pass `role_prompt` as `behavior_ref` instead of empty string — the prompt was a local variable in `start()` and inaccessible from `stop()`, now stored as `self._orchestrator_role_prompt`

## Test plan
- [x] `python -m pytest cli/tests/test_session.py -x -q` — 73 passed
- [x] `npx tsc --noEmit` — clean compile
- [ ] Manual: verify Reset View button re-centers the agent tree
- [ ] Manual: verify arrow markers on tree edges
- [ ] Manual: verify orchestrator memory dump artifact contains role prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)