### PR TITLE
Add full context parameters to all trace events

### DIFF
--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -640,6 +640,9 @@ def _emit_delegate_end(
     summary: str,
     start_time: float,
     output: str = "",
+    role: str = "",
+    session_id: str = "",
+    agent_id: str = "",
 ) -> None:
     """Emit delegate_end if tracer is active."""
     if tracer is not None and span_id is not None:
@@ -650,6 +653,9 @@ def _emit_delegate_end(
             summary=summary,
             duration_ms=duration_ms,
             output=output,
+            role=role,
+            session_id=session_id,
+            agent_id=agent_id,
         )
 
 
@@ -723,6 +729,8 @@ def handle_delegate(
             parent_span=parent_span,
             context=request.task_text,
             depth=request.depth,
+            session_id=request.run_id,
+            parent_agent_id=request.parent_agent_id,
         )
 
     # 2. Resolve role + skills
@@ -833,8 +841,14 @@ def handle_delegate(
                 tracer.memory_get(
                     span_id=delegate_span_id,
                     provider=memory_provider.name,
+                    session_id=request.run_id,
+                    agent_id=agent_id,
+                    role=request.role_slug,
+                    behavior_ref=role_prompt,
+                    task=task_text,
                     cards=get_result.context_cards or [],
                     card_count=len(get_result.context_cards) if get_result.context_cards else 0,
+                    parent_agent_id=request.parent_agent_id,
                 )
 
         # 7b. Spawn
@@ -894,6 +908,9 @@ def handle_delegate(
                 exit_code=result.exit_code,
                 output=result.output,
                 duration_ms=agent_duration_ms,
+                agent_id=agent_id,
+                role=request.role_slug,
+                session_id=request.run_id,
             )
 
         # 8a. Memory dump — record result after wait
@@ -932,6 +949,8 @@ def handle_delegate(
                 tracer, delegate_span_id, 1,
                 f"Agent timed out after {config.agent_timeout}s",
                 delegate_start_time, output=result.output,
+                role=request.role_slug, session_id=request.run_id,
+                agent_id=agent_id,
             )
             return DelegateResult(
                 summary=f"Agent timed out after {config.agent_timeout}s",
@@ -944,6 +963,8 @@ def handle_delegate(
             _emit_delegate_end(
                 tracer, delegate_span_id, result.exit_code,
                 result.summary, delegate_start_time, output=result.output,
+                role=request.role_slug, session_id=request.run_id,
+                agent_id=agent_id,
             )
             return DelegateResult(
                 summary=result.summary,
@@ -959,6 +980,8 @@ def handle_delegate(
             _emit_delegate_end(
                 tracer, delegate_span_id, result.exit_code,
                 result.summary, delegate_start_time, output=result.output,
+                role=request.role_slug, session_id=request.run_id,
+                agent_id=agent_id,
             )
             return DelegateResult(
                 summary=result.summary,
@@ -978,6 +1001,8 @@ def handle_delegate(
             _emit_delegate_end(
                 tracer, delegate_span_id, result.exit_code,
                 result.summary, delegate_start_time, output=result.output,
+                role=request.role_slug, session_id=request.run_id,
+                agent_id=agent_id,
             )
             return DelegateResult(
                 summary=result.summary,
@@ -1004,6 +1029,8 @@ def handle_delegate(
     _emit_delegate_end(
         tracer, delegate_span_id, result.exit_code,
         result.summary, delegate_start_time, output=result.output,
+        role=request.role_slug, session_id=request.run_id,
+        agent_id=agent_id,
     )
     return DelegateResult(
         summary=result.summary,

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -415,6 +415,11 @@ class Session:
                     self._tracer.memory_get(
                         span_id=self._session_span_id,
                         provider=self._memory_provider.name,
+                        session_id=self._run_id,
+                        agent_id=agent_id,
+                        role=self.config.orchestrator_role,
+                        behavior_ref=role_prompt,
+                        task=self.task,
                         cards=get_result.context_cards or [],
                         card_count=len(get_result.context_cards) if get_result.context_cards else 0,
                     )

--- a/cli/src/strawpot/trace.py
+++ b/cli/src/strawpot/trace.py
@@ -134,7 +134,14 @@ class Tracer:
         )
 
     def delegate_start(
-        self, *, role: str, parent_span: str, context: str, depth: int = 0
+        self,
+        *,
+        role: str,
+        parent_span: str,
+        context: str,
+        depth: int = 0,
+        session_id: str = "",
+        parent_agent_id: str | None = None,
     ) -> str:
         """Emit ``delegate_start``.  Stores context as artifact.  Returns new span_id."""
         span_id = self._new_span_id()
@@ -146,6 +153,8 @@ class Tracer:
             role=role,
             depth=depth,
             context_ref=context_ref,
+            session_id=session_id,
+            parent_agent_id=parent_agent_id,
         )
         return span_id
 
@@ -157,6 +166,9 @@ class Tracer:
         summary: str,
         duration_ms: int,
         output: str = "",
+        role: str = "",
+        session_id: str = "",
+        agent_id: str = "",
     ) -> None:
         """Emit ``delegate_end``.  Stores output as artifact."""
         output_ref = self.store_artifact(output)
@@ -167,6 +179,9 @@ class Tracer:
             summary=summary,
             duration_ms=duration_ms,
             output_ref=output_ref,
+            role=role,
+            session_id=session_id,
+            agent_id=agent_id,
         )
 
     def delegate_denied(
@@ -188,18 +203,32 @@ class Tracer:
         *,
         span_id: str,
         provider: str,
+        session_id: str,
+        agent_id: str,
+        role: str,
+        behavior_ref: str = "",
+        task: str = "",
         cards: list,
         card_count: int,
+        parent_agent_id: str | None = None,
     ) -> None:
         """Emit ``memory_get``.  Stores serialised cards as artifact."""
         cards_content = json.dumps([str(c) for c in cards]) if cards else ""
         cards_ref = self.store_artifact(cards_content)
+        behavior_artifact = self.store_artifact(behavior_ref)
+        task_ref = self.store_artifact(task)
         self.emit(
             "memory_get",
             span_id,
             provider=provider,
+            session_id=session_id,
+            agent_id=agent_id,
+            role=role,
+            behavior_ref=behavior_artifact,
+            task_ref=task_ref,
             cards_ref=cards_ref,
             card_count=card_count,
+            parent_agent_id=parent_agent_id,
         )
 
     def memory_dump(
@@ -276,6 +305,9 @@ class Tracer:
         exit_code: int,
         output: str,
         duration_ms: int,
+        agent_id: str = "",
+        role: str = "",
+        session_id: str = "",
     ) -> None:
         """Emit ``agent_end``.  Stores output as artifact."""
         output_ref = self.store_artifact(output)
@@ -285,4 +317,7 @@ class Tracer:
             exit_code=exit_code,
             output_ref=output_ref,
             duration_ms=duration_ms,
+            agent_id=agent_id,
+            role=role,
+            session_id=session_id,
         )

--- a/cli/tests/test_trace.py
+++ b/cli/tests/test_trace.py
@@ -225,10 +225,13 @@ class TestDelegateEvents:
         span_id = tracer.delegate_start(
             role="reviewer", parent_span="root",
             context="Review this code please.",
+            session_id="run_abc", parent_agent_id="agent_000",
         )
         assert isinstance(span_id, str)
         events = _read_events(session_dir)
         assert events[0]["event"] == "delegate_start"
+        assert events[0]["data"]["session_id"] == "run_abc"
+        assert events[0]["data"]["parent_agent_id"] == "agent_000"
         ref = events[0]["data"]["context_ref"]
         assert ref is not None
         artifact_path = os.path.join(session_dir, "artifacts", ref)
@@ -249,12 +252,16 @@ class TestDelegateEvents:
         tracer.delegate_end(
             span_id="s1", exit_code=0, summary="Done", duration_ms=1234,
             output="task output here",
+            role="reviewer", session_id="run_abc", agent_id="agent_123",
         )
         events = _read_events(session_dir)
         assert events[0]["event"] == "delegate_end"
         assert events[0]["data"]["exit_code"] == 0
         assert events[0]["data"]["summary"] == "Done"
         assert events[0]["data"]["duration_ms"] == 1234
+        assert events[0]["data"]["role"] == "reviewer"
+        assert events[0]["data"]["session_id"] == "run_abc"
+        assert events[0]["data"]["agent_id"] == "agent_123"
         ref = events[0]["data"]["output_ref"]
         assert ref is not None
         artifact_path = os.path.join(session_dir, "artifacts", ref)
@@ -291,18 +298,30 @@ class TestMemoryEvents:
         tracer, session_dir = _make_tracer(tmp_path)
         tracer.memory_get(
             span_id="s1", provider="semantic",
+            session_id="run_abc", agent_id="agent_123",
+            role="implementer", behavior_ref="You are an implementer.",
+            task="write tests",
             cards=["card1", "card2"], card_count=2,
+            parent_agent_id="agent_000",
         )
         events = _read_events(session_dir)
         assert events[0]["event"] == "memory_get"
         assert events[0]["data"]["card_count"] == 2
+        assert events[0]["data"]["session_id"] == "run_abc"
+        assert events[0]["data"]["agent_id"] == "agent_123"
+        assert events[0]["data"]["role"] == "implementer"
+        assert events[0]["data"]["behavior_ref"] is not None
+        assert events[0]["data"]["task_ref"] is not None
+        assert events[0]["data"]["parent_agent_id"] == "agent_000"
         ref = events[0]["data"]["cards_ref"]
         assert ref is not None
 
     def test_memory_get_empty_cards(self, tmp_path):
         tracer, session_dir = _make_tracer(tmp_path)
         tracer.memory_get(
-            span_id="s1", provider="noop", cards=[], card_count=0,
+            span_id="s1", provider="noop",
+            session_id="run_x", agent_id="agent_x", role="worker",
+            cards=[], card_count=0,
         )
         events = _read_events(session_dir)
         assert events[0]["data"]["cards_ref"] is None
@@ -384,11 +403,15 @@ class TestAgentEvents:
         tracer.agent_end(
             span_id="s1", exit_code=0,
             output="task completed successfully", duration_ms=9876,
+            agent_id="agent_123", role="implementer", session_id="run_abc",
         )
         events = _read_events(session_dir)
         assert events[0]["event"] == "agent_end"
         assert events[0]["data"]["exit_code"] == 0
         assert events[0]["data"]["duration_ms"] == 9876
+        assert events[0]["data"]["agent_id"] == "agent_123"
+        assert events[0]["data"]["role"] == "implementer"
+        assert events[0]["data"]["session_id"] == "run_abc"
         ref = events[0]["data"]["output_ref"]
         assert ref is not None
         artifact_path = os.path.join(session_dir, "artifacts", ref)

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -177,12 +177,28 @@ function extractArtifacts(events: TraceEvent[]): ArtifactEntry[] {
         agentId: d.agent_id ? String(d.agent_id) : undefined,
       });
     }
-    if (e.event === "memory_get" && d.cards_ref) {
-      artifacts.push({
-        label: `Memory Cards (${d.provider || "memory"})`,
-        hash: String(d.cards_ref),
-        event: e.event,
-      });
+    if (e.event === "memory_get") {
+      if (d.cards_ref) {
+        artifacts.push({
+          label: `Memory Cards (${d.provider || "memory"})`,
+          hash: String(d.cards_ref),
+          event: e.event,
+        });
+      }
+      if (d.behavior_ref) {
+        artifacts.push({
+          label: `Memory Get Behavior (${d.role || "agent"})`,
+          hash: String(d.behavior_ref),
+          event: e.event,
+        });
+      }
+      if (d.task_ref) {
+        artifacts.push({
+          label: `Memory Get Task (${d.role || "agent"})`,
+          hash: String(d.task_ref),
+          event: e.event,
+        });
+      }
     }
     if (e.event === "memory_dump") {
       if (d.output_ref) {


### PR DESCRIPTION
## Summary
- Enrich `memory_get`, `delegate_start`, `delegate_end`, and `agent_end` tracer methods with all available context (`session_id`, `agent_id`, `role`, `behavior_ref`, `task`, `parent_agent_id`) so each trace event is self-contained
- Update all call sites in `delegation.py` (including `_emit_delegate_end` helper and its 5 call sites) and `session.py`
- Surface new `memory_get` artifact refs (`behavior_ref`, `task_ref`) in the GUI Artifacts section

## Test plan
- [x] All 30 trace tests pass with new parameter assertions
- [x] Frontend type-checks clean (`tsc --noEmit`)
- [ ] Verify new fields appear in GUI event timeline key=value params
- [ ] Verify new artifact buttons render for `memory_get` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)