### PR TITLE
Fix memory provider not receiving config from registry

### DIFF
--- a/cli/src/strawpot/memory/registry.py
+++ b/cli/src/strawpot/memory/registry.py
@@ -147,6 +147,14 @@ def resolve_memory(
     script, pip_package, module_path = _resolve_script(memory_dir, strawpot_meta)
     params = strawpot_meta.get("params", {})
     config = _merge_config(params, user_config or {})
+
+    # Resolve relative storage_dir to absolute path based on project_dir
+    # so the provider doesn't depend on CWD.
+    if "storage_dir" in config:
+        sd = Path(os.path.expandvars(os.path.expanduser(config["storage_dir"])))
+        if not sd.is_absolute():
+            config["storage_dir"] = str(Path(project_dir) / sd)
+
     env_schema = strawpot_meta.get("env", {})
     tools = strawpot_meta.get("tools", {})
     version = metadata.get("version", "0.0.0")
@@ -273,9 +281,12 @@ def load_provider(spec: MemorySpec) -> MemoryProvider:
             and issubclass(attr, object)
         ):
             try:
-                instance = attr()
+                instance = attr(config=spec.config)
             except TypeError:
-                continue
+                try:
+                    instance = attr()
+                except TypeError:
+                    continue
             if isinstance(instance, MemoryProvider):
                 return instance
 

--- a/cli/tests/test_memory_registry.py
+++ b/cli/tests/test_memory_registry.py
@@ -156,7 +156,8 @@ def test_resolve_project_local(tmp_path, monkeypatch):
     spec = resolve_memory("test-mem", str(project_dir))
     assert spec.name == "test-memory"
     assert spec.version == "0.1.0"
-    assert spec.config == {"storage_dir": ".strawpot/memory", "em_max_events": 10000}
+    assert spec.config["storage_dir"] == str(project_dir / ".strawpot" / "memory")
+    assert spec.config["em_max_events"] == 10000
     assert spec.env_schema["API_KEY"]["required"] is True
     assert "sometool" in spec.tools
     assert spec.script.endswith("provider.py")
@@ -315,6 +316,39 @@ def test_load_provider(tmp_path):
         behavior_ref="desc", task="t",
     )
     assert result.context_cards == []
+
+
+def test_load_provider_passes_config(tmp_path):
+    """load_provider passes spec.config to the provider constructor."""
+    provider_code = dedent("""\
+        from strawpot_memory.memory_protocol import DumpReceipt, GetResult, RememberResult
+
+        class ConfigProvider:
+            name = "test-config"
+
+            def __init__(self, config=None):
+                self.received_config = config
+
+            def get(self, *, session_id, agent_id, role, behavior_ref,
+                    task, budget=None, parent_agent_id=None):
+                return GetResult()
+
+            def dump(self, *, session_id, agent_id, role, behavior_ref,
+                     task, status, output, tool_trace="",
+                     parent_agent_id=None, artifacts=None):
+                return DumpReceipt()
+
+            def remember(self, *, session_id, agent_id, role, content,
+                         keywords=None, scope="project"):
+                return RememberResult(status="accepted")
+    """)
+    script = tmp_path / "provider.py"
+    script.write_text(provider_code)
+    cfg = {"storage_dir": "/custom/path", "extra": "value"}
+    spec = MemorySpec(name="test", version="1.0", script=str(script), config=cfg)
+
+    provider = load_provider(spec)
+    assert provider.received_config == cfg
 
 
 def test_load_provider_no_class(tmp_path):


### PR DESCRIPTION
## Summary
- `load_provider()` now passes `spec.config` to the provider constructor (was calling `attr()` with no args, silently ignoring all config)
- `resolve_memory()` resolves relative `storage_dir` to absolute path based on `project_dir` so the provider doesn't depend on CWD
- Adds `test_load_provider_passes_config` test

## Test plan
- [x] All 24 `test_memory_registry.py` tests pass
- [ ] Run a strawpot session and verify `memory_prompt` is no longer empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)