### PR TITLE
Add ## Memory section header to formatted memory prompt

### DIFF
--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -618,7 +618,9 @@ def _format_memory_prompt(get_result: GetResult) -> str:
     parts = []
     for card in get_result.context_cards:
         parts.append(f"[{card.kind.value}] {card.content}")
-    return "\n\n".join(parts)
+    if not parts:
+        return ""
+    return "## Memory\n\n" + "\n\n".join(parts)
 
 
 def _agent_status(result: AgentResult, *, timed_out: bool = False) -> str:

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -1621,7 +1621,7 @@ class TestFormatMemoryPrompt:
             context_cards=[ContextCard(kind=MemoryKind.PM, content="Do X")]
         )
         result = _format_memory_prompt(get_result)
-        assert result == "[PM] Do X"
+        assert result == "## Memory\n\n[PM] Do X"
 
     def test_multiple_cards(self):
         get_result = GetResult(
@@ -1632,6 +1632,7 @@ class TestFormatMemoryPrompt:
             ]
         )
         result = _format_memory_prompt(get_result)
+        assert result.startswith("## Memory\n\n")
         assert "[PM] instructions" in result
         assert "[SM] fact A" in result
         assert "[STM] scratch" in result


### PR DESCRIPTION
## Summary
- `_format_memory_prompt` now wraps context cards with a `## Memory` header so agents can clearly distinguish memory context from role instructions
- All 5 wrappers (claude_code, gemini, codex, openhands, pi) benefit automatically — they pass through the formatted string unchanged

## Test plan
- [x] `TestFormatMemoryPrompt` tests pass (empty, single card, multiple cards)
- [x] Existing delegation memory tests still pass (use `in` checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)