### PR TITLE
Migrate AppLayout and Dashboard to shadcn/ui + TanStack Query

### DIFF
--- a/gui/frontend/src/components/SessionTable.tsx
+++ b/gui/frontend/src/components/SessionTable.tsx
@@ -1,5 +1,15 @@
 import { Link } from "react-router-dom";
-import type { Session } from "../api/types";
+import type { Session } from "@/api/types";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
 
 export default function SessionTable({
   sessions,
@@ -9,50 +19,90 @@ export default function SessionTable({
   projectNames?: Map<number, string>;
 }) {
   return (
-    <table className="session-table">
-      <thead>
-        <tr>
-          <th>Run ID</th>
-          {projectNames && <th>Project</th>}
-          <th>Role</th>
-          <th>Status</th>
-          <th>Started</th>
-          <th>Duration</th>
-          <th>Task</th>
-        </tr>
-      </thead>
-      <tbody>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Run ID</TableHead>
+          {projectNames && <TableHead>Project</TableHead>}
+          <TableHead>Role</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Started</TableHead>
+          <TableHead>Duration</TableHead>
+          <TableHead>Task</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
         {sessions.map((s) => (
-          <tr key={s.run_id}>
-            <td>
-              <Link to={`/projects/${s.project_id}/sessions/${s.run_id}`}>
+          <TableRow key={s.run_id}>
+            <TableCell>
+              <Link
+                to={`/projects/${s.project_id}/sessions/${s.run_id}`}
+                className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+              >
                 {s.run_id.slice(0, 16)}
               </Link>
-            </td>
+            </TableCell>
             {projectNames && (
-              <td>
-                <Link to={`/projects/${s.project_id}`}>
+              <TableCell>
+                <Link
+                  to={`/projects/${s.project_id}`}
+                  className="text-sm text-primary underline-offset-4 hover:underline"
+                >
                   {projectNames.get(s.project_id) ?? `#${s.project_id}`}
                 </Link>
-              </td>
+              </TableCell>
             )}
-            <td>{s.role}</td>
-            <td>
-              <span className={`badge badge-${statusColor(s.status)}`}>
-                {s.status}
-              </span>
-            </td>
-            <td>{formatTime(s.started_at)}</td>
-            <td>{formatDuration(s.duration_ms)}</td>
-            <td className="cell-task">{s.task ?? "—"}</td>
-          </tr>
+            <TableCell className="text-sm">{s.role}</TableCell>
+            <TableCell>
+              <StatusBadge status={s.status} />
+            </TableCell>
+            <TableCell className="text-sm text-muted-foreground">
+              {formatTime(s.started_at)}
+            </TableCell>
+            <TableCell className="text-sm text-muted-foreground">
+              {formatDuration(s.duration_ms)}
+            </TableCell>
+            <TableCell className="max-w-[300px] truncate text-sm">
+              {s.task ?? "—"}
+            </TableCell>
+          </TableRow>
         ))}
-      </tbody>
-    </table>
+      </TableBody>
+    </Table>
   );
 }
 
-export function statusColor(status: string): string {
+function StatusBadge({ status }: { status: string }) {
+  const variant = statusVariant(status);
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "text-xs font-medium",
+        variant === "running" &&
+          "border-green-200 bg-green-50 text-green-700",
+        variant === "success" &&
+          "border-green-200 bg-green-50 text-green-700",
+        variant === "error" &&
+          "border-red-200 bg-red-50 text-red-700",
+        variant === "warning" &&
+          "border-orange-200 bg-orange-50 text-orange-700",
+        variant === "default" &&
+          "border-muted bg-muted text-muted-foreground",
+      )}
+    >
+      {status === "running" && (
+        <span className="mr-1.5 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-green-500" />
+      )}
+      {status}
+    </Badge>
+  );
+}
+
+// Alias for backward compatibility with unmigrated pages
+export const statusColor = statusVariant;
+
+export function statusVariant(status: string): string {
   switch (status) {
     case "running":
     case "starting":

--- a/gui/frontend/src/index.css
+++ b/gui/frontend/src/index.css
@@ -73,61 +73,9 @@
   background: #fafafa;
 }
 
-.app-layout {
-  display: flex;
-  min-height: 100vh;
-}
+/* Layout CSS removed — now in AppLayout.tsx with Tailwind */
 
-.sidebar {
-  width: 220px;
-  background: #1a1a2e;
-  color: #e0e0e0;
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.sidebar-brand {
-  font-size: 1.25rem;
-  font-weight: 700;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.sidebar nav {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.sidebar nav a {
-  color: #b0b0b0;
-  text-decoration: none;
-  padding: 0.5rem 0.75rem;
-  border-radius: 4px;
-}
-
-.sidebar nav a:hover {
-  background: rgba(255, 255, 255, 0.05);
-  color: #fff;
-}
-
-.sidebar nav a.active {
-  background: rgba(255, 255, 255, 0.1);
-  color: #fff;
-}
-
-.main-content {
-  flex: 1;
-  padding: 2rem;
-}
-
-/* Dashboard */
-
-.dashboard h1 {
-  margin-bottom: 1.5rem;
-}
+/* Dashboard (kept: dashboard-section, empty, error used by other pages) */
 
 .dashboard-section {
   margin-bottom: 2rem;
@@ -148,39 +96,7 @@
   color: #c0392b;
 }
 
-/* Cards */
-
-.card-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 0.75rem;
-}
-
-.card {
-  display: block;
-  background: #fff;
-  border: 1px solid #e0e0e0;
-  border-radius: 6px;
-  padding: 1rem;
-  text-decoration: none;
-  color: inherit;
-  transition: border-color 0.15s;
-}
-
-.card:hover {
-  border-color: #999;
-}
-
-.card-title {
-  font-weight: 600;
-  margin-bottom: 0.25rem;
-}
-
-.card-meta {
-  font-size: 0.85rem;
-  color: #888;
-  word-break: break-all;
-}
+/* Cards CSS removed — now using shadcn Card component */
 
 /* Badges */
 

--- a/gui/frontend/src/layouts/AppLayout.tsx
+++ b/gui/frontend/src/layouts/AppLayout.tsx
@@ -1,20 +1,105 @@
-import { NavLink, Outlet } from "react-router-dom";
+import { NavLink, Outlet, useLocation } from "react-router-dom";
+import { LayoutDashboard, FolderKanban } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Separator } from "@/components/ui/separator";
+
+const navItems = [
+  { to: "/", label: "Dashboard", icon: LayoutDashboard, end: true },
+  { to: "/projects", label: "Projects", icon: FolderKanban },
+];
+
+function useBreadcrumbs() {
+  const location = useLocation();
+  const segments = location.pathname.split("/").filter(Boolean);
+
+  const crumbs: { label: string; href?: string }[] = [
+    { label: "Dashboard", href: "/" },
+  ];
+
+  if (segments[0] === "projects") {
+    crumbs.push({ label: "Projects", href: "/projects" });
+
+    if (segments[1]) {
+      const projectHref = `/projects/${segments[1]}`;
+      crumbs.push({ label: `Project #${segments[1]}`, href: projectHref });
+
+      if (segments[2] === "sessions" && segments[3]) {
+        crumbs.push({ label: `Session ${segments[3].slice(0, 8)}…` });
+      }
+    }
+  }
+
+  return crumbs;
+}
 
 export default function AppLayout() {
+  const crumbs = useBreadcrumbs();
+
   return (
-    <div className="app-layout">
-      <aside className="sidebar">
-        <div className="sidebar-brand">StrawPot</div>
-        <nav>
-          <NavLink to="/" end>
-            Dashboard
-          </NavLink>
-          <NavLink to="/projects">Projects</NavLink>
+    <div className="flex min-h-screen">
+      {/* Sidebar */}
+      <aside className="flex w-56 flex-col border-r border-border bg-card">
+        <div className="flex h-14 items-center border-b border-border px-4">
+          <span className="text-lg font-bold tracking-tight">StrawPot</span>
+        </div>
+        <nav className="flex flex-col gap-1 p-3">
+          {navItems.map(({ to, label, icon: Icon, end }) => (
+            <NavLink
+              key={to}
+              to={to}
+              end={end}
+              className={({ isActive }) =>
+                cn(
+                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground",
+                )
+              }
+            >
+              <Icon className="h-4 w-4" />
+              {label}
+            </NavLink>
+          ))}
         </nav>
       </aside>
-      <main className="main-content">
-        <Outlet />
-      </main>
+
+      {/* Main content */}
+      <div className="flex flex-1 flex-col">
+        <header className="flex h-14 items-center border-b border-border px-6">
+          <Breadcrumb>
+            <BreadcrumbList>
+              {crumbs.map((crumb, i) => {
+                const isLast = i === crumbs.length - 1;
+                return (
+                  <BreadcrumbItem key={crumb.label}>
+                    {i > 0 && <BreadcrumbSeparator />}
+                    {isLast ? (
+                      <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
+                    ) : (
+                      <BreadcrumbLink href={crumb.href}>
+                        {crumb.label}
+                      </BreadcrumbLink>
+                    )}
+                  </BreadcrumbItem>
+                );
+              })}
+            </BreadcrumbList>
+          </Breadcrumb>
+        </header>
+        <Separator />
+        <main className="flex-1 overflow-auto p-6">
+          <Outlet />
+        </main>
+      </div>
     </div>
   );
 }

--- a/gui/frontend/src/pages/Dashboard.tsx
+++ b/gui/frontend/src/pages/Dashboard.tsx
@@ -1,84 +1,164 @@
 import { Link } from "react-router-dom";
-import SessionTable from "../components/SessionTable";
-import { useApi } from "../hooks/useApi";
-import type { Project, SessionList } from "../api/types";
+import { useProjects } from "@/hooks/queries/use-projects";
+import { useRunningSessions, useRecentSessions } from "@/hooks/queries/use-sessions";
+import SessionTable from "@/components/SessionTable";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AlertCircle, FolderKanban } from "lucide-react";
 
 export default function Dashboard() {
-  const projects = useApi<Project[]>("/projects");
-  const running = useApi<SessionList>("/sessions?status=running&per_page=50");
-  const recent = useApi<SessionList>(
-    "/sessions?per_page=10",
-  );
+  const projects = useProjects();
+  const running = useRunningSessions();
+  const recent = useRecentSessions();
 
-  const loading = projects.loading || running.loading || recent.loading;
+  const loading = projects.isLoading || running.isLoading || recent.isLoading;
   const error = projects.error || running.error || recent.error;
 
-  if (loading) return <p>Loading...</p>;
-  if (error) return <p className="error">Error: {error}</p>;
+  if (loading) return <DashboardSkeleton />;
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 text-destructive">
+        <AlertCircle className="h-4 w-4" />
+        <span>Error: {error.message}</span>
+      </div>
+    );
+  }
 
   const projectList = projects.data ?? [];
   const runningSessions = running.data?.items ?? [];
   const recentSessions = recent.data?.items ?? [];
 
-  // Build project name lookup
   const projectNames = new Map<number, string>();
   for (const p of projectList) {
     projectNames.set(p.id, p.display_name);
   }
 
-  // Count running sessions per project
   const runningByProject = new Map<number, number>();
   for (const s of runningSessions) {
-    runningByProject.set(s.project_id, (runningByProject.get(s.project_id) ?? 0) + 1);
+    runningByProject.set(
+      s.project_id,
+      (runningByProject.get(s.project_id) ?? 0) + 1,
+    );
   }
 
   return (
-    <div className="dashboard">
-      <h1>Dashboard</h1>
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold tracking-tight">Dashboard</h1>
 
-      <section className="dashboard-section">
-        <h2>Projects ({projectList.length})</h2>
+      {/* Projects */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-medium text-muted-foreground">
+          Projects ({projectList.length})
+        </h2>
         {projectList.length === 0 ? (
-          <p className="empty">No projects registered.</p>
+          <p className="text-sm italic text-muted-foreground">
+            No projects registered.
+          </p>
         ) : (
-          <div className="card-grid">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
             {projectList.map((p) => (
-              <Link
-                key={p.id}
-                to={`/projects/${p.id}`}
-                className="card"
-              >
-                <div className="card-title">{p.display_name}</div>
-                <div className="card-meta">{p.working_dir}</div>
-                {!p.dir_exists && (
-                  <span className="badge badge-warning">Directory missing</span>
-                )}
-                {(runningByProject.get(p.id) ?? 0) > 0 && (
-                  <span className="badge badge-running">
-                    {runningByProject.get(p.id)} running
-                  </span>
-                )}
+              <Link key={p.id} to={`/projects/${p.id}`} className="group">
+                <Card className="transition-colors group-hover:border-foreground/20">
+                  <CardHeader className="pb-2">
+                    <CardTitle className="flex items-center gap-2 text-base">
+                      <FolderKanban className="h-4 w-4 text-muted-foreground" />
+                      {p.display_name}
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="break-all text-sm text-muted-foreground">
+                      {p.working_dir}
+                    </p>
+                    <div className="mt-2 flex gap-1.5">
+                      {!p.dir_exists && (
+                        <Badge
+                          variant="outline"
+                          className="border-orange-200 bg-orange-50 text-xs text-orange-700"
+                        >
+                          Directory missing
+                        </Badge>
+                      )}
+                      {(runningByProject.get(p.id) ?? 0) > 0 && (
+                        <Badge
+                          variant="outline"
+                          className="border-green-200 bg-green-50 text-xs text-green-700"
+                        >
+                          <span className="mr-1 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-green-500" />
+                          {runningByProject.get(p.id)} running
+                        </Badge>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
               </Link>
             ))}
           </div>
         )}
       </section>
 
+      {/* Running Sessions */}
       {runningSessions.length > 0 && (
-        <section className="dashboard-section">
-          <h2>Running Sessions ({runningSessions.length})</h2>
-          <SessionTable sessions={runningSessions} projectNames={projectNames} />
+        <section className="space-y-3">
+          <h2 className="text-sm font-medium text-muted-foreground">
+            Running Sessions ({runningSessions.length})
+          </h2>
+          <Card>
+            <CardContent className="p-0">
+              <SessionTable
+                sessions={runningSessions}
+                projectNames={projectNames}
+              />
+            </CardContent>
+          </Card>
         </section>
       )}
 
-      <section className="dashboard-section">
-        <h2>Recent Sessions</h2>
+      {/* Recent Sessions */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-medium text-muted-foreground">
+          Recent Sessions
+        </h2>
         {recentSessions.length === 0 ? (
-          <p className="empty">No sessions yet.</p>
+          <p className="text-sm italic text-muted-foreground">
+            No sessions yet.
+          </p>
         ) : (
-          <SessionTable sessions={recentSessions} projectNames={projectNames} />
+          <Card>
+            <CardContent className="p-0">
+              <SessionTable
+                sessions={recentSessions}
+                projectNames={projectNames}
+              />
+            </CardContent>
+          </Card>
         )}
       </section>
+    </div>
+  );
+}
+
+function DashboardSkeleton() {
+  return (
+    <div className="space-y-8">
+      <Skeleton className="h-8 w-40" />
+      <div className="space-y-3">
+        <Skeleton className="h-4 w-24" />
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-28 rounded-lg" />
+          ))}
+        </div>
+      </div>
+      <div className="space-y-3">
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-48 rounded-lg" />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Rewrite AppLayout with Tailwind sidebar (lucide icons, active state) and breadcrumb header
- Migrate Dashboard to TanStack Query hooks (`useProjects`, `useRunningSessions`, `useRecentSessions`) replacing custom `useApi`
- Migrate SessionTable to shadcn Table + Badge components with color-coded status badges
- Remove 82 lines of legacy CSS (layout, cards); preserve CSS still used by unmigrated pages
- Add loading skeleton and error state with proper icons

## Test plan
- [x] `npm run build` succeeds (2093 modules, no errors)
- [ ] Verify Dashboard renders projects, running sessions, recent sessions
- [ ] Verify sidebar navigation and breadcrumbs work across routes
- [ ] Verify unmigrated pages (ProjectList, ProjectDetail, SessionDetail) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)