### PR TITLE
Fix SSE crash when session directory does not exist

### DIFF
--- a/gui/src/strawpot_gui/routers/sse.py
+++ b/gui/src/strawpot_gui/routers/sse.py
@@ -36,8 +36,9 @@ async def _watch_session_dir(
             poll_delay_ms=50,
         ):
             yield {path for _, path in changes}
-    except RuntimeError:
-        # awatch can raise if the directory is removed mid-watch
+    except (RuntimeError, FileNotFoundError):
+        # awatch raises FileNotFoundError if the directory doesn't exist,
+        # and RuntimeError if it is removed mid-watch.
         return
 
 


### PR DESCRIPTION
## Summary
- Catch `FileNotFoundError` in `_watch_session_dir()` so SSE endpoints end gracefully when the session directory doesn't exist on disk (e.g., deleted or not yet created)

## Test plan
- [ ] Launch a session, delete its directory, confirm no server crash
- [ ] Navigate to a session whose directory is missing — SSE stream closes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)