### PR TITLE
Add agent log streaming, session detail tabs, and toast notifications

### DIFF
--- a/gui/frontend/src/components/ui/sonner.tsx
+++ b/gui/frontend/src/components/ui/sonner.tsx
@@ -5,15 +5,12 @@ import {
   OctagonXIcon,
   TriangleAlertIcon,
 } from "lucide-react"
-import { useTheme } from "next-themes"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
-
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme="light"
       className="toaster group"
       icons={{
         success: <CircleCheckIcon className="size-4" />,

--- a/gui/frontend/src/hooks/useAgentLogSSE.ts
+++ b/gui/frontend/src/hooks/useAgentLogSSE.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from "react";
+
+const MAX_LINES = 10_000;
+
+export interface UseAgentLogSSEResult {
+  lines: string[];
+  connected: boolean;
+  done: boolean;
+}
+
+export function useAgentLogSSE(
+  runId: string,
+  agentId: string,
+  active: boolean,
+): UseAgentLogSSEResult {
+  const [lines, setLines] = useState<string[]>([]);
+  const [connected, setConnected] = useState(false);
+  const [done, setDone] = useState(false);
+  const esRef = useRef<EventSource | null>(null);
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const backoffMs = useRef(1000);
+  const prevKeyRef = useRef("");
+
+  useEffect(() => {
+    if (!active || !agentId) return;
+
+    const key = `${runId}:${agentId}`;
+    if (prevKeyRef.current !== key) {
+      setLines([]);
+      setDone(false);
+      prevKeyRef.current = key;
+    }
+
+    function connect() {
+      const es = new EventSource(
+        `/api/sessions/${runId}/logs/${agentId}`,
+      );
+      esRef.current = es;
+
+      es.onopen = () => {
+        setConnected(true);
+        backoffMs.current = 1000;
+      };
+
+      es.addEventListener("snapshot", (msg) => {
+        try {
+          const data = JSON.parse(msg.data);
+          if (Array.isArray(data.lines)) {
+            setLines(data.lines.slice(-MAX_LINES));
+          }
+        } catch {
+          /* ignore */
+        }
+      });
+
+      es.addEventListener("append", (msg) => {
+        try {
+          const data = JSON.parse(msg.data);
+          if (Array.isArray(data.lines) && data.lines.length > 0) {
+            setLines((prev) => {
+              const merged = [...prev, ...data.lines];
+              return merged.length > MAX_LINES
+                ? merged.slice(-MAX_LINES)
+                : merged;
+            });
+          }
+        } catch {
+          /* ignore */
+        }
+      });
+
+      es.addEventListener("done", () => {
+        setDone(true);
+        es.close();
+        esRef.current = null;
+      });
+
+      es.onerror = () => {
+        es.close();
+        esRef.current = null;
+        setConnected(false);
+        reconnectTimer.current = setTimeout(() => {
+          backoffMs.current = Math.min(backoffMs.current * 2, 15000);
+          connect();
+        }, backoffMs.current);
+      };
+    }
+
+    connect();
+
+    return () => {
+      esRef.current?.close();
+      esRef.current = null;
+      if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
+    };
+  }, [runId, agentId, active]);
+
+  return { lines, connected, done };
+}

--- a/gui/frontend/src/hooks/useGlobalSSE.ts
+++ b/gui/frontend/src/hooks/useGlobalSSE.ts
@@ -1,29 +1,68 @@
 import { useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { queryKeys } from "@/lib/query-keys";
 
+const MAX_TOASTS_PER_WINDOW = 3;
+const TOAST_WINDOW_MS = 10_000;
+const RECONNECT_SUPPRESS_MS = 2000;
+
 /**
- * Connect to the global SSE event bus and invalidate TanStack Query
- * caches when session lifecycle events arrive.
+ * Connect to the global SSE event bus, invalidate TanStack Query
+ * caches, and fire toast notifications on session lifecycle events.
  */
 export function useGlobalSSE(): void {
   const qc = useQueryClient();
   const esRef = useRef<EventSource | null>(null);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const backoffMs = useRef(1000);
+  const connectedAt = useRef(0);
+  const toastLog = useRef<Record<string, number[]>>({});
 
   useEffect(() => {
+    function shouldToast(eventType: string): boolean {
+      const now = Date.now();
+      // Suppress toasts right after (re)connect to avoid stale flood
+      if (now - connectedAt.current < RECONNECT_SUPPRESS_MS) return false;
+      // Rate limit: max N per event type within window
+      const recent = (toastLog.current[eventType] ?? []).filter(
+        (t) => now - t < TOAST_WINDOW_MS,
+      );
+      if (recent.length >= MAX_TOASTS_PER_WINDOW) return false;
+      recent.push(now);
+      toastLog.current[eventType] = recent;
+      return true;
+    }
+
     function connect() {
       const es = new EventSource("/api/events");
       esRef.current = es;
 
       es.onopen = () => {
-        backoffMs.current = 1000; // reset on successful connect
+        backoffMs.current = 1000;
+        connectedAt.current = Date.now();
       };
 
       const handleLifecycle = (e: MessageEvent) => {
         try {
           const data = JSON.parse(e.data);
+          const runIdShort = (data.run_id ?? "unknown").slice(0, 12);
+
+          // Fire toast notifications
+          if (shouldToast(e.type)) {
+            if (e.type === "session_started") {
+              toast.info(`Session ${runIdShort} started`);
+            } else if (e.type === "session_completed") {
+              toast.success(`Session ${runIdShort} completed`, {
+                description: data.summary?.slice(0, 80),
+              });
+            } else if (e.type === "session_failed") {
+              toast.error(`Session ${runIdShort} failed`);
+            } else if (e.type === "session_stopped") {
+              toast.warning(`Session ${runIdShort} stopped`);
+            }
+          }
+
           // Invalidate all session list queries
           qc.invalidateQueries({ queryKey: ["sessions"] });
           // Invalidate specific project sessions if project_id present

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 import { useSession } from "@/hooks/queries/use-sessions";
 import { useStopSession } from "@/hooks/mutations/use-sessions";
 import AgentTreeFlow from "@/components/AgentTreeFlow";
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Table,
   TableBody,
@@ -40,6 +41,7 @@ import type { SessionDetail as SessionDetailType, TraceEvent } from "@/api/types
 
 export default function SessionDetail() {
   const { projectId, runId } = useParams();
+  const [searchParams] = useSearchParams();
   const pid = Number(projectId);
 
   const isActive = (status?: string) =>
@@ -90,6 +92,8 @@ export default function SessionDetail() {
   }
 
   const artifacts = extractArtifacts(displayEvents);
+  const defaultTab =
+    searchParams.get("tab") ?? (active ? "agent-tree" : "overview");
 
   return (
     <div className="space-y-6">
@@ -102,58 +106,93 @@ export default function SessionDetail() {
 
       <SessionMetadata session={sessionData} />
 
-      {sessionData.task && (
-        <section className="space-y-2">
-          <h2 className="text-sm font-medium text-muted-foreground">Task</h2>
-          <Card>
-            <CardContent className="pt-4">
-              <pre className="whitespace-pre-wrap break-words text-sm">
-                {sessionData.task}
-              </pre>
-            </CardContent>
-          </Card>
-        </section>
-      )}
+      <Tabs defaultValue={defaultTab}>
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="agent-tree">Agent Tree</TabsTrigger>
+          <TabsTrigger value="logs">Logs</TabsTrigger>
+          <TabsTrigger value="trace">
+            Trace{displayEvents.length > 0 && ` (${displayEvents.length})`}
+          </TabsTrigger>
+          <TabsTrigger value="artifacts">
+            Artifacts{artifacts.length > 0 && ` (${artifacts.length})`}
+          </TabsTrigger>
+        </TabsList>
 
-      {displayEvents.length > 0 && (
-        <section className="space-y-2">
-          <h2 className="text-sm font-medium text-muted-foreground">
-            Trace Events ({displayEvents.length})
-          </h2>
-          <EventTimeline events={displayEvents} runId={sessionData.run_id} />
-        </section>
-      )}
+        <TabsContent value="overview" className="space-y-4">
+          {sessionData.task && (
+            <section className="space-y-2">
+              <h2 className="text-sm font-medium text-muted-foreground">
+                Task
+              </h2>
+              <Card>
+                <CardContent className="pt-4">
+                  <pre className="whitespace-pre-wrap break-words text-sm">
+                    {sessionData.task}
+                  </pre>
+                </CardContent>
+              </Card>
+            </section>
+          )}
 
-      {sessionData.summary && (
-        <section className="space-y-2">
-          <h2 className="text-sm font-medium text-muted-foreground">
-            Summary
-          </h2>
-          <Card>
-            <CardContent className="pt-4">
-              <pre className="whitespace-pre-wrap break-words text-sm">
-                {sessionData.summary}
-              </pre>
-            </CardContent>
-          </Card>
-        </section>
-      )}
+          {sessionData.summary && (
+            <section className="space-y-2">
+              <h2 className="text-sm font-medium text-muted-foreground">
+                Summary
+              </h2>
+              <Card>
+                <CardContent className="pt-4">
+                  <pre className="whitespace-pre-wrap break-words text-sm">
+                    {sessionData.summary}
+                  </pre>
+                </CardContent>
+              </Card>
+            </section>
+          )}
 
-      {artifacts.length > 0 && (
-        <section className="space-y-2">
-          <h2 className="text-sm font-medium text-muted-foreground">
-            Artifacts
-          </h2>
-          <ArtifactList artifacts={artifacts} runId={sessionData.run_id} />
-        </section>
-      )}
+          {!sessionData.task && !sessionData.summary && (
+            <p className="text-sm text-muted-foreground">
+              No overview information available yet.
+            </p>
+          )}
+        </TabsContent>
 
-      <section className="space-y-2">
-        <h2 className="text-sm font-medium text-muted-foreground">
-          Agent Tree
-        </h2>
-        <AgentTreeFlow runId={sessionData.run_id} />
-      </section>
+        <TabsContent value="agent-tree">
+          <AgentTreeFlow runId={sessionData.run_id} />
+        </TabsContent>
+
+        <TabsContent value="logs">
+          <p className="text-sm text-muted-foreground">
+            Agent log viewer coming in a future update.
+          </p>
+        </TabsContent>
+
+        <TabsContent value="trace">
+          {displayEvents.length > 0 ? (
+            <EventTimeline
+              events={displayEvents}
+              runId={sessionData.run_id}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No trace events recorded yet.
+            </p>
+          )}
+        </TabsContent>
+
+        <TabsContent value="artifacts">
+          {artifacts.length > 0 ? (
+            <ArtifactList
+              artifacts={artifacts}
+              runId={sessionData.run_id}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No artifacts recorded yet.
+            </p>
+          )}
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -17,7 +17,7 @@ from strawpot_gui.db import init_db, sync_sessions
 from strawpot_gui.event_bus import event_bus
 
 logger = logging.getLogger(__name__)
-from strawpot_gui.routers import config, fs, health, projects, sessions, sse
+from strawpot_gui.routers import config, fs, health, logs, projects, sessions, sse
 
 
 def _auto_rebuild_frontend(dist_dir: Path) -> None:
@@ -92,6 +92,7 @@ def create_app(db_path: str | None = None) -> FastAPI:
     app.include_router(config.router)
     app.include_router(sessions.router)
     app.include_router(sse.router)
+    app.include_router(logs.router)
     app.include_router(fs.router)
 
     # Serve built frontend — check installed package path then dev path

--- a/gui/src/strawpot_gui/routers/logs.py
+++ b/gui/src/strawpot_gui/routers/logs.py
@@ -1,0 +1,199 @@
+"""SSE and REST endpoints for agent log streaming."""
+
+import asyncio
+import json
+import os
+
+from fastapi import APIRouter, Request
+from fastapi.responses import PlainTextResponse, StreamingResponse
+
+from strawpot_gui.sse import (
+    format_sse,
+    format_sse_typed,
+    resolve_session_dir,
+    sse_retry,
+    watch_dir,
+)
+
+router = APIRouter(prefix="/api", tags=["logs"])
+
+_TERMINAL_STATUSES = ("completed", "failed", "stopped")
+_MAX_SNAPSHOT_LINES = 500
+
+
+def _read_log_tail(path: str, max_lines: int = _MAX_SNAPSHOT_LINES) -> tuple[list[str], int]:
+    """Read the last *max_lines* lines from a log file.
+
+    Returns (lines, byte_offset) where offset is the end-of-file position.
+    """
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            all_lines = f.readlines()
+            offset = f.tell()
+        # Strip trailing newlines from each line
+        lines = [ln.rstrip("\n") for ln in all_lines[-max_lines:]]
+        return lines, offset
+    except OSError:
+        return [], 0
+
+
+def _read_log_delta(path: str, offset: int) -> tuple[list[str], int]:
+    """Read new content from a log file starting at *offset*.
+
+    Returns (new_lines, new_offset).
+    """
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            f.seek(offset)
+            raw = f.read()
+            new_offset = f.tell()
+        if not raw:
+            return [], offset
+        lines = [ln.rstrip("\n") for ln in raw.splitlines()]
+        return lines, new_offset
+    except OSError:
+        return [], offset
+
+
+def _validate_agent(session_dir: str, agent_id: str) -> bool:
+    """Check that agent_id exists in session.json agents dict."""
+    path = os.path.join(session_dir, "session.json")
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        return agent_id in data.get("agents", {})
+    except (OSError, json.JSONDecodeError):
+        # If session.json doesn't exist yet, check agent dir on disk
+        return os.path.isdir(os.path.join(session_dir, "agents", agent_id))
+
+
+# ---------------------------------------------------------------------------
+# SSE: Agent log streaming
+# ---------------------------------------------------------------------------
+
+
+@router.get("/sessions/{run_id}/logs/{agent_id}")
+async def agent_log_sse(run_id: str, agent_id: str, request: Request):
+    """SSE endpoint for streaming an agent's log output.
+
+    Protocol:
+    - ``event: snapshot`` — initial batch (last 500 lines + byte offset)
+    - ``event: append``   — new lines since last send
+    - ``event: done``     — session reached terminal state, stream closes
+    """
+    db_path = request.app.state.db_path
+    session_dir, status = resolve_session_dir(db_path, run_id)
+
+    if session_dir is None:
+        async def not_found():
+            yield format_sse(1, {"error": "Session not found"})
+
+        return StreamingResponse(
+            not_found(),
+            media_type="text/event-stream",
+            status_code=404,
+        )
+
+    if not _validate_agent(session_dir, agent_id):
+        async def agent_not_found():
+            yield format_sse(1, {"error": f"Agent {agent_id} not found"})
+
+        return StreamingResponse(
+            agent_not_found(),
+            media_type="text/event-stream",
+            status_code=404,
+        )
+
+    log_path = os.path.join(session_dir, "agents", agent_id, ".log")
+
+    async def event_stream():
+        event_id = 0
+
+        yield sse_retry(3000)
+
+        # Snapshot: send last N lines
+        lines, offset = _read_log_tail(log_path)
+        event_id += 1
+        yield format_sse_typed(event_id, "snapshot", {
+            "lines": lines,
+            "offset": offset,
+        })
+
+        # Terminal sessions: send done immediately
+        if status in _TERMINAL_STATUSES:
+            event_id += 1
+            yield format_sse_typed(event_id, "done", {})
+            return
+
+        # Watch agent directory for log changes
+        agent_dir = os.path.join(session_dir, "agents", agent_id)
+        stop = asyncio.Event()
+
+        try:
+            async for changed_files in watch_dir(agent_dir, stop):
+                if await request.is_disconnected():
+                    return
+
+                if not changed_files:
+                    # Timeout — check DB status
+                    _, current_status = resolve_session_dir(db_path, run_id)
+                    if current_status in _TERMINAL_STATUSES:
+                        # Final read
+                        new_lines, offset = _read_log_delta(log_path, offset)
+                        if new_lines:
+                            event_id += 1
+                            yield format_sse_typed(event_id, "append", {
+                                "lines": new_lines,
+                                "offset": offset,
+                            })
+                        event_id += 1
+                        yield format_sse_typed(event_id, "done", {})
+                        return
+                    continue
+
+                if any(f.endswith(".log") for f in changed_files):
+                    new_lines, offset = _read_log_delta(log_path, offset)
+                    if new_lines:
+                        event_id += 1
+                        yield format_sse_typed(event_id, "append", {
+                            "lines": new_lines,
+                            "offset": offset,
+                        })
+        finally:
+            stop.set()
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# REST: Full log download
+# ---------------------------------------------------------------------------
+
+
+@router.get("/sessions/{run_id}/logs/{agent_id}/full")
+async def agent_log_full(run_id: str, agent_id: str, request: Request):
+    """Return the complete log file as plain text."""
+    db_path = request.app.state.db_path
+    session_dir, _ = resolve_session_dir(db_path, run_id)
+
+    if session_dir is None:
+        return PlainTextResponse("Session not found", status_code=404)
+
+    if not _validate_agent(session_dir, agent_id):
+        return PlainTextResponse(f"Agent {agent_id} not found", status_code=404)
+
+    log_path = os.path.join(session_dir, "agents", agent_id, ".log")
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+            content = f.read()
+        return PlainTextResponse(content)
+    except OSError:
+        return PlainTextResponse("", status_code=200)

--- a/gui/src/strawpot_gui/routers/sse.py
+++ b/gui/src/strawpot_gui/routers/sse.py
@@ -3,55 +3,21 @@
 import asyncio
 import json
 import os
-from typing import AsyncIterator
 
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
-from watchfiles import awatch
 
-from strawpot_gui.db import get_db
 from strawpot_gui.event_bus import EventBus, SessionEvent, event_bus
-from strawpot_gui.sse import TreeState, format_sse, format_sse_typed, sse_retry
+from strawpot_gui.sse import (
+    TreeState,
+    format_sse,
+    format_sse_typed,
+    resolve_session_dir,
+    sse_retry,
+    watch_dir,
+)
 
 router = APIRouter(prefix="/api", tags=["sse"])
-
-# Fallback timeout (ms) for watchfiles — ensures periodic DB status checks
-# even when no file changes occur (e.g., user-initiated stop via API).
-_WATCH_TIMEOUT_MS = 5000
-
-
-async def _watch_session_dir(
-    session_dir: str, stop_event: asyncio.Event
-) -> AsyncIterator[set[str]]:
-    """Yield sets of changed file paths whenever the session directory changes.
-
-    Yields an empty set on timeout (no file changes detected within
-    _WATCH_TIMEOUT_MS), allowing callers to perform periodic checks.
-    """
-    try:
-        async for changes in awatch(
-            session_dir,
-            stop_event=stop_event,
-            rust_timeout=_WATCH_TIMEOUT_MS,
-            poll_delay_ms=50,
-        ):
-            yield {path for _, path in changes}
-    except (RuntimeError, FileNotFoundError):
-        # awatch raises FileNotFoundError if the directory doesn't exist,
-        # and RuntimeError if it is removed mid-watch.
-        return
-
-
-def _resolve_session_dir(db_path: str, run_id: str) -> tuple[str | None, str | None]:
-    """Look up session_dir and status from the database."""
-    with get_db(db_path) as conn:
-        row = conn.execute(
-            "SELECT session_dir, status FROM sessions WHERE run_id = ?",
-            (run_id,),
-        ).fetchone()
-    if not row:
-        return None, None
-    return row["session_dir"], row["status"]
 
 
 def _read_session_json(session_dir: str) -> dict | None:
@@ -116,7 +82,7 @@ def _publish_terminal(run_id: str, status: str) -> None:
 async def session_tree_sse(run_id: str, request: Request):
     """SSE endpoint for real-time agent tree updates."""
     db_path = request.app.state.db_path
-    session_dir, status = _resolve_session_dir(db_path, run_id)
+    session_dir, status = resolve_session_dir(db_path, run_id)
 
     if session_dir is None:
         async def not_found():
@@ -154,7 +120,7 @@ async def session_tree_sse(run_id: str, request: Request):
         stop = asyncio.Event()
 
         try:
-            async for changed_files in _watch_session_dir(session_dir, stop):
+            async for changed_files in watch_dir(session_dir, stop):
                 if await request.is_disconnected():
                     return
 
@@ -162,7 +128,7 @@ async def session_tree_sse(run_id: str, request: Request):
 
                 if not changed_files:
                     # Timeout — no file changes; check DB status only
-                    _, current_status = _resolve_session_dir(db_path, run_id)
+                    _, current_status = resolve_session_dir(db_path, run_id)
                     if current_status in ("completed", "failed", "stopped"):
                         # Final read before closing
                         new_events, trace_offset = _read_trace_lines(
@@ -228,7 +194,7 @@ async def session_events_sse(run_id: str, request: Request):
     - Subsequent updates: sends ``event: delta`` with only new events
     """
     db_path = request.app.state.db_path
-    session_dir, status = _resolve_session_dir(db_path, run_id)
+    session_dir, status = resolve_session_dir(db_path, run_id)
 
     if session_dir is None:
         async def not_found():
@@ -267,13 +233,13 @@ async def session_events_sse(run_id: str, request: Request):
         stop = asyncio.Event()
 
         try:
-            async for changed_files in _watch_session_dir(session_dir, stop):
+            async for changed_files in watch_dir(session_dir, stop):
                 if await request.is_disconnected():
                     return
 
                 if not changed_files:
                     # Timeout — check DB status
-                    _, current_status = _resolve_session_dir(db_path, run_id)
+                    _, current_status = resolve_session_dir(db_path, run_id)
                     if current_status in ("completed", "failed", "stopped"):
                         new_events, trace_offset = _read_trace_lines(
                             trace_path, trace_offset

--- a/gui/src/strawpot_gui/sse.py
+++ b/gui/src/strawpot_gui/sse.py
@@ -1,7 +1,17 @@
-"""SSE utilities and agent tree state builder."""
+"""SSE utilities, shared helpers, and agent tree state builder."""
 
+import asyncio
 import json
 from dataclasses import dataclass, field
+from typing import AsyncIterator
+
+from watchfiles import awatch
+
+from strawpot_gui.db import get_db
+
+# Fallback timeout (ms) for watchfiles — ensures periodic DB status checks
+# even when no file changes occur (e.g., user-initiated stop via API).
+WATCH_TIMEOUT_MS = 5000
 
 
 def format_sse(event_id: int, data: dict) -> str:
@@ -19,6 +29,45 @@ def format_sse_typed(event_id: int, event_type: str, data: dict) -> str:
 def sse_retry(ms: int = 3000) -> str:
     """Format an SSE retry directive."""
     return f"retry: {ms}\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers used by multiple SSE routers
+# ---------------------------------------------------------------------------
+
+
+async def watch_dir(
+    path: str, stop_event: asyncio.Event
+) -> AsyncIterator[set[str]]:
+    """Yield sets of changed file paths whenever a directory changes.
+
+    Yields an empty set on timeout (no file changes detected within
+    WATCH_TIMEOUT_MS), allowing callers to perform periodic checks.
+    """
+    try:
+        async for changes in awatch(
+            path,
+            stop_event=stop_event,
+            rust_timeout=WATCH_TIMEOUT_MS,
+            poll_delay_ms=50,
+        ):
+            yield {p for _, p in changes}
+    except (RuntimeError, FileNotFoundError):
+        # awatch raises FileNotFoundError if the directory doesn't exist,
+        # and RuntimeError if it is removed mid-watch.
+        return
+
+
+def resolve_session_dir(db_path: str, run_id: str) -> tuple[str | None, str | None]:
+    """Look up session_dir and status from the database."""
+    with get_db(db_path) as conn:
+        row = conn.execute(
+            "SELECT session_dir, status FROM sessions WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+    if not row:
+        return None, None
+    return row["session_dir"], row["status"]
 
 
 @dataclass

--- a/gui/tests/test_agent_log_sse.py
+++ b/gui/tests/test_agent_log_sse.py
@@ -1,0 +1,180 @@
+"""Integration tests for the agent log SSE and REST endpoints."""
+
+import json
+import os
+
+from test_sessions_sync import _register_project, _write_session
+
+from strawpot_gui.db import sync_sessions
+
+
+def _write_agent_log(session_dir, agent_id, content):
+    """Write a .log file for an agent."""
+    agent_dir = os.path.join(session_dir, "agents", agent_id)
+    os.makedirs(agent_dir, exist_ok=True)
+    with open(os.path.join(agent_dir, ".log"), "w") as f:
+        f.write(content)
+
+
+def _parse_sse_named_events(body):
+    """Parse SSE events with event types."""
+    events = []
+    current_type = "message"
+    for line in body.splitlines():
+        if line.startswith("event: "):
+            current_type = line[7:].strip()
+        elif line.startswith("data: "):
+            try:
+                events.append((current_type, json.loads(line[6:])))
+            except json.JSONDecodeError:
+                pass
+            current_type = "message"
+    return events
+
+
+class TestAgentLogSSETerminal:
+    """Tests for completed sessions — snapshot then done."""
+
+    def test_completed_session_returns_snapshot_and_done(self, client, tmp_path):
+        """Completed session sends log snapshot then done event."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        session_dir = _write_session(project_dir, "run_log1", archived=True)
+        _write_agent_log(session_dir, "agent_abc", "line 1\nline 2\nline 3\n")
+
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get("/api/sessions/run_log1/logs/agent_abc")
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+
+        events = _parse_sse_named_events(resp.text)
+        assert len(events) >= 2
+
+        etype, data = events[0]
+        assert etype == "snapshot"
+        assert data["lines"] == ["line 1", "line 2", "line 3"]
+        assert data["offset"] > 0
+
+        etype2, _ = events[1]
+        assert etype2 == "done"
+
+    def test_empty_log_returns_empty_snapshot(self, client, tmp_path):
+        """Session with no log file returns empty snapshot then done."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        session_dir = _write_session(project_dir, "run_log2", archived=True)
+        # Create agent dir but no .log file
+        os.makedirs(os.path.join(session_dir, "agents", "agent_abc"))
+
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get("/api/sessions/run_log2/logs/agent_abc")
+        assert resp.status_code == 200
+
+        events = _parse_sse_named_events(resp.text)
+        assert len(events) >= 2
+
+        etype, data = events[0]
+        assert etype == "snapshot"
+        assert data["lines"] == []
+        assert data["offset"] == 0
+
+        etype2, _ = events[1]
+        assert etype2 == "done"
+
+    def test_large_log_returns_last_500_lines(self, client, tmp_path):
+        """Large log files are truncated to the last 500 lines."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        session_dir = _write_session(project_dir, "run_log3", archived=True)
+        lines = [f"line {i}" for i in range(1000)]
+        _write_agent_log(session_dir, "agent_abc", "\n".join(lines) + "\n")
+
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get("/api/sessions/run_log3/logs/agent_abc")
+        events = _parse_sse_named_events(resp.text)
+
+        etype, data = events[0]
+        assert etype == "snapshot"
+        assert len(data["lines"]) == 500
+        assert data["lines"][0] == "line 500"
+        assert data["lines"][-1] == "line 999"
+
+
+class TestAgentLogSSENotFound:
+    def test_unknown_session_returns_404(self, client):
+        """Non-existent session returns 404."""
+        resp = client.get("/api/sessions/run_nonexistent/logs/agent_abc")
+        assert resp.status_code == 404
+
+    def test_unknown_agent_returns_404(self, client, tmp_path):
+        """Non-existent agent returns 404."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        _write_session(project_dir, "run_log4", archived=True)
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get("/api/sessions/run_log4/logs/agent_nonexistent")
+        assert resp.status_code == 404
+
+
+class TestAgentLogREST:
+    """Tests for the full log download REST endpoint."""
+
+    def test_full_log_returns_plaintext(self, client, tmp_path):
+        """Full log endpoint returns complete content as text/plain."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        session_dir = _write_session(project_dir, "run_log5", archived=True)
+        _write_agent_log(session_dir, "agent_abc", "hello world\n")
+
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get("/api/sessions/run_log5/logs/agent_abc/full")
+        assert resp.status_code == 200
+        assert "text/plain" in resp.headers["content-type"]
+        assert resp.text == "hello world\n"
+
+    def test_missing_log_returns_empty(self, client, tmp_path):
+        """Missing log file returns empty 200 response."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        session_dir = _write_session(project_dir, "run_log6", archived=True)
+        os.makedirs(os.path.join(session_dir, "agents", "agent_abc"))
+
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get("/api/sessions/run_log6/logs/agent_abc/full")
+        assert resp.status_code == 200
+        assert resp.text == ""
+
+    def test_unknown_session_returns_404(self, client):
+        """Non-existent session returns 404."""
+        resp = client.get("/api/sessions/run_nonexistent/logs/agent_abc/full")
+        assert resp.status_code == 404
+
+    def test_unknown_agent_returns_404(self, client, tmp_path):
+        """Non-existent agent returns 404."""
+        project_dir = tmp_path / "proj"
+        project_dir.mkdir()
+        _register_project(client, project_dir)
+
+        _write_session(project_dir, "run_log7", archived=True)
+        sync_sessions(client.app.state.db_path)
+
+        resp = client.get("/api/sessions/run_log7/logs/agent_nonexistent/full")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Add agent log SSE endpoint (`GET /api/sessions/{id}/logs/{agent_id}`) with snapshot/append/done protocol and REST download endpoint
- Extract shared SSE helpers (`resolve_session_dir`, `watch_dir`) from router to `sse.py` for reuse
- Reorganize SessionDetail page into 5 tabs (Overview, Agent Tree, Logs, Trace, Artifacts) with auto-tab selection and `?tab=` deep-link support
- Add `useAgentLogSSE` frontend hook with reconnection and 10k line cap
- Wire toast notifications (sonner) into `useGlobalSSE` with rate limiting (max 3/type/10s, 2s suppress after reconnect)
- Fix sonner component: remove `next-themes` dependency, hardcode light theme

This is PR1 of Phase 3 (Product UX). It establishes the backend and frontend infrastructure that PR2 (Agent Log Viewer + Launch Dialog) and PR3 (Dashboard Activity Feed) depend on.

## Test plan
- [ ] `cd gui && pytest` — all 125 tests pass (9 new agent log tests)
- [ ] `cd gui/frontend && npm run build` — builds cleanly
- [ ] Navigate to completed session — tabs visible, Overview is default tab
- [ ] Navigate to running session — Agent Tree is default tab
- [ ] Launch a session — toast notification appears
- [ ] Session completes — success toast with summary preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)