### PR TITLE
Add agent log viewer, launch dialog, and skeleton components

### DIFF
--- a/gui/frontend/src/components/AgentLogViewer.tsx
+++ b/gui/frontend/src/components/AgentLogViewer.tsx
@@ -1,0 +1,295 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAgentLogSSE } from "@/hooks/useAgentLogSSE";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ArrowDown, Download, Search } from "lucide-react";
+import type { AgentInfo } from "@/api/types";
+
+const LINE_HEIGHT = 18;
+const OVERSCAN = 10;
+
+interface AgentLogViewerProps {
+  runId: string;
+  agents: Record<string, AgentInfo>;
+  active: boolean;
+}
+
+export default function AgentLogViewer({
+  runId,
+  agents,
+  active,
+}: AgentLogViewerProps) {
+  const agentIds = Object.keys(agents);
+  const rootId = agentIds.find((id) => agents[id].parent === null) ?? agentIds[0] ?? "";
+  const [selectedAgent, setSelectedAgent] = useState(rootId);
+  const { lines, connected, done } = useAgentLogSSE(runId, selectedAgent, true);
+
+  // Search
+  const [search, setSearch] = useState("");
+  const lowerSearch = search.toLowerCase();
+  const matchIndices = search
+    ? lines.reduce<number[]>((acc, line, i) => {
+        if (line.toLowerCase().includes(lowerSearch)) acc.push(i);
+        return acc;
+      }, [])
+    : [];
+
+  // Virtual scrolling
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
+
+  // Auto-scroll
+  const [autoScroll, setAutoScroll] = useState(true);
+  const prevLineCount = useRef(0);
+
+  const totalHeight = lines.length * LINE_HEIGHT;
+  const startIndex = Math.max(0, Math.floor(scrollTop / LINE_HEIGHT) - OVERSCAN);
+  const visibleCount = Math.ceil(containerHeight / LINE_HEIGHT) + OVERSCAN * 2;
+  const endIndex = Math.min(lines.length, startIndex + visibleCount);
+  const visibleLines = lines.slice(startIndex, endIndex);
+  const gutterWidth = String(lines.length).length;
+
+  const handleScroll = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    setScrollTop(el.scrollTop);
+    setContainerHeight(el.clientHeight);
+
+    // Disable auto-scroll if user scrolled away from bottom
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - LINE_HEIGHT * 2;
+    setAutoScroll(atBottom);
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    setContainerHeight(el.clientHeight);
+  }, []);
+
+  // Auto-scroll on new lines
+  useEffect(() => {
+    if (autoScroll && lines.length > prevLineCount.current) {
+      const el = containerRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
+    }
+    prevLineCount.current = lines.length;
+  }, [lines.length, autoScroll]);
+
+  const jumpToBottom = () => {
+    const el = containerRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+      setAutoScroll(true);
+    }
+  };
+
+  const handleDownload = async () => {
+    try {
+      const res = await fetch(
+        `/api/sessions/${runId}/logs/${selectedAgent}/full`,
+      );
+      if (!res.ok) return;
+      const text = await res.text();
+      const blob = new Blob([text], { type: "text/plain" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${selectedAgent}.log`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Toolbar */}
+      <div className="flex items-center gap-2">
+        {agentIds.length > 1 && (
+          <Select value={selectedAgent} onValueChange={setSelectedAgent}>
+            <SelectTrigger className="w-[220px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {agentIds.map((id) => (
+                <SelectItem key={id} value={id}>
+                  {agents[id].role} ({id.slice(0, 8)})
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        {agentIds.length === 1 && (
+          <span className="text-sm text-muted-foreground">
+            {agents[selectedAgent]?.role} ({selectedAgent.slice(0, 8)})
+          </span>
+        )}
+
+        <div className="relative ml-auto">
+          <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            className="h-8 w-[200px] pl-7 text-xs"
+            placeholder="Search logs..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        {search && (
+          <span className="text-xs text-muted-foreground">
+            {matchIndices.length} match{matchIndices.length !== 1 ? "es" : ""}
+          </span>
+        )}
+
+        <Button variant="outline" size="sm" onClick={handleDownload}>
+          <Download className="mr-1 h-3.5 w-3.5" />
+          Download
+        </Button>
+
+        <StatusIndicator connected={connected} done={done} active={active} />
+      </div>
+
+      {/* Terminal */}
+      <div className="relative">
+        <div
+          ref={containerRef}
+          className="h-[500px] overflow-auto rounded-md bg-[#1e1e1e] font-mono text-xs text-[#d4d4d4]"
+          onScroll={handleScroll}
+        >
+          {lines.length === 0 ? (
+            <div className="flex h-full items-center justify-center text-[#666]">
+              {active && !done ? "Waiting for log output..." : "No log output."}
+            </div>
+          ) : (
+            <div style={{ height: totalHeight, position: "relative" }}>
+              <div
+                style={{
+                  position: "absolute",
+                  top: startIndex * LINE_HEIGHT,
+                  left: 0,
+                  right: 0,
+                }}
+              >
+                {visibleLines.map((line, i) => {
+                  const lineNum = startIndex + i;
+                  const isMatch =
+                    search && line.toLowerCase().includes(lowerSearch);
+                  return (
+                    <div
+                      key={lineNum}
+                      className={isMatch ? "bg-yellow-900/30" : undefined}
+                      style={{
+                        height: LINE_HEIGHT,
+                        lineHeight: `${LINE_HEIGHT}px`,
+                        display: "flex",
+                        whiteSpace: "pre",
+                      }}
+                    >
+                      <span
+                        className="select-none text-right text-[#555]"
+                        style={{
+                          width: `${(gutterWidth + 2) * 0.6}em`,
+                          paddingRight: "1em",
+                          flexShrink: 0,
+                        }}
+                      >
+                        {lineNum + 1}
+                      </span>
+                      <span>
+                        {isMatch ? (
+                          <HighlightedLine line={line} search={lowerSearch} />
+                        ) : (
+                          line
+                        )}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Jump to bottom button */}
+        {!autoScroll && lines.length > 0 && (
+          <Button
+            size="sm"
+            variant="secondary"
+            className="absolute bottom-3 right-4 shadow-md"
+            onClick={jumpToBottom}
+          >
+            <ArrowDown className="mr-1 h-3.5 w-3.5" />
+            Jump to bottom
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatusIndicator({
+  connected,
+  done,
+  active,
+}: {
+  connected: boolean;
+  done: boolean;
+  active: boolean;
+}) {
+  if (done || !active) {
+    return (
+      <span className="text-xs text-muted-foreground">
+        Session ended
+      </span>
+    );
+  }
+  return (
+    <span className="flex items-center gap-1 text-xs text-muted-foreground">
+      <span
+        className={`inline-block h-1.5 w-1.5 rounded-full ${
+          connected ? "animate-pulse bg-green-500" : "bg-orange-400"
+        }`}
+      />
+      {connected ? "Live" : "Connecting..."}
+    </span>
+  );
+}
+
+function HighlightedLine({
+  line,
+  search,
+}: {
+  line: string;
+  search: string;
+}) {
+  const parts: React.ReactNode[] = [];
+  const lower = line.toLowerCase();
+  let lastIndex = 0;
+  let idx = lower.indexOf(search, lastIndex);
+  let key = 0;
+
+  while (idx !== -1) {
+    if (idx > lastIndex) {
+      parts.push(line.slice(lastIndex, idx));
+    }
+    parts.push(
+      <span key={key++} className="bg-yellow-500/60 text-white">
+        {line.slice(idx, idx + search.length)}
+      </span>,
+    );
+    lastIndex = idx + search.length;
+    idx = lower.indexOf(search, lastIndex);
+  }
+  if (lastIndex < line.length) {
+    parts.push(line.slice(lastIndex));
+  }
+  return <>{parts}</>;
+}

--- a/gui/frontend/src/components/LaunchDialog.tsx
+++ b/gui/frontend/src/components/LaunchDialog.tsx
@@ -1,0 +1,206 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useProjectConfig } from "@/hooks/queries/use-projects";
+import { useRoles } from "@/hooks/queries/use-roles";
+import { useLaunchSession } from "@/hooks/mutations/use-sessions";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { ChevronDown } from "lucide-react";
+
+interface LaunchDialogProps {
+  projectId: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function LaunchDialog({
+  projectId,
+  open,
+  onOpenChange,
+}: LaunchDialogProps) {
+  const navigate = useNavigate();
+  const config = useProjectConfig(projectId);
+  const roles = useRoles();
+  const launchSession = useLaunchSession();
+  const defaults = config.data?.merged;
+
+  const [task, setTask] = useState("");
+  const [role, setRole] = useState("");
+  const [runtime, setRuntime] = useState("");
+  const [isolation, setIsolation] = useState("");
+  const [mergeStrategy, setMergeStrategy] = useState("");
+
+  const resetForm = () => {
+    setTask("");
+    setRole("");
+    setRuntime("");
+    setIsolation("");
+    setMergeStrategy("");
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const body: {
+        project_id: number;
+        task: string;
+        role?: string;
+        overrides?: Record<string, string>;
+      } = {
+        project_id: projectId,
+        task: task.trim(),
+      };
+      if (role.trim()) body.role = role.trim();
+
+      const overrides: Record<string, string> = {};
+      if (runtime.trim()) overrides.runtime = runtime.trim();
+      if (isolation.trim()) overrides.isolation = isolation.trim();
+      if (mergeStrategy.trim()) overrides.merge_strategy = mergeStrategy.trim();
+      if (Object.keys(overrides).length > 0) body.overrides = overrides;
+
+      const result = await launchSession.mutateAsync(body);
+      resetForm();
+      onOpenChange(false);
+      navigate(`/projects/${projectId}/sessions/${result.run_id}`);
+    } catch {
+      // error state handled by mutation
+    }
+  };
+
+  const defaultRole = defaults?.orchestrator_role ?? "orchestrator";
+  const installedRoles = (roles.data ?? []).filter((v) => v !== defaultRole);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Launch Session</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="task">
+              Task <span className="text-destructive">*</span>
+            </Label>
+            <Textarea
+              id="task"
+              value={task}
+              onChange={(e) => setTask(e.target.value)}
+              placeholder="Describe what the agent should do..."
+              required
+              autoFocus
+              rows={3}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="role">Role</Label>
+            <Select value={role} onValueChange={setRole}>
+              <SelectTrigger id="role">
+                <SelectValue placeholder={defaultRole} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={defaultRole}>{defaultRole}</SelectItem>
+                {installedRoles.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {v}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Collapsible>
+            <CollapsibleTrigger asChild>
+              <Button type="button" variant="ghost" size="sm">
+                <ChevronDown className="mr-1 h-4 w-4" />
+                Advanced Options
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="mt-3 space-y-4">
+              <div className="grid grid-cols-3 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="runtime">Runtime</Label>
+                  <Input
+                    id="runtime"
+                    value={runtime}
+                    onChange={(e) => setRuntime(e.target.value)}
+                    placeholder={defaults?.runtime ?? "strawpot-claude-code"}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="isolation">Isolation</Label>
+                  <Select value={isolation} onValueChange={setIsolation}>
+                    <SelectTrigger id="isolation">
+                      <SelectValue
+                        placeholder={defaults?.isolation ?? "none"}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">none</SelectItem>
+                      <SelectItem value="worktree">worktree</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="merge-strategy">Merge Strategy</Label>
+                  <Select
+                    value={mergeStrategy}
+                    onValueChange={setMergeStrategy}
+                  >
+                    <SelectTrigger id="merge-strategy">
+                      <SelectValue
+                        placeholder={defaults?.merge_strategy ?? "auto"}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="auto">auto</SelectItem>
+                      <SelectItem value="local">local</SelectItem>
+                      <SelectItem value="pr">pr</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+
+          {launchSession.error && (
+            <p className="text-sm text-destructive">
+              {launchSession.error.message}
+            </p>
+          )}
+          <div className="flex gap-2">
+            <Button type="submit" disabled={launchSession.isPending}>
+              {launchSession.isPending ? "Launching..." : "Launch"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/gui/frontend/src/components/skeletons/DashboardSkeleton.tsx
+++ b/gui/frontend/src/components/skeletons/DashboardSkeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DashboardSkeleton() {
+  return (
+    <div className="space-y-8">
+      <Skeleton className="h-8 w-40" />
+      <div className="space-y-3">
+        <Skeleton className="h-4 w-24" />
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-28 rounded-lg" />
+          ))}
+        </div>
+      </div>
+      <div className="space-y-3">
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-48 rounded-lg" />
+      </div>
+    </div>
+  );
+}

--- a/gui/frontend/src/components/skeletons/ProjectDetailSkeleton.tsx
+++ b/gui/frontend/src/components/skeletons/ProjectDetailSkeleton.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ProjectDetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="h-24 rounded-lg" />
+      <Skeleton className="h-64 rounded-lg" />
+    </div>
+  );
+}

--- a/gui/frontend/src/components/skeletons/SessionDetailSkeleton.tsx
+++ b/gui/frontend/src/components/skeletons/SessionDetailSkeleton.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function SessionDetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-8 w-64" />
+      <Skeleton className="h-32 rounded-lg" />
+      <Skeleton className="h-64 rounded-lg" />
+    </div>
+  );
+}

--- a/gui/frontend/src/pages/Dashboard.tsx
+++ b/gui/frontend/src/pages/Dashboard.tsx
@@ -9,8 +9,8 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
 import { AlertCircle, FolderKanban } from "lucide-react";
+import DashboardSkeleton from "@/components/skeletons/DashboardSkeleton";
 
 export default function Dashboard() {
   const projects = useProjects();
@@ -143,22 +143,3 @@ export default function Dashboard() {
   );
 }
 
-function DashboardSkeleton() {
-  return (
-    <div className="space-y-8">
-      <Skeleton className="h-8 w-40" />
-      <div className="space-y-3">
-        <Skeleton className="h-4 w-24" />
-        <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
-          {[1, 2, 3].map((i) => (
-            <Skeleton key={i} className="h-28 rounded-lg" />
-          ))}
-        </div>
-      </div>
-      <div className="space-y-3">
-        <Skeleton className="h-4 w-32" />
-        <Skeleton className="h-48 rounded-lg" />
-      </div>
-    </div>
-  );
-}

--- a/gui/frontend/src/pages/ProjectDetail.tsx
+++ b/gui/frontend/src/pages/ProjectDetail.tsx
@@ -1,49 +1,27 @@
 import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
-import { useProject, useProjectConfig } from "@/hooks/queries/use-projects";
+import { Link, useParams } from "react-router-dom";
+import { useProject } from "@/hooks/queries/use-projects";
 import { useProjectSessions } from "@/hooks/queries/use-sessions";
-import { useRoles } from "@/hooks/queries/use-roles";
-import { useLaunchSession } from "@/hooks/mutations/use-sessions";
 import SessionTable from "@/components/SessionTable";
+import LaunchDialog from "@/components/LaunchDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import { AlertCircle, ArrowLeft, ChevronDown, Play } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { AlertCircle, ArrowLeft, Play } from "lucide-react";
+import ProjectDetailSkeleton from "@/components/skeletons/ProjectDetailSkeleton";
 
 export default function ProjectDetail() {
   const { projectId } = useParams();
   const pid = Number(projectId);
   const project = useProject(pid);
   const sessions = useProjectSessions(pid);
-  const [showLaunch, setShowLaunch] = useState(false);
+  const [launchOpen, setLaunchOpen] = useState(false);
 
   const loading = project.isLoading || sessions.isLoading;
   const error = project.error || sessions.error;
 
   if (loading) {
-    return (
-      <div className="space-y-6">
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="h-24 rounded-lg" />
-        <Skeleton className="h-64 rounded-lg" />
-      </div>
-    );
+    return <ProjectDetailSkeleton />;
   }
   if (error) {
     return (
@@ -70,7 +48,7 @@ export default function ProjectDetail() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-tight">{p.display_name}</h1>
         <div className="flex gap-2">
-          <Button onClick={() => setShowLaunch(true)} disabled={!p.dir_exists}>
+          <Button onClick={() => setLaunchOpen(true)} disabled={!p.dir_exists}>
             <Play className="mr-2 h-4 w-4" />
             Launch Session
           </Button>
@@ -111,13 +89,11 @@ export default function ProjectDetail() {
         </CardContent>
       </Card>
 
-      {showLaunch && (
-        <LaunchForm
-          projectId={pid}
-          onLaunched={() => setShowLaunch(false)}
-          onCancel={() => setShowLaunch(false)}
-        />
-      )}
+      <LaunchDialog
+        projectId={pid}
+        open={launchOpen}
+        onOpenChange={setLaunchOpen}
+      />
 
       <section className="space-y-3">
         <h2 className="text-sm font-medium text-muted-foreground">
@@ -136,168 +112,5 @@ export default function ProjectDetail() {
         )}
       </section>
     </div>
-  );
-}
-
-function LaunchForm({
-  projectId,
-  onLaunched,
-  onCancel,
-}: {
-  projectId: number;
-  onLaunched: () => void;
-  onCancel: () => void;
-}) {
-  const navigate = useNavigate();
-  const config = useProjectConfig(projectId);
-  const roles = useRoles();
-  const launchSession = useLaunchSession();
-  const defaults = config.data?.merged;
-
-  const [task, setTask] = useState("");
-  const [role, setRole] = useState("");
-  const [runtime, setRuntime] = useState("");
-  const [isolation, setIsolation] = useState("");
-  const [mergeStrategy, setMergeStrategy] = useState("");
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-      const body: {
-        project_id: number;
-        task: string;
-        role?: string;
-        overrides?: Record<string, string>;
-      } = {
-        project_id: projectId,
-        task: task.trim(),
-      };
-      if (role.trim()) body.role = role.trim();
-
-      const overrides: Record<string, string> = {};
-      if (runtime.trim()) overrides.runtime = runtime.trim();
-      if (isolation.trim()) overrides.isolation = isolation.trim();
-      if (mergeStrategy.trim()) overrides.merge_strategy = mergeStrategy.trim();
-      if (Object.keys(overrides).length > 0) body.overrides = overrides;
-
-      const result = await launchSession.mutateAsync(body);
-      onLaunched();
-      navigate(`/projects/${projectId}/sessions/${result.run_id}`);
-    } catch {
-      // error state handled by mutation
-    }
-  };
-
-  const defaultRole = defaults?.orchestrator_role ?? "orchestrator";
-  const installedRoles = (roles.data ?? []).filter((v) => v !== defaultRole);
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Launch Session</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="task">
-              Task <span className="text-destructive">*</span>
-            </Label>
-            <Textarea
-              id="task"
-              value={task}
-              onChange={(e) => setTask(e.target.value)}
-              placeholder="Describe what the agent should do..."
-              required
-              autoFocus
-              rows={3}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="role">Role</Label>
-            <Select value={role} onValueChange={setRole}>
-              <SelectTrigger id="role">
-                <SelectValue placeholder={defaultRole} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={defaultRole}>{defaultRole}</SelectItem>
-                {installedRoles.map((v) => (
-                  <SelectItem key={v} value={v}>
-                    {v}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <Collapsible>
-            <CollapsibleTrigger asChild>
-              <Button type="button" variant="ghost" size="sm">
-                <ChevronDown className="mr-1 h-4 w-4" />
-                Advanced Options
-              </Button>
-            </CollapsibleTrigger>
-            <CollapsibleContent className="mt-3 space-y-4">
-              <div className="grid grid-cols-3 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="runtime">Runtime</Label>
-                  <Input
-                    id="runtime"
-                    value={runtime}
-                    onChange={(e) => setRuntime(e.target.value)}
-                    placeholder={defaults?.runtime ?? "strawpot-claude-code"}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="isolation">Isolation</Label>
-                  <Select value={isolation} onValueChange={setIsolation}>
-                    <SelectTrigger id="isolation">
-                      <SelectValue
-                        placeholder={defaults?.isolation ?? "none"}
-                      />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="none">none</SelectItem>
-                      <SelectItem value="worktree">worktree</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="merge-strategy">Merge Strategy</Label>
-                  <Select
-                    value={mergeStrategy}
-                    onValueChange={setMergeStrategy}
-                  >
-                    <SelectTrigger id="merge-strategy">
-                      <SelectValue
-                        placeholder={defaults?.merge_strategy ?? "auto"}
-                      />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="auto">auto</SelectItem>
-                      <SelectItem value="local">local</SelectItem>
-                      <SelectItem value="pr">pr</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            </CollapsibleContent>
-          </Collapsible>
-
-          {launchSession.error && (
-            <p className="text-sm text-destructive">
-              {launchSession.error.message}
-            </p>
-          )}
-          <div className="flex gap-2">
-            <Button type="submit" disabled={launchSession.isPending}>
-              {launchSession.isPending ? "Launching..." : "Launch"}
-            </Button>
-            <Button type="button" variant="outline" onClick={onCancel}>
-              Cancel
-            </Button>
-          </div>
-        </form>
-      </CardContent>
-    </Card>
   );
 }

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -3,12 +3,13 @@ import { Link, useParams, useSearchParams } from "react-router-dom";
 import { useSession } from "@/hooks/queries/use-sessions";
 import { useStopSession } from "@/hooks/mutations/use-sessions";
 import AgentTreeFlow from "@/components/AgentTreeFlow";
+import AgentLogViewer from "@/components/AgentLogViewer";
 import { formatTime, formatDuration } from "@/components/SessionTable";
 import { useTraceSSE } from "@/hooks/useTraceSSE";
+import SessionDetailSkeleton from "@/components/skeletons/SessionDetailSkeleton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Table,
@@ -66,13 +67,7 @@ export default function SessionDetail() {
   const displayEvents = sseEvents.length > 0 ? sseEvents : restEvents;
 
   if (session.isLoading) {
-    return (
-      <div className="space-y-6">
-        <Skeleton className="h-8 w-64" />
-        <Skeleton className="h-32 rounded-lg" />
-        <Skeleton className="h-64 rounded-lg" />
-      </div>
-    );
+    return <SessionDetailSkeleton />;
   }
   if (session.error) {
     return (
@@ -162,9 +157,17 @@ export default function SessionDetail() {
         </TabsContent>
 
         <TabsContent value="logs">
-          <p className="text-sm text-muted-foreground">
-            Agent log viewer coming in a future update.
-          </p>
+          {Object.keys(sessionData.agents).length > 0 ? (
+            <AgentLogViewer
+              runId={sessionData.run_id}
+              agents={sessionData.agents}
+              active={active}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No agents registered yet.
+            </p>
+          )}
         </TabsContent>
 
         <TabsContent value="trace">


### PR DESCRIPTION
## Summary
- **AgentLogViewer**: Terminal-style log viewer with virtual scrolling (18px fixed line height), search with match highlighting, auto-scroll with "Jump to bottom" button, agent selector dropdown, and full log download
- **LaunchDialog**: Extracted inline `LaunchForm` from `ProjectDetail.tsx` into a reusable `Dialog`-wrapped component with form reset on close
- **Skeleton components**: Extracted loading skeletons from Dashboard, ProjectDetail, and SessionDetail into `components/skeletons/`
- Wired `AgentLogViewer` into the SessionDetail **Logs** tab (replaces placeholder text)

## Test plan
- [ ] All 125 backend tests pass
- [ ] Frontend builds cleanly (`npm run build`)
- [ ] Navigate to a completed session → Logs tab shows log viewer with agent output
- [ ] Log viewer: search filters lines, Download fetches full log, agent selector switches agents
- [ ] ProjectDetail: "Launch Session" opens a dialog instead of inline card
- [ ] Loading states on Dashboard, ProjectDetail, SessionDetail show skeleton placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)