### PR TITLE
Add dashboard activity feed with live agent output

### DIFF
--- a/gui/frontend/src/components/ActiveAgentsPanel.tsx
+++ b/gui/frontend/src/components/ActiveAgentsPanel.tsx
@@ -1,0 +1,82 @@
+import { useQueries } from "@tanstack/react-query";
+import { useRunningSessions } from "@/hooks/queries/use-sessions";
+import { api } from "@/api/client";
+import { queryKeys } from "@/lib/query-keys";
+import AgentActivityCard from "@/components/AgentActivityCard";
+import type { SessionDetail } from "@/api/types";
+
+const MAX_CARDS = 8;
+
+interface AgentEntry {
+  runId: string;
+  projectId: number;
+  agentId: string;
+  role: string;
+  runtime: string;
+  startedAt: string;
+}
+
+export default function ActiveAgentsPanel() {
+  const running = useRunningSessions();
+  const runningSessions = running.data?.items ?? [];
+
+  // Fetch session details in parallel to get agents map
+  const detailQueries = useQueries({
+    queries: runningSessions.slice(0, MAX_CARDS).map((s) => ({
+      queryKey: queryKeys.sessions.detail(s.project_id, s.run_id),
+      queryFn: () =>
+        api.get<SessionDetail>(
+          `/projects/${s.project_id}/sessions/${s.run_id}`,
+        ),
+      staleTime: 10_000,
+    })),
+  });
+
+  // Flatten all agents across sessions
+  const agents: AgentEntry[] = [];
+  for (const q of detailQueries) {
+    if (!q.data) continue;
+    const session = q.data;
+    for (const [agentId, info] of Object.entries(session.agents)) {
+      agents.push({
+        runId: session.run_id,
+        projectId: session.project_id,
+        agentId,
+        role: info.role,
+        runtime: info.runtime,
+        startedAt: info.started_at,
+      });
+    }
+  }
+
+  if (agents.length === 0) return null;
+
+  const visible = agents.slice(0, MAX_CARDS);
+  const overflow = agents.length - MAX_CARDS;
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-medium text-muted-foreground">
+        Active Agents ({agents.length})
+      </h2>
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-3">
+        {visible.map((a) => (
+          <AgentActivityCard
+            key={`${a.runId}:${a.agentId}`}
+            runId={a.runId}
+            projectId={a.projectId}
+            agentId={a.agentId}
+            role={a.role}
+            runtime={a.runtime}
+            startedAt={a.startedAt}
+          />
+        ))}
+      </div>
+      {overflow > 0 && (
+        <p className="text-xs text-muted-foreground">
+          +{overflow} more agent{overflow !== 1 ? "s" : ""} running
+        </p>
+      )}
+    </section>
+  );
+}

--- a/gui/frontend/src/components/AgentActivityCard.tsx
+++ b/gui/frontend/src/components/AgentActivityCard.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { useAgentLogSSE } from "@/hooks/useAgentLogSSE";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ChevronRight } from "lucide-react";
+
+const TAIL_LINES = 4;
+const IDLE_TIMEOUT_MS = 5000;
+
+interface AgentActivityCardProps {
+  runId: string;
+  projectId: number;
+  agentId: string;
+  role: string;
+  runtime: string;
+  startedAt: string;
+}
+
+export default function AgentActivityCard({
+  runId,
+  projectId,
+  agentId,
+  role,
+  runtime,
+  startedAt,
+}: AgentActivityCardProps) {
+  const { lines, done } = useAgentLogSSE(runId, agentId, true);
+  const tail = lines.slice(-TAIL_LINES);
+
+  // Elapsed time counter
+  const [elapsed, setElapsed] = useState("");
+  useEffect(() => {
+    const start = new Date(startedAt).getTime();
+    const update = () => {
+      const ms = Date.now() - start;
+      const s = Math.floor(ms / 1000) % 60;
+      const m = Math.floor(ms / 60000) % 60;
+      const h = Math.floor(ms / 3600000);
+      setElapsed(h > 0 ? `${h}h ${m}m` : `${m}m ${s}s`);
+    };
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [startedAt]);
+
+  // Idle detection — dim dot after 5s of no new lines
+  const lastLineCount = useRef(lines.length);
+  const lastActivityTime = useRef(Date.now());
+  const [idle, setIdle] = useState(false);
+
+  useEffect(() => {
+    if (lines.length !== lastLineCount.current) {
+      lastLineCount.current = lines.length;
+      lastActivityTime.current = Date.now();
+      setIdle(false);
+    }
+  }, [lines.length]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (Date.now() - lastActivityTime.current > IDLE_TIMEOUT_MS) {
+        setIdle(true);
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <Card className="overflow-hidden">
+      <CardContent className="space-y-2 pt-4">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span
+              className={`inline-block h-2 w-2 rounded-full ${
+                done
+                  ? "bg-muted-foreground"
+                  : idle
+                    ? "bg-green-300"
+                    : "animate-pulse bg-green-500"
+              }`}
+            />
+            <span className="font-medium text-sm">{role}</span>
+          </div>
+          <Badge variant="outline" className="text-xs">
+            {runtime.replace("strawpot-", "")}
+          </Badge>
+        </div>
+
+        {/* Session info */}
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span>Session: {runId.slice(0, 12)}</span>
+          <span>&middot;</span>
+          <span>{elapsed}</span>
+        </div>
+
+        {/* Log tail */}
+        <div className="rounded bg-[#1e1e1e] px-2 py-1.5 font-mono text-[11px] leading-[16px] text-[#d4d4d4]">
+          {tail.length > 0 ? (
+            tail.map((line, i) => (
+              <div key={i} className="truncate">
+                <span className="text-[#666]">&gt; </span>
+                {line}
+              </div>
+            ))
+          ) : (
+            <div className="text-[#555]">Waiting for output...</div>
+          )}
+        </div>
+
+        {/* Link */}
+        <div className="flex justify-end">
+          <Link
+            to={`/projects/${projectId}/sessions/${runId}?tab=logs`}
+            className="inline-flex items-center gap-0.5 text-xs text-primary hover:underline"
+          >
+            View Session
+            <ChevronRight className="h-3 w-3" />
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/gui/frontend/src/layouts/AppLayout.tsx
+++ b/gui/frontend/src/layouts/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Outlet, useLocation } from "react-router-dom";
+import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
 import { LayoutDashboard, FolderKanban } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useProject } from "@/hooks/queries/use-projects";
@@ -53,7 +53,7 @@ export default function AppLayout() {
       {/* Sidebar */}
       <aside className="flex w-56 flex-col border-r border-border bg-card">
         <div className="flex h-14 items-center border-b border-border px-4">
-          <span className="text-lg font-bold tracking-tight">StrawPot</span>
+          <Link to="/" className="text-lg font-bold tracking-tight hover:text-foreground/80">StrawPot</Link>
         </div>
         <nav className="flex flex-col gap-1 p-3">
           {navItems.map(({ to, label, icon: Icon, end }) => (

--- a/gui/frontend/src/pages/Dashboard.tsx
+++ b/gui/frontend/src/pages/Dashboard.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { AlertCircle, FolderKanban } from "lucide-react";
+import ActiveAgentsPanel from "@/components/ActiveAgentsPanel";
 import DashboardSkeleton from "@/components/skeletons/DashboardSkeleton";
 
 export default function Dashboard() {
@@ -50,6 +51,9 @@ export default function Dashboard() {
   return (
     <div className="space-y-8">
       <h1 className="text-2xl font-bold tracking-tight">Dashboard</h1>
+
+      {/* Active Agents */}
+      <ActiveAgentsPanel />
 
       {/* Projects */}
       <section className="space-y-3">


### PR DESCRIPTION
## Summary
- **AgentActivityCard**: Live agent output card with pulsing status dot (dims after 5s idle), elapsed time counter, last 4 log lines in dark terminal mini-view, link to session Logs tab
- **ActiveAgentsPanel**: Fetches running session details via `useQueries`, flattens agents across sessions, renders grid of activity cards (max 8, "+N more" overflow). Returns `null` when no agents running
- **StrawPot logo** in sidebar now links to Dashboard

**Depends on PR #149** — merge that first, then this PR's diff will show only the activity feed changes.

## Test plan
- [ ] Frontend builds cleanly (`npm run build`)
- [ ] All 125 backend tests pass
- [ ] Dashboard shows no activity section when no agents running
- [ ] Dashboard shows activity cards with live log output when agents are running
- [ ] Activity cards show pulsing green dot, elapsed time, last 4 lines of log output
- [ ] "View Session" link navigates to session detail Logs tab
- [ ] Clicking "StrawPot" logo navigates to Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)