### PR TITLE
Add dark mode, command palette, and keyboard shortcuts (Phase 4)

### DIFF
--- a/gui/frontend/src/components/CommandPalette.tsx
+++ b/gui/frontend/src/components/CommandPalette.tsx
@@ -1,0 +1,108 @@
+import { useNavigate } from "react-router-dom";
+import { useTheme } from "next-themes";
+import { useProjects } from "@/hooks/queries/use-projects";
+import { useRunningSessions } from "@/hooks/queries/use-sessions";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandShortcut,
+} from "@/components/ui/command";
+import {
+  LayoutDashboard,
+  FolderKanban,
+  Play,
+  Sun,
+  Moon,
+  Monitor,
+} from "lucide-react";
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function CommandPalette({
+  open,
+  onOpenChange,
+}: CommandPaletteProps) {
+  const navigate = useNavigate();
+  const { setTheme } = useTheme();
+  const projects = useProjects();
+  const running = useRunningSessions();
+
+  const projectList = projects.data ?? [];
+  const runningSessions = running.data?.items ?? [];
+
+  const go = (path: string) => {
+    onOpenChange(false);
+    navigate(path);
+  };
+
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange} showCloseButton={false}>
+      <CommandInput placeholder="Type a command or search..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+
+        <CommandGroup heading="Navigation">
+          <CommandItem onSelect={() => go("/")}>
+            <LayoutDashboard />
+            Dashboard
+            <CommandShortcut>G D</CommandShortcut>
+          </CommandItem>
+          <CommandItem onSelect={() => go("/projects")}>
+            <FolderKanban />
+            Projects
+            <CommandShortcut>G P</CommandShortcut>
+          </CommandItem>
+        </CommandGroup>
+
+        {projectList.length > 0 && (
+          <CommandGroup heading="Projects">
+            {projectList.map((p) => (
+              <CommandItem key={p.id} onSelect={() => go(`/projects/${p.id}`)}>
+                <FolderKanban />
+                {p.display_name}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {runningSessions.length > 0 && (
+          <CommandGroup heading="Running Sessions">
+            {runningSessions.map((s) => (
+              <CommandItem
+                key={s.run_id}
+                onSelect={() =>
+                  go(`/projects/${s.project_id}/sessions/${s.run_id}`)
+                }
+              >
+                <Play />
+                {s.role} ({s.run_id.slice(0, 8)})
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        <CommandGroup heading="Theme">
+          <CommandItem onSelect={() => { setTheme("light"); onOpenChange(false); }}>
+            <Sun />
+            Light
+          </CommandItem>
+          <CommandItem onSelect={() => { setTheme("dark"); onOpenChange(false); }}>
+            <Moon />
+            Dark
+          </CommandItem>
+          <CommandItem onSelect={() => { setTheme("system"); onOpenChange(false); }}>
+            <Monitor />
+            System
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/gui/frontend/src/components/KeyboardShortcutsDialog.tsx
+++ b/gui/frontend/src/components/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,53 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+const shortcuts = [
+  { keys: ["⌘", "K"], description: "Open command palette" },
+  { keys: ["G", "D"], description: "Go to Dashboard" },
+  { keys: ["G", "P"], description: "Go to Projects" },
+  { keys: ["?"], description: "Show keyboard shortcuts" },
+];
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function KeyboardShortcutsDialog({
+  open,
+  onOpenChange,
+}: KeyboardShortcutsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Keyboard Shortcuts</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-2">
+          {shortcuts.map((s) => (
+            <div
+              key={s.description}
+              className="flex items-center justify-between text-sm"
+            >
+              <span className="text-muted-foreground">{s.description}</span>
+              <div className="flex gap-1">
+                {s.keys.map((key) => (
+                  <kbd
+                    key={key}
+                    className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs"
+                  >
+                    {key}
+                  </kbd>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/gui/frontend/src/components/SessionTable.tsx
+++ b/gui/frontend/src/components/SessionTable.tsx
@@ -80,13 +80,13 @@ function StatusBadge({ status }: { status: string }) {
       className={cn(
         "text-xs font-medium",
         variant === "running" &&
-          "border-green-200 bg-green-50 text-green-700",
+          "border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400",
         variant === "success" &&
-          "border-green-200 bg-green-50 text-green-700",
+          "border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400",
         variant === "error" &&
-          "border-red-200 bg-red-50 text-red-700",
+          "border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-400",
         variant === "warning" &&
-          "border-orange-200 bg-orange-50 text-orange-700",
+          "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-400",
         variant === "default" &&
           "border-muted bg-muted text-muted-foreground",
       )}

--- a/gui/frontend/src/components/ui/sonner.tsx
+++ b/gui/frontend/src/components/ui/sonner.tsx
@@ -5,12 +5,15 @@ import {
   OctagonXIcon,
   TriangleAlertIcon,
 } from "lucide-react"
+import { useTheme } from "next-themes"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
   return (
     <Sonner
-      theme="light"
+      theme={theme as ToasterProps["theme"]}
       className="toaster group"
       icons={{
         success: <CircleCheckIcon className="size-4" />,

--- a/gui/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/gui/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+
+const SEQUENCE_TIMEOUT_MS = 500;
+
+interface UseKeyboardShortcutsOptions {
+  onCommandPalette: () => void;
+  onShortcutsHelp: () => void;
+}
+
+export function useKeyboardShortcuts({
+  onCommandPalette,
+  onShortcutsHelp,
+}: UseKeyboardShortcutsOptions) {
+  const navigate = useNavigate();
+  const pendingKey = useRef<string | null>(null);
+  const pendingTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      // Suppress when focus is in an input-like element
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      // Cmd+K / Ctrl+K — command palette
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        onCommandPalette();
+        return;
+      }
+
+      // Ignore if modifier keys are held (except for Cmd+K above)
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      // ? — shortcuts help
+      if (e.key === "?") {
+        e.preventDefault();
+        onShortcutsHelp();
+        return;
+      }
+
+      // Two-key sequences: g+d, g+p
+      if (pendingKey.current === "g") {
+        pendingKey.current = null;
+        clearTimeout(pendingTimer.current);
+
+        if (e.key === "d") {
+          e.preventDefault();
+          navigate("/");
+          return;
+        }
+        if (e.key === "p") {
+          e.preventDefault();
+          navigate("/projects");
+          return;
+        }
+      }
+
+      if (e.key === "g") {
+        pendingKey.current = "g";
+        pendingTimer.current = setTimeout(() => {
+          pendingKey.current = null;
+        }, SEQUENCE_TIMEOUT_MS);
+        return;
+      }
+    }
+
+    document.addEventListener("keydown", handler);
+    return () => {
+      document.removeEventListener("keydown", handler);
+      clearTimeout(pendingTimer.current);
+    };
+  }, [navigate, onCommandPalette, onShortcutsHelp]);
+}

--- a/gui/frontend/src/index.css
+++ b/gui/frontend/src/index.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+/* Use class-based dark mode (matches next-themes attribute="class") */
+@custom-variant dark (&:is(.dark *));
+
 /*
  * Map CSS variables to Tailwind 4 theme so that utility classes
  * like bg-primary, text-muted-foreground, border-border work.

--- a/gui/frontend/src/layouts/AppLayout.tsx
+++ b/gui/frontend/src/layouts/AppLayout.tsx
@@ -1,7 +1,12 @@
+import { useState } from "react";
 import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
-import { LayoutDashboard, FolderKanban } from "lucide-react";
+import { useTheme } from "next-themes";
+import { LayoutDashboard, FolderKanban, Sun, Moon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useProject } from "@/hooks/queries/use-projects";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import CommandPalette from "@/components/CommandPalette";
+import KeyboardShortcutsDialog from "@/components/KeyboardShortcutsDialog";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -10,6 +15,13 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Separator } from "@/components/ui/separator";
 
 const navItems = [
@@ -47,6 +59,14 @@ function useBreadcrumbs() {
 
 export default function AppLayout() {
   const crumbs = useBreadcrumbs();
+  const { setTheme } = useTheme();
+  const [cmdOpen, setCmdOpen] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+
+  useKeyboardShortcuts({
+    onCommandPalette: () => setCmdOpen(true),
+    onShortcutsHelp: () => setShortcutsOpen(true),
+  });
 
   return (
     <div className="flex min-h-screen">
@@ -75,11 +95,12 @@ export default function AppLayout() {
             </NavLink>
           ))}
         </nav>
+
       </aside>
 
       {/* Main content */}
       <div className="flex flex-1 flex-col">
-        <header className="flex h-14 items-center border-b border-border px-6">
+        <header className="flex h-14 items-center justify-between border-b border-border px-6">
           <Breadcrumb>
             <BreadcrumbList>
               {crumbs.map((crumb, i) => {
@@ -99,12 +120,47 @@ export default function AppLayout() {
               })}
             </BreadcrumbList>
           </Breadcrumb>
+          <div className="flex items-center gap-1.5">
+            <button
+              onClick={() => setCmdOpen(true)}
+              className="flex items-center gap-1.5 rounded-md border border-border bg-muted/50 px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted"
+            >
+              <kbd className="font-mono">⌘K</kbd>
+            </button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+                  <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+                  <span className="sr-only">Toggle theme</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => setTheme("light")}>
+                  Light
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setTheme("dark")}>
+                  Dark
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setTheme("system")}>
+                  System
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </header>
         <Separator />
         <main className="flex-1 overflow-auto p-6">
           <Outlet />
         </main>
       </div>
+
+      {/* Command palette + shortcuts help */}
+      <CommandPalette open={cmdOpen} onOpenChange={setCmdOpen} />
+      <KeyboardShortcutsDialog
+        open={shortcutsOpen}
+        onOpenChange={setShortcutsOpen}
+      />
     </div>
   );
 }

--- a/gui/frontend/src/main.tsx
+++ b/gui/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "next-themes";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
 import { queryClient } from "@/lib/query-client";
@@ -10,13 +11,15 @@ import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-        <Toaster />
-      </TooltipProvider>
-    </QueryClientProvider>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+          <Toaster />
+        </TooltipProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
   </StrictMode>,
 );

--- a/gui/frontend/src/pages/Dashboard.tsx
+++ b/gui/frontend/src/pages/Dashboard.tsx
@@ -83,7 +83,7 @@ export default function Dashboard() {
                       {!p.dir_exists && (
                         <Badge
                           variant="outline"
-                          className="border-orange-200 bg-orange-50 text-xs text-orange-700"
+                          className="border-orange-200 bg-orange-50 text-xs text-orange-700 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-400"
                         >
                           Directory missing
                         </Badge>
@@ -91,7 +91,7 @@ export default function Dashboard() {
                       {(runningByProject.get(p.id) ?? 0) > 0 && (
                         <Badge
                           variant="outline"
-                          className="border-green-200 bg-green-50 text-xs text-green-700"
+                          className="border-green-200 bg-green-50 text-xs text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400"
                         >
                           <span className="mr-1 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-green-500" />
                           {runningByProject.get(p.id)} running

--- a/gui/frontend/src/pages/ProjectDetail.tsx
+++ b/gui/frontend/src/pages/ProjectDetail.tsx
@@ -70,14 +70,14 @@ export default function ProjectDetail() {
               {p.dir_exists ? (
                 <Badge
                   variant="outline"
-                  className="border-green-200 bg-green-50 text-xs text-green-700"
+                  className="border-green-200 bg-green-50 text-xs text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400"
                 >
                   OK
                 </Badge>
               ) : (
                 <Badge
                   variant="outline"
-                  className="border-orange-200 bg-orange-50 text-xs text-orange-700"
+                  className="border-orange-200 bg-orange-50 text-xs text-orange-700 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-400"
                 >
                   Missing
                 </Badge>

--- a/gui/frontend/src/pages/ProjectList.tsx
+++ b/gui/frontend/src/pages/ProjectList.tsx
@@ -97,14 +97,14 @@ export default function ProjectList() {
                       {p.dir_exists ? (
                         <Badge
                           variant="outline"
-                          className="border-green-200 bg-green-50 text-xs text-green-700"
+                          className="border-green-200 bg-green-50 text-xs text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400"
                         >
                           OK
                         </Badge>
                       ) : (
                         <Badge
                           variant="outline"
-                          className="border-orange-200 bg-orange-50 text-xs text-orange-700"
+                          className="border-orange-200 bg-orange-50 text-xs text-orange-700 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-400"
                         >
                           Missing
                         </Badge>

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -277,11 +277,11 @@ function StatusBadge({ status }: { status: string }) {
       variant="outline"
       className={cn(
         "text-xs font-medium",
-        variant === "running" && "border-green-200 bg-green-50 text-green-700",
-        variant === "success" && "border-green-200 bg-green-50 text-green-700",
-        variant === "error" && "border-red-200 bg-red-50 text-red-700",
+        variant === "running" && "border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400",
+        variant === "success" && "border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400",
+        variant === "error" && "border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-400",
         variant === "warning" &&
-          "border-orange-200 bg-orange-50 text-orange-700",
+          "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-400",
         variant === "default" && "border-muted bg-muted text-muted-foreground",
       )}
     >
@@ -530,9 +530,9 @@ function EventBadge({ event }: { event: string }) {
       variant="outline"
       className={cn(
         "text-xs font-medium",
-        variant === "running" && "border-green-200 bg-green-50 text-green-700",
-        variant === "success" && "border-green-200 bg-green-50 text-green-700",
-        variant === "error" && "border-red-200 bg-red-50 text-red-700",
+        variant === "running" && "border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400",
+        variant === "success" && "border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400",
+        variant === "error" && "border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-400",
         variant === "default" && "border-muted bg-muted text-muted-foreground",
       )}
     >


### PR DESCRIPTION
## Summary
- Wire up `next-themes` ThemeProvider with class-based dark mode (`@custom-variant dark` for Tailwind v4)
- Add command palette (`Cmd+K`) with fuzzy search across projects, sessions, navigation, and theme switching
- Add global keyboard shortcuts: `g d` (Dashboard), `g p` (Projects), `?` (shortcuts help)
- Add keyboard shortcuts help dialog
- Add theme toggle dropdown in header
- Fix status badge colors for dark mode across Dashboard, ProjectList, ProjectDetail, SessionDetail, and SessionTable
- Make sonner toasts respect current theme

## Test plan
- [ ] Toggle dark mode via header dropdown — entire UI switches themes correctly
- [ ] Status badges (completed, running, error, warning, OK, Missing) have proper colors in both light and dark mode
- [ ] `Cmd+K` opens command palette; type project name → navigates
- [ ] Press `g` then `d` → navigates to Dashboard
- [ ] Press `g` then `p` → navigates to Projects
- [ ] Press `?` → shows keyboard shortcuts help dialog
- [ ] Toasts respect current theme (dark bg in dark mode)
- [ ] `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)