### PR TITLE
Add resource browsers with install/uninstall via strawhub

### DIFF
--- a/gui/frontend/src/App.tsx
+++ b/gui/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Dashboard from "./pages/Dashboard";
 import ProjectList from "./pages/ProjectList";
 import ProjectDetail from "./pages/ProjectDetail";
 import SessionDetail from "./pages/SessionDetail";
+import ResourceBrowser from "./pages/ResourceBrowser";
 import NotFound from "./pages/NotFound";
 import { useGlobalSSE } from "./hooks/useGlobalSSE";
 
@@ -19,6 +20,10 @@ export default function App() {
         <Route
           path="projects/:projectId/sessions/:runId"
           element={<SessionDetail />}
+        />
+        <Route
+          path="resources/:resourceType"
+          element={<ResourceBrowser />}
         />
         <Route path="*" element={<NotFound />} />
       </Route>

--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -78,3 +78,22 @@ export interface TreeData {
   pending_delegations: PendingDelegation[];
   denied_delegations: DeniedDelegation[];
 }
+
+export interface Resource {
+  name: string;
+  version: string | null;
+  description: string;
+  source: "global" | "project";
+  path: string;
+}
+
+export interface ResourceDetail extends Resource {
+  frontmatter: Record<string, unknown>;
+  body: string;
+}
+
+export interface InstallResult {
+  exit_code: number;
+  stdout: string;
+  stderr: string;
+}

--- a/gui/frontend/src/components/CommandPalette.tsx
+++ b/gui/frontend/src/components/CommandPalette.tsx
@@ -18,6 +18,10 @@ import {
   Sun,
   Moon,
   Monitor,
+  Users,
+  Wrench,
+  Bot,
+  Brain,
 } from "lucide-react";
 
 interface CommandPaletteProps {
@@ -87,6 +91,25 @@ export default function CommandPalette({
             ))}
           </CommandGroup>
         )}
+
+        <CommandGroup heading="Resources">
+          <CommandItem onSelect={() => go("/resources/roles")}>
+            <Users />
+            Roles
+          </CommandItem>
+          <CommandItem onSelect={() => go("/resources/skills")}>
+            <Wrench />
+            Skills
+          </CommandItem>
+          <CommandItem onSelect={() => go("/resources/agents")}>
+            <Bot />
+            Agents
+          </CommandItem>
+          <CommandItem onSelect={() => go("/resources/memories")}>
+            <Brain />
+            Memory
+          </CommandItem>
+        </CommandGroup>
 
         <CommandGroup heading="Theme">
           <CommandItem onSelect={() => { setTheme("light"); onOpenChange(false); }}>

--- a/gui/frontend/src/components/InstallDialog.tsx
+++ b/gui/frontend/src/components/InstallDialog.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { useInstallResource } from "@/hooks/mutations/use-registry";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { CheckCircle2, XCircle } from "lucide-react";
+import { toast } from "sonner";
+
+const RESOURCE_TYPE_OPTIONS = [
+  { value: "roles", label: "Role" },
+  { value: "skills", label: "Skill" },
+  { value: "agents", label: "Agent" },
+  { value: "memories", label: "Memory" },
+];
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  defaultType?: string;
+}
+
+type ResultState = { status: "success" | "error"; message: string } | null;
+
+export default function InstallDialog({ open, onOpenChange, defaultType }: Props) {
+  const [type, setType] = useState(defaultType ?? "roles");
+  const [name, setName] = useState("");
+  const [result, setResult] = useState<ResultState>(null);
+  const [output, setOutput] = useState<string | null>(null);
+  const install = useInstallResource();
+  const isDone = result?.status === "success";
+
+  const handleInstall = () => {
+    if (!name.trim()) return;
+    setResult(null);
+    setOutput(null);
+    install.mutate(
+      { type, name: name.trim() },
+      {
+        onSuccess: (res) => {
+          if (res.exit_code === 0) {
+            toast.success(`Installed ${name.trim()}`);
+            setResult({ status: "success", message: `Successfully installed ${name.trim()}` });
+            setOutput(res.stdout || null);
+          } else {
+            setResult({ status: "error", message: "Installation failed" });
+            setOutput(res.stderr || res.stdout || "Unknown error.");
+          }
+        },
+        onError: () => {
+          setResult({ status: "error", message: "Install request failed" });
+          toast.error("Install request failed");
+        },
+      },
+    );
+  };
+
+  const handleClose = (v: boolean) => {
+    if (!v) {
+      setResult(null);
+      setOutput(null);
+      setName("");
+    }
+    onOpenChange(v);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Install Resource</DialogTitle>
+          <DialogDescription>
+            Install a resource from StrawHub by name.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          {result && (
+            <Alert variant={result.status === "error" ? "destructive" : "default"} className={result.status === "success" ? "border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-300" : ""}>
+              {result.status === "success" ? (
+                <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
+              ) : (
+                <XCircle className="h-4 w-4" />
+              )}
+              <AlertTitle>{result.status === "success" ? "Installed" : "Error"}</AlertTitle>
+              <AlertDescription>{result.message}</AlertDescription>
+            </Alert>
+          )}
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="install-type">Type</Label>
+            <Select value={type} onValueChange={setType} disabled={isDone}>
+              <SelectTrigger id="install-type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RESOURCE_TYPE_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="install-name">Package Name</Label>
+            <Input
+              id="install-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. strawpot-claude-code"
+              readOnly={isDone}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleInstall();
+              }}
+            />
+          </div>
+          {output && (
+            <details className="text-sm">
+              <summary className="cursor-pointer text-xs font-medium text-muted-foreground">
+                Output
+              </summary>
+              <pre className="mt-2 max-h-40 overflow-auto rounded-md bg-muted p-3 text-xs">
+                {output}
+              </pre>
+            </details>
+          )}
+        </div>
+        <DialogFooter>
+          {result?.status === "success" ? (
+            <Button onClick={() => handleClose(false)}>
+              Done
+            </Button>
+          ) : (
+            <Button
+              onClick={handleInstall}
+              disabled={!name.trim() || install.isPending}
+            >
+              {install.isPending ? "Installing..." : "Install"}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/gui/frontend/src/components/ResourceDetailSheet.tsx
+++ b/gui/frontend/src/components/ResourceDetailSheet.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import type { ResourceDetail } from "@/api/types";
+import { useUninstallResource } from "@/hooks/mutations/use-registry";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { toast } from "sonner";
+
+interface Props {
+  resource: ResourceDetail | null;
+  resourceType: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function ResourceDetailSheet({
+  resource,
+  resourceType,
+  open,
+  onOpenChange,
+}: Props) {
+  const uninstall = useUninstallResource();
+  const [confirming, setConfirming] = useState(false);
+
+  if (!resource) return null;
+
+  const handleUninstall = () => {
+    if (!confirming) {
+      setConfirming(true);
+      return;
+    }
+    uninstall.mutate(
+      { type: resourceType, name: resource.name },
+      {
+        onSuccess: (result) => {
+          if (result.exit_code === 0) {
+            toast.success(`Uninstalled ${resource.name}`);
+            onOpenChange(false);
+          } else {
+            toast.error(`Uninstall failed: ${result.stderr || result.stdout}`);
+          }
+          setConfirming(false);
+        },
+        onError: () => {
+          toast.error("Uninstall request failed");
+          setConfirming(false);
+        },
+      },
+    );
+  };
+
+  const metadata = resource.frontmatter?.metadata as Record<string, unknown> | undefined;
+
+  return (
+    <Sheet open={open} onOpenChange={(v) => { onOpenChange(v); setConfirming(false); }}>
+      <SheetContent side="right" className="flex h-full flex-col sm:max-w-lg">
+        <SheetHeader className="shrink-0">
+          <SheetTitle className="flex items-center gap-2">
+            {resource.name}
+            {resource.version && (
+              <Badge variant="outline" className="text-xs font-normal">
+                v{resource.version}
+              </Badge>
+            )}
+          </SheetTitle>
+          <SheetDescription>{resource.description || "No description"}</SheetDescription>
+        </SheetHeader>
+
+        <div className="shrink-0 flex flex-col gap-4 px-4">
+          <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+            <span>Source: <strong>{resource.source}</strong></span>
+            <span>Path: <code className="rounded bg-muted px-1">{resource.path}</code></span>
+          </div>
+
+          {metadata && Object.keys(metadata).length > 0 && (
+            <details className="text-sm">
+              <summary className="cursor-pointer font-medium text-muted-foreground">
+                Metadata
+              </summary>
+              <pre className="mt-2 max-h-40 overflow-auto rounded-md bg-muted p-3 text-xs">
+                {JSON.stringify(metadata, null, 2)}
+              </pre>
+            </details>
+          )}
+        </div>
+
+        <ScrollArea className="min-h-0 flex-1 px-4">
+          <div className="prose prose-sm dark:prose-invert max-w-none whitespace-pre-wrap">
+            {resource.body || "No content."}
+          </div>
+        </ScrollArea>
+
+        <div className="shrink-0 border-t border-border p-4">
+          <Button
+            variant={confirming ? "destructive" : "outline"}
+            size="sm"
+            onClick={handleUninstall}
+            disabled={uninstall.isPending}
+          >
+            {uninstall.isPending
+              ? "Uninstalling..."
+              : confirming
+                ? "Confirm Uninstall"
+                : "Uninstall"}
+          </Button>
+          {confirming && !uninstall.isPending && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="ml-2"
+              onClick={() => setConfirming(false)}
+            >
+              Cancel
+            </Button>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/gui/frontend/src/hooks/mutations/use-registry.ts
+++ b/gui/frontend/src/hooks/mutations/use-registry.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import type { InstallResult } from "@/api/types";
+
+export function useInstallResource() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { type: string; name: string }) =>
+      api.post<InstallResult>("/registry/install", body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry"] });
+    },
+  });
+}
+
+export function useUninstallResource() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ type, name }: { type: string; name: string }) =>
+      api.delete<InstallResult>(`/registry/${type}/${name}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry"] });
+    },
+  });
+}

--- a/gui/frontend/src/hooks/queries/use-registry.ts
+++ b/gui/frontend/src/hooks/queries/use-registry.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import { queryKeys } from "@/lib/query-keys";
+import type { Resource, ResourceDetail } from "@/api/types";
+
+export function useResources(type: string) {
+  return useQuery({
+    queryKey: queryKeys.registry.list(type),
+    queryFn: () => api.get<Resource[]>(`/registry/${type}`),
+  });
+}
+
+export function useResourceDetail(
+  type: string,
+  name: string,
+  options?: { enabled?: boolean },
+) {
+  return useQuery({
+    queryKey: queryKeys.registry.detail(type, name),
+    queryFn: () => api.get<ResourceDetail>(`/registry/${type}/${name}`),
+    enabled: options?.enabled ?? !!name,
+  });
+}

--- a/gui/frontend/src/layouts/AppLayout.tsx
+++ b/gui/frontend/src/layouts/AppLayout.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
 import { useTheme } from "next-themes";
-import { LayoutDashboard, FolderKanban, Sun, Moon } from "lucide-react";
+import { LayoutDashboard, FolderKanban, Users, Wrench, Bot, Brain, Sun, Moon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useProject } from "@/hooks/queries/use-projects";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -29,6 +29,13 @@ const navItems = [
   { to: "/projects", label: "Projects", icon: FolderKanban },
 ];
 
+const resourceItems = [
+  { to: "/resources/roles", label: "Roles", icon: Users },
+  { to: "/resources/skills", label: "Skills", icon: Wrench },
+  { to: "/resources/agents", label: "Agents", icon: Bot },
+  { to: "/resources/memories", label: "Memory", icon: Brain },
+];
+
 function useBreadcrumbs() {
   const location = useLocation();
   const segments = location.pathname.split("/").filter(Boolean);
@@ -51,6 +58,20 @@ function useBreadcrumbs() {
       if (segments[2] === "sessions" && segments[3]) {
         crumbs.push({ label: `Session ${segments[3].slice(0, 8)}…` });
       }
+    }
+  }
+
+  if (segments[0] === "resources") {
+    const typeLabels: Record<string, string> = {
+      roles: "Roles",
+      skills: "Skills",
+      agents: "Agents",
+      memories: "Memory",
+    };
+    crumbs.push({ label: "Resources" });
+    if (segments[1]) {
+      crumbs[crumbs.length - 1].href = `/resources/${segments[1]}`;
+      crumbs.push({ label: typeLabels[segments[1]] ?? segments[1] });
     }
   }
 
@@ -81,6 +102,27 @@ export default function AppLayout() {
               key={to}
               to={to}
               end={end}
+              className={({ isActive }) =>
+                cn(
+                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground",
+                )
+              }
+            >
+              <Icon className="h-4 w-4" />
+              {label}
+            </NavLink>
+          ))}
+
+          <div className="mt-4 mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">
+            Resources
+          </div>
+          {resourceItems.map(({ to, label, icon: Icon }) => (
+            <NavLink
+              key={to}
+              to={to}
               className={({ isActive }) =>
                 cn(
                   "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",

--- a/gui/frontend/src/lib/query-keys.ts
+++ b/gui/frontend/src/lib/query-keys.ts
@@ -14,4 +14,8 @@ export const queryKeys = {
   roles: {
     all: ["roles"] as const,
   },
+  registry: {
+    list: (type: string) => ["registry", type] as const,
+    detail: (type: string, name: string) => ["registry", type, name] as const,
+  },
 };

--- a/gui/frontend/src/pages/ResourceBrowser.tsx
+++ b/gui/frontend/src/pages/ResourceBrowser.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { useResources, useResourceDetail } from "@/hooks/queries/use-registry";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import ResourceDetailSheet from "@/components/ResourceDetailSheet";
+import InstallDialog from "@/components/InstallDialog";
+import { Download } from "lucide-react";
+
+const TYPE_LABELS: Record<string, string> = {
+  roles: "Roles",
+  skills: "Skills",
+  agents: "Agents",
+  memories: "Memory Providers",
+};
+
+export default function ResourceBrowser() {
+  const { resourceType = "roles" } = useParams<{ resourceType: string }>();
+  const { data: resources, isLoading } = useResources(resourceType);
+  const [selectedName, setSelectedName] = useState<string | null>(null);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [installOpen, setInstallOpen] = useState(false);
+
+  const { data: detail } = useResourceDetail(resourceType, selectedName ?? "", {
+    enabled: sheetOpen && !!selectedName,
+  });
+
+  const label = TYPE_LABELS[resourceType] ?? resourceType;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{label}</h1>
+          <p className="text-sm text-muted-foreground">
+            Installed {label.toLowerCase()} from StrawHub
+          </p>
+        </div>
+        <Button onClick={() => setInstallOpen(true)} size="sm">
+          <Download className="mr-2 h-4 w-4" />
+          Install
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      ) : !resources || resources.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border p-8 text-center text-muted-foreground">
+          No {label.toLowerCase()} installed yet.
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Version</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead>Source</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {resources.map((r) => (
+              <TableRow
+                key={r.name}
+                className="cursor-pointer"
+                onClick={() => {
+                  setSelectedName(r.name);
+                  setSheetOpen(true);
+                }}
+              >
+                <TableCell className="font-medium">{r.name}</TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {r.version ?? "—"}
+                </TableCell>
+                <TableCell className="max-w-[300px] truncate text-sm">
+                  {r.description || "—"}
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline" className="text-xs">
+                    {r.source}
+                  </Badge>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <ResourceDetailSheet
+        resource={detail ?? null}
+        resourceType={resourceType}
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+      />
+
+      <InstallDialog
+        open={installOpen}
+        onOpenChange={setInstallOpen}
+        defaultType={resourceType}
+      />
+    </div>
+  );
+}

--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -17,7 +17,7 @@ from strawpot_gui.db import init_db, sync_sessions
 from strawpot_gui.event_bus import event_bus
 
 logger = logging.getLogger(__name__)
-from strawpot_gui.routers import config, fs, health, logs, projects, sessions, sse
+from strawpot_gui.routers import config, fs, health, logs, projects, registry, sessions, sse
 
 
 def _auto_rebuild_frontend(dist_dir: Path) -> None:
@@ -94,6 +94,7 @@ def create_app(db_path: str | None = None) -> FastAPI:
     app.include_router(sse.router)
     app.include_router(logs.router)
     app.include_router(fs.router)
+    app.include_router(registry.router)
 
     # Serve built frontend — check installed package path then dev path
     static_dir = Path(__file__).resolve().parent / "static"

--- a/gui/src/strawpot_gui/routers/registry.py
+++ b/gui/src/strawpot_gui/routers/registry.py
@@ -1,0 +1,162 @@
+"""Resource registry endpoints — list, detail, install, uninstall."""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from fastapi import APIRouter, Body, HTTPException
+
+from strawpot.agents.registry import parse_agent_md
+from strawpot.config import get_strawpot_home
+from strawpot.context import parse_frontmatter
+from strawpot.memory.registry import parse_memory_md
+
+router = APIRouter(prefix="/api/registry", tags=["registry"])
+
+# Maps URL resource_type to (directory_name, manifest_filename)
+RESOURCE_TYPES: dict[str, tuple[str, str]] = {
+    "roles": ("roles", "ROLE.md"),
+    "skills": ("skills", "SKILL.md"),
+    "agents": ("agents", "AGENT.md"),
+    "memories": ("memories", "MEMORY.md"),
+}
+
+
+def _validate_type(resource_type: str) -> tuple[str, str]:
+    """Return (dir_name, manifest) or raise 400."""
+    entry = RESOURCE_TYPES.get(resource_type)
+    if entry is None:
+        raise HTTPException(
+            400,
+            f"Unknown resource type: {resource_type}. "
+            f"Valid types: {', '.join(RESOURCE_TYPES)}",
+        )
+    return entry
+
+
+def _parse_manifest(manifest_path: Path, resource_type: str) -> tuple[dict, str]:
+    """Parse a manifest file and return (frontmatter, body)."""
+    if resource_type == "agents":
+        return parse_agent_md(manifest_path)
+    if resource_type == "memories":
+        return parse_memory_md(manifest_path)
+    # roles and skills use generic frontmatter parsing
+    text = manifest_path.read_text(encoding="utf-8")
+    parsed = parse_frontmatter(text)
+    return parsed.get("frontmatter", {}), parsed.get("body", "")
+
+
+def _read_version(resource_dir: Path, fm: dict) -> str | None:
+    """Read version from .version file, falling back to frontmatter metadata."""
+    version_file = resource_dir / ".version"
+    if version_file.is_file():
+        try:
+            return version_file.read_text(encoding="utf-8").strip() or None
+        except OSError:
+            pass
+    metadata = fm.get("metadata", {})
+    return metadata.get("version", fm.get("version")) or None
+
+
+def _scan_dir(
+    base_dir: Path, dir_name: str, manifest: str, resource_type: str, source: str
+) -> list[dict]:
+    """Scan a directory for installed resources."""
+    scan_path = base_dir / dir_name
+    if not scan_path.is_dir():
+        return []
+    items = []
+    for entry in sorted(scan_path.iterdir()):
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        manifest_path = entry / manifest
+        if not manifest_path.is_file():
+            continue
+        try:
+            fm, _body = _parse_manifest(manifest_path, resource_type)
+        except (ValueError, Exception):
+            fm = {}
+        items.append(
+            {
+                "name": fm.get("name", entry.name),
+                "version": _read_version(entry, fm),
+                "description": fm.get("description", ""),
+                "source": source,
+                "path": str(entry),
+            }
+        )
+    return items
+
+
+@router.get("/{resource_type}")
+def list_resources(resource_type: str):
+    """List all installed resources of a given type."""
+    dir_name, manifest = _validate_type(resource_type)
+    home = get_strawpot_home()
+    return _scan_dir(home, dir_name, manifest, resource_type, "global")
+
+
+@router.get("/{resource_type}/{name}")
+def get_resource(resource_type: str, name: str):
+    """Get detail for a single installed resource."""
+    dir_name, manifest = _validate_type(resource_type)
+    home = get_strawpot_home()
+
+    resource_dir = home / dir_name / name
+    manifest_path = resource_dir / manifest
+    if not manifest_path.is_file():
+        raise HTTPException(404, f"Resource not found: {resource_type}/{name}")
+
+    fm, body = _parse_manifest(manifest_path, resource_type)
+    return {
+        "name": fm.get("name", name),
+        "version": _read_version(resource_dir, fm),
+        "description": fm.get("description", ""),
+        "frontmatter": fm,
+        "body": body,
+        "source": "global",
+        "path": str(resource_dir),
+    }
+
+
+def _run_strawhub(*args: str) -> dict:
+    """Run a strawhub CLI command and return result."""
+    cmd = shutil.which("strawhub")
+    if cmd is None:
+        raise HTTPException(
+            503,
+            "strawhub CLI not found on PATH. Install it with: pip install strawhub",
+        )
+    result = subprocess.run(
+        [cmd, *args],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return {
+        "exit_code": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+@router.post("/install")
+def install_resource(data: dict = Body(...)):
+    """Install a resource via strawhub."""
+    resource_type = data.get("type", "")
+    name = data.get("name", "")
+    if not resource_type or not name:
+        raise HTTPException(400, "Both 'type' and 'name' are required")
+    # strawhub uses singular type names for install
+    singular = resource_type.rstrip("s") if resource_type != "memories" else "memory"
+    return _run_strawhub("install", "-y", singular, name, "--global")
+
+
+@router.delete("/{resource_type}/{name}")
+def uninstall_resource(resource_type: str, name: str):
+    """Uninstall a resource via strawhub."""
+    _validate_type(resource_type)
+    singular = resource_type.rstrip("s") if resource_type != "memories" else "memory"
+    return _run_strawhub("uninstall", singular, name, "--global")


### PR DESCRIPTION
## Summary

- **Backend**: New registry router (`/api/registry`) with endpoints to list, view detail, install, and uninstall resources (roles, skills, agents, memory providers) via the `strawhub` CLI
- **Frontend**: Resource browser page with table view, detail side sheet with two-step uninstall confirmation, install dialog with success/error feedback, sidebar navigation with 4 resource type links, command palette integration, and breadcrumbs
- **Version handling**: Reads `.version` file first (written by strawhub), falls back to frontmatter metadata

## Test plan

- [ ] Navigate to each resource type via sidebar (Roles, Skills, Agents, Memory)
- [ ] Verify installed resources show correct name, version, and description
- [ ] Click a resource row → detail sheet opens with metadata and markdown body
- [ ] Uninstall button requires two-step confirmation
- [ ] Install dialog: enter package name, verify install runs without hanging
- [ ] Install success shows green alert, keeps slug visible, readonly inputs, "Done" button
- [ ] Install failure shows red error alert with output
- [ ] Command palette (Cmd+K) shows all 4 resource navigation items
- [ ] Breadcrumbs update correctly for resource pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)