### PR TITLE
Fix agent install to read strawpot.install from AGENT.md

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -16,7 +16,7 @@ from strawpot.agents.interactive import (
     DirectWrapperRuntime,
     InteractiveWrapperRuntime,
 )
-from strawpot.agents.registry import resolve_agent, validate_agent
+from strawpot.agents.registry import parse_agent_md, resolve_agent, validate_agent
 from strawpot.memory.registry import resolve_memory
 from strawpot.agents.wrapper import WrapperRuntime
 from strawpot.config import get_strawpot_home, load_config
@@ -34,6 +34,17 @@ def cli():
 # ---------------------------------------------------------------------------
 
 
+def _get_agent_install_cmd(agent_dir: Path) -> str | None:
+    """Read metadata.strawpot.install.<os> from AGENT.md frontmatter."""
+    try:
+        from strawpot.agents.registry import _current_os
+        frontmatter, _ = parse_agent_md(agent_dir / "AGENT.md")
+        install_map = frontmatter.get("metadata", {}).get("strawpot", {}).get("install", {})
+        return install_map.get(_current_os())
+    except (ValueError, OSError):
+        return None
+
+
 def _ensure_agent_installed(name: str, working_dir: str, *, auto_setup: bool = False) -> None:
     """Prompt to install an agent from StrawHub if it is not found locally."""
     try:
@@ -45,13 +56,29 @@ def _ensure_agent_installed(name: str, working_dir: str, *, auto_setup: bool = F
     else:
         return  # already available
 
-    # Check if agent files exist but binary is missing (needs install script)
+    # Check if agent files exist but binary is missing (needs install)
     agent_dirs = [
         Path(working_dir) / ".strawpot" / "agents" / name,
         get_strawpot_home() / "agents" / name,
     ]
     for agent_dir in agent_dirs:
         if (agent_dir / "AGENT.md").is_file():
+            # 1. Try metadata.strawpot.install.<os> from AGENT.md frontmatter
+            install_cmd = _get_agent_install_cmd(agent_dir)
+            if install_cmd:
+                click.echo(f"Running install for '{name}'...")
+                result = subprocess.run(
+                    ["sh", "-c", install_cmd],
+                    cwd=str(agent_dir),
+                    env={**os.environ, "INSTALL_DIR": str(agent_dir)},
+                    stdin=sys.stdin,
+                    stdout=sys.stdout,
+                    stderr=sys.stderr,
+                )
+                if result.returncode != 0:
+                    click.echo(f"Install failed for '{name}'.", err=True)
+                return
+            # 2. Fallback to install.sh on disk
             install_script = agent_dir / "install.sh"
             if install_script.is_file():
                 click.echo(f"Running install script for '{name}'...")
@@ -66,7 +93,7 @@ def _ensure_agent_installed(name: str, working_dir: str, *, auto_setup: bool = F
                 if result.returncode != 0:
                     click.echo(f"Install script failed for '{name}'.", err=True)
                 return
-            click.echo(f"Agent '{name}' binary is missing and no install script found.", err=True)
+            click.echo(f"Agent '{name}' binary is missing and no install command found.", err=True)
             return
 
     if not auto_setup:
@@ -91,13 +118,13 @@ def _ensure_agent_installed(name: str, working_dir: str, *, auto_setup: bool = F
         click.echo(f"Failed to install agent '{name}'.", err=True)
         return
 
-    # Run install.sh if present (downloads compiled binary into agent dir)
+    # Run install command from AGENT.md or fallback to install.sh
     global_agent_dir = get_strawpot_home() / "agents" / name
-    install_script = global_agent_dir / "install.sh"
-    if install_script.is_file():
-        click.echo(f"Running install script for '{name}'...")
+    install_cmd = _get_agent_install_cmd(global_agent_dir)
+    if install_cmd:
+        click.echo(f"Running install for '{name}'...")
         result = subprocess.run(
-            ["sh", str(install_script)],
+            ["sh", "-c", install_cmd],
             cwd=str(global_agent_dir),
             env={**os.environ, "INSTALL_DIR": str(global_agent_dir)},
             stdin=sys.stdin,
@@ -105,7 +132,21 @@ def _ensure_agent_installed(name: str, working_dir: str, *, auto_setup: bool = F
             stderr=sys.stderr,
         )
         if result.returncode != 0:
-            click.echo(f"Install script failed for '{name}'.", err=True)
+            click.echo(f"Install failed for '{name}'.", err=True)
+    else:
+        install_script = global_agent_dir / "install.sh"
+        if install_script.is_file():
+            click.echo(f"Running install script for '{name}'...")
+            result = subprocess.run(
+                ["sh", str(install_script)],
+                cwd=str(global_agent_dir),
+                env={**os.environ, "INSTALL_DIR": str(global_agent_dir)},
+                stdin=sys.stdin,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+            )
+            if result.returncode != 0:
+                click.echo(f"Install script failed for '{name}'.", err=True)
 
 
 def _ensure_skill_installed(name: str, working_dir: str, *, auto_setup: bool = False) -> None:

--- a/cli/tests/test_cli_bootstrap.py
+++ b/cli/tests/test_cli_bootstrap.py
@@ -1,5 +1,6 @@
 """Tests for strawpot.cli bootstrap helpers (_ensure_agent_installed, _ensure_skill_installed)."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
@@ -10,6 +11,9 @@ from strawpot.cli import (
     _ensure_role_installed,
     _ensure_skill_installed,
 )
+
+# Prevent tests from finding real AGENT.md files in ~/.strawpot/
+_EMPTY_HOME = Path("/nonexistent/strawpot_test_home")
 
 
 # ---------------------------------------------------------------------------
@@ -27,11 +31,12 @@ def test_ensure_agent_already_installed(mock_resolve):
     mock_resolve.assert_called_once_with("strawpot-claude-code", "/tmp/project")
 
 
+@patch("strawpot.cli.get_strawpot_home", return_value=_EMPTY_HOME)
 @patch("strawpot.cli.subprocess.run")
 @patch("strawpot.cli.shutil.which", return_value="/usr/bin/strawhub")
 @patch("strawpot.cli.click.confirm", return_value=True)
 @patch("strawpot.cli.resolve_agent", side_effect=FileNotFoundError("not found"))
-def test_ensure_agent_installs_on_confirm(mock_resolve, mock_confirm, mock_which, mock_run):
+def test_ensure_agent_installs_on_confirm(mock_resolve, mock_confirm, mock_which, mock_run, _):
     """Installs agent via strawhub when user confirms."""
     mock_run.return_value = MagicMock(returncode=0)
 
@@ -43,11 +48,12 @@ def test_ensure_agent_installs_on_confirm(mock_resolve, mock_confirm, mock_which
     assert cmd == ["/usr/bin/strawhub", "install", "agent", "strawpot-claude-code", "--global"]
 
 
+@patch("strawpot.cli.get_strawpot_home", return_value=_EMPTY_HOME)
 @patch("strawpot.cli.subprocess.run")
 @patch("strawpot.cli.shutil.which", return_value="/usr/bin/strawhub")
 @patch("strawpot.cli.click.confirm", return_value=False)
 @patch("strawpot.cli.resolve_agent", side_effect=FileNotFoundError("not found"))
-def test_ensure_agent_skips_on_decline(mock_resolve, mock_confirm, mock_which, mock_run):
+def test_ensure_agent_skips_on_decline(mock_resolve, mock_confirm, mock_which, mock_run, _):
     """Does nothing when user declines install."""
     _ensure_agent_installed("strawpot-claude-code", "/tmp/project")
 
@@ -55,11 +61,12 @@ def test_ensure_agent_skips_on_decline(mock_resolve, mock_confirm, mock_which, m
     mock_run.assert_not_called()
 
 
+@patch("strawpot.cli.get_strawpot_home", return_value=_EMPTY_HOME)
 @patch("strawpot.cli.click.echo")
 @patch("strawpot.cli.shutil.which", return_value=None)
 @patch("strawpot.cli.click.confirm", return_value=True)
 @patch("strawpot.cli.resolve_agent", side_effect=FileNotFoundError("not found"))
-def test_ensure_agent_strawhub_not_found(mock_resolve, mock_confirm, mock_which, mock_echo):
+def test_ensure_agent_strawhub_not_found(mock_resolve, mock_confirm, mock_which, mock_echo, _):
     """Shows error when strawhub CLI is not on PATH."""
     _ensure_agent_installed("strawpot-claude-code", "/tmp/project")
 
@@ -68,12 +75,13 @@ def test_ensure_agent_strawhub_not_found(mock_resolve, mock_confirm, mock_which,
     assert any("strawhub CLI not found" in c for c in calls)
 
 
+@patch("strawpot.cli.get_strawpot_home", return_value=_EMPTY_HOME)
 @patch("strawpot.cli.click.echo")
 @patch("strawpot.cli.subprocess.run")
 @patch("strawpot.cli.shutil.which", return_value="/usr/bin/strawhub")
 @patch("strawpot.cli.click.confirm", return_value=True)
 @patch("strawpot.cli.resolve_agent", side_effect=FileNotFoundError("not found"))
-def test_ensure_agent_install_fails(mock_resolve, mock_confirm, mock_which, mock_run, mock_echo):
+def test_ensure_agent_install_fails(mock_resolve, mock_confirm, mock_which, mock_run, mock_echo, _):
     """Shows error when install command fails."""
     mock_run.return_value = MagicMock(returncode=1)
 
@@ -81,6 +89,63 @@ def test_ensure_agent_install_fails(mock_resolve, mock_confirm, mock_which, mock
 
     calls = [str(c) for c in mock_echo.call_args_list]
     assert any("Failed to install agent" in c for c in calls)
+
+
+def test_ensure_agent_runs_strawpot_install_from_frontmatter(tmp_path):
+    """Runs metadata.strawpot.install.<os> from AGENT.md when binary is missing."""
+    agent_dir = tmp_path / ".strawpot" / "agents" / "test-agent"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "AGENT.md").write_text(
+        "---\n"
+        "name: test-agent\n"
+        "metadata:\n"
+        "  strawpot:\n"
+        "    bin:\n"
+        "      macos: test_agent\n"
+        "      linux: test_agent\n"
+        "    install:\n"
+        "      macos: curl -fsSL https://example.com/install.sh | sh\n"
+        "      linux: curl -fsSL https://example.com/install.sh | sh\n"
+        "---\n"
+    )
+    # resolve_agent raises ValueError because binary doesn't exist
+    with patch("strawpot.cli.resolve_agent", side_effect=ValueError("binary not found")), \
+         patch("strawpot.cli.subprocess.run") as mock_run, \
+         patch("strawpot.cli.click.echo"):
+        mock_run.return_value = MagicMock(returncode=0)
+        _ensure_agent_installed("test-agent", str(tmp_path))
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["sh", "-c", mock_run.call_args[0][0][2]]
+        # Verify the install command from frontmatter was used
+        assert "curl" in mock_run.call_args[0][0][2]
+
+
+def test_ensure_agent_falls_back_to_install_sh(tmp_path):
+    """Falls back to install.sh when no strawpot.install in AGENT.md."""
+    agent_dir = tmp_path / ".strawpot" / "agents" / "test-agent"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "AGENT.md").write_text(
+        "---\n"
+        "name: test-agent\n"
+        "metadata:\n"
+        "  strawpot:\n"
+        "    bin:\n"
+        "      macos: test_agent\n"
+        "      linux: test_agent\n"
+        "---\n"
+    )
+    (agent_dir / "install.sh").write_text("#!/bin/sh\necho installed\n")
+    with patch("strawpot.cli.resolve_agent", side_effect=ValueError("binary not found")), \
+         patch("strawpot.cli.subprocess.run") as mock_run, \
+         patch("strawpot.cli.click.echo"):
+        mock_run.return_value = MagicMock(returncode=0)
+        _ensure_agent_installed("test-agent", str(tmp_path))
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["sh", str(agent_dir / "install.sh")]
 
 
 # ---------------------------------------------------------------------------
@@ -260,11 +325,12 @@ def test_ensure_role_install_fails(mock_confirm, mock_which, mock_run, mock_echo
 # ---------------------------------------------------------------------------
 
 
+@patch("strawpot.cli.get_strawpot_home", return_value=_EMPTY_HOME)
 @patch("strawpot.cli.subprocess.run")
 @patch("strawpot.cli.shutil.which", return_value="/usr/bin/strawhub")
 @patch("strawpot.cli.click.confirm")
 @patch("strawpot.cli.resolve_agent", side_effect=FileNotFoundError("not found"))
-def test_ensure_agent_auto_setup_skips_confirm(mock_resolve, mock_confirm, mock_which, mock_run):
+def test_ensure_agent_auto_setup_skips_confirm(mock_resolve, mock_confirm, mock_which, mock_run, _):
     """auto_setup=True installs without prompting."""
     mock_run.return_value = MagicMock(returncode=0)
 


### PR DESCRIPTION
## Summary
- `_ensure_agent_installed` now parses `metadata.strawpot.install.<os>` from AGENT.md frontmatter and runs the install command when the agent binary is missing
- Falls back to `install.sh` on disk if no frontmatter install is defined
- Also applies after `strawhub install` downloads the agent files
- Isolates existing bootstrap tests from real `~/.strawpot/` to prevent flaky failures on dev machines

## Test plan
- [x] `pytest cli/tests/test_cli_bootstrap.py` — 23 passed
- [x] `pytest cli/tests/test_cli.py cli/tests/test_cli_headless.py` — 16 passed
- [ ] Manual: install an agent with `strawpot.install` in AGENT.md, verify install command runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)