### PR TITLE
Re-enable automatic PyPI release on cli changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 name: Release
 
 on:
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - "cli/**"
+  push:
+    branches: [main]
+    paths:
+      - "cli/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Uncomment the `push` trigger in `release.yml` so PyPI releases fire automatically when `cli/**` changes land on `main`

## Test plan
- [ ] Verify workflow triggers on next cli change merged to main
- [ ] Manual `workflow_dispatch` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)