### PR TITLE
Add update and reinstall actions for resources

### DIFF
--- a/gui/frontend/src/components/ResourceDetailSheet.tsx
+++ b/gui/frontend/src/components/ResourceDetailSheet.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import type { ResourceDetail } from "@/api/types";
-import { useUninstallResource } from "@/hooks/mutations/use-registry";
+import {
+  useUninstallResource,
+  useUpdateResource,
+  useReinstallResource,
+} from "@/hooks/mutations/use-registry";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -28,7 +32,10 @@ export default function ResourceDetailSheet({
   onOpenChange,
 }: Props) {
   const uninstall = useUninstallResource();
+  const updateResource = useUpdateResource();
+  const reinstall = useReinstallResource();
   const [confirming, setConfirming] = useState(false);
+  const actionPending = updateResource.isPending || reinstall.isPending || uninstall.isPending;
 
   if (!resource) return null;
 
@@ -53,6 +60,38 @@ export default function ResourceDetailSheet({
           toast.error("Uninstall request failed");
           setConfirming(false);
         },
+      },
+    );
+  };
+
+  const handleUpdate = () => {
+    updateResource.mutate(
+      { type: resourceType, name: resource.name },
+      {
+        onSuccess: (result) => {
+          if (result.exit_code === 0) {
+            toast.success(`Updated ${resource.name}`);
+          } else {
+            toast.error(`Update failed: ${result.stderr || result.stdout}`);
+          }
+        },
+        onError: () => toast.error("Update request failed"),
+      },
+    );
+  };
+
+  const handleReinstall = () => {
+    reinstall.mutate(
+      { type: resourceType, name: resource.name },
+      {
+        onSuccess: (result) => {
+          if (result.exit_code === 0) {
+            toast.success(`Reinstalled ${resource.name}`);
+          } else {
+            toast.error(`Reinstall failed: ${result.stderr || result.stdout}`);
+          }
+        },
+        onError: () => toast.error("Reinstall request failed"),
       },
     );
   };
@@ -103,12 +142,28 @@ export default function ResourceDetailSheet({
           </div>
         </ScrollArea>
 
-        <div className="shrink-0 border-t border-border p-4">
+        <div className="shrink-0 border-t border-border p-4 flex gap-2">
+          <Button
+            size="sm"
+            onClick={handleUpdate}
+            disabled={actionPending}
+          >
+            {updateResource.isPending ? "Updating..." : "Update"}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleReinstall}
+            disabled={actionPending}
+          >
+            {reinstall.isPending ? "Reinstalling..." : "Reinstall"}
+          </Button>
+          <div className="flex-1" />
           <Button
             variant={confirming ? "destructive" : "outline"}
             size="sm"
             onClick={handleUninstall}
-            disabled={uninstall.isPending}
+            disabled={actionPending}
           >
             {uninstall.isPending
               ? "Uninstalling..."
@@ -120,7 +175,6 @@ export default function ResourceDetailSheet({
             <Button
               variant="ghost"
               size="sm"
-              className="ml-2"
               onClick={() => setConfirming(false)}
             >
               Cancel

--- a/gui/frontend/src/hooks/mutations/use-registry.ts
+++ b/gui/frontend/src/hooks/mutations/use-registry.ts
@@ -25,6 +25,28 @@ export function useUninstallResource() {
   });
 }
 
+export function useUpdateResource() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { type: string; name: string }) =>
+      api.post<InstallResult>("/registry/update", body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry"] });
+    },
+  });
+}
+
+export function useReinstallResource() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { type: string; name: string }) =>
+      api.post<InstallResult>("/registry/reinstall", body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["registry"] });
+    },
+  });
+}
+
 export function useSaveResourceConfig() {
   const qc = useQueryClient();
   return useMutation({

--- a/gui/src/strawpot_gui/routers/registry.py
+++ b/gui/src/strawpot_gui/routers/registry.py
@@ -273,3 +273,39 @@ def uninstall_resource(resource_type: str, name: str):
     _validate_type(resource_type)
     singular = resource_type.rstrip("s") if resource_type != "memories" else "memory"
     return _run_strawhub("uninstall", singular, name, "--global")
+
+
+def _singular_type(resource_type: str) -> str:
+    return resource_type.rstrip("s") if resource_type != "memories" else "memory"
+
+
+@router.post("/update")
+def update_resource(data: dict = Body(...)):
+    """Update a resource to its latest version via strawhub."""
+    resource_type = data.get("type", "")
+    name = data.get("name", "")
+    if not resource_type or not name:
+        raise HTTPException(400, "Both 'type' and 'name' are required")
+    singular = _singular_type(resource_type)
+    return _run_strawhub("update", singular, name, "--global")
+
+
+@router.post("/reinstall")
+def reinstall_resource(data: dict = Body(...)):
+    """Reinstall a resource (re-download the current version) via strawhub."""
+    resource_type = data.get("type", "")
+    name = data.get("name", "")
+    if not resource_type or not name:
+        raise HTTPException(400, "Both 'type' and 'name' are required")
+
+    dir_name, _manifest = _validate_type(resource_type)
+    home = get_strawpot_home()
+    version_file = home / dir_name / name / ".version"
+    if not version_file.is_file():
+        raise HTTPException(404, f"Resource not found or has no version: {resource_type}/{name}")
+    version = version_file.read_text(encoding="utf-8").strip()
+    if not version:
+        raise HTTPException(404, f"Empty version file for: {resource_type}/{name}")
+
+    singular = _singular_type(resource_type)
+    return _run_strawhub("install", "-y", singular, name, "--version", version, "--force", "--global")


### PR DESCRIPTION
## Summary
- Add `POST /api/registry/update` endpoint — delegates to `strawhub update <type> <name> --global`
- Add `POST /api/registry/reinstall` endpoint — reads current `.version`, runs `strawhub install --version <ver> --force --global`
- Add Update and Reinstall buttons in the resource detail sheet footer

## Test plan
- [ ] Open resource detail sheet → see Update, Reinstall, Uninstall buttons
- [ ] Click Update → shows toast with strawhub update result
- [ ] Click Reinstall → re-downloads same version, shows toast
- [ ] All buttons disable while any action is pending
- [ ] Frontend builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)