### PR TITLE
Fix delegation error propagation on non-zero exit

### DIFF
--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -799,6 +799,12 @@ class Session:
                 register_agent=self._register_agent,
                 files_dirs=self._files_dirs,
             )
+            if result.exit_code != 0:
+                return error_response(
+                    request.request_id,
+                    "ERR_SUBAGENT_NONZERO_EXIT",
+                    result.summary,
+                )
             return ok_response(
                 request.request_id,
                 delegate_result=denden_pb2.DelegateResult(

--- a/cli/tests/e2e/test_error_handling.py
+++ b/cli/tests/e2e/test_error_handling.py
@@ -47,6 +47,21 @@ class TestErrorHandling:
             active = list(running_dir.iterdir())
             assert len(active) == 0
 
+    def test_delegation_subagent_failure_returns_error(self, make_session, git_project):
+        """Sub-agent that exits non-zero causes ERROR response to calling agent."""
+        session = make_session(
+            str(git_project),
+            task="delegate implementer exit 1",
+            agent_script=STUB_AGENT_DELEGATE,
+        )
+        session.start(str(git_project))
+
+        # The orchestrator (stub_agent_delegate) receives ERROR from denden
+        # and prints "Delegation error: ..." — verify it saw the error
+        result = session._orchestrator_result
+        assert result is not None
+        assert "Delegation error:" in result.output
+
     def test_stale_session_recovery(self, git_project, make_config, strawpot_home):
         """Stale session files with dead PIDs are cleaned up."""
         config = make_config()

--- a/cli/tests/test_session.py
+++ b/cli/tests/test_session.py
@@ -580,6 +580,37 @@ class TestHandleDelegate:
         mock_error.assert_called_once()
         assert result == "error"
 
+    @patch("strawpot.session.handle_delegate")
+    @patch("strawpot.session.error_response")
+    def test_nonzero_exit_returns_error_response(
+        self, mock_error, mock_handle, tmp_path
+    ):
+        """Non-zero exit_code from sub-agent returns error_response."""
+        from strawpot.delegation import DelegateResult
+
+        mock_handle.return_value = DelegateResult(
+            summary="Agent crashed", output="traceback...", exit_code=1
+        )
+        mock_error.return_value = "error"
+
+        session = _make_session(tmp_path)
+        session._env = IsolatedEnv(path=str(tmp_path))
+        session._working_dir = str(tmp_path)
+        session._run_id = "run_test"
+        session._denden_addr = "127.0.0.1:9700"
+        session._register_agent(
+            "agent_orch", role="orchestrator", parent_id=None
+        )
+
+        result = session._handle_delegate(self._make_denden_request())
+
+        mock_error.assert_called_once_with(
+            "req_123",
+            "ERR_SUBAGENT_NONZERO_EXIT",
+            "Agent crashed",
+        )
+        assert result == "error"
+
 
 # ---------------------------------------------------------------------------
 # Ask user handler


### PR DESCRIPTION
## Summary
- When a delegated agent exits with non-zero code (e.g., Codex CLI model error), `_handle_delegate()` now returns `error_response(ERR_SUBAGENT_NONZERO_EXIT)` instead of `ok_response()`
- Previously the calling agent always received `status=OK` regardless of whether the sub-agent succeeded or failed

## Test plan
- [x] Unit test: `test_nonzero_exit_returns_error_response` verifies error_response is called with correct error code
- [x] E2E test: `test_delegation_subagent_failure_returns_error` verifies full gRPC flow — sub-agent exits 1, orchestrator receives "Delegation error:"
- [x] All 504 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)