### PR TITLE
Add agent setup guidance and fix update abort

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -126,3 +126,12 @@ export interface ResourceConfig {
   params_schema: Record<string, ParamSchema>;
   params_values: Record<string, unknown>;
 }
+
+export interface AgentValidation {
+  tools_ok: boolean;
+  missing_tools: { name: string; install_hint: string | null }[];
+  env_ok: boolean;
+  missing_env: string[];
+  setup_command: string | null;
+  setup_description: string | null;
+}

--- a/gui/frontend/src/components/AgentSetupGuide.tsx
+++ b/gui/frontend/src/components/AgentSetupGuide.tsx
@@ -1,0 +1,53 @@
+import { useAgentValidation } from "@/hooks/queries/use-registry";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { AlertCircle, Terminal } from "lucide-react";
+
+interface Props {
+  agentName: string;
+}
+
+export default function AgentSetupGuide({ agentName }: Props) {
+  const { data } = useAgentValidation(agentName);
+
+  if (!data) return null;
+  if (data.tools_ok && !data.setup_command) return null;
+
+  return (
+    <div className="mb-4 space-y-3">
+      {!data.tools_ok && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Missing Prerequisites</AlertTitle>
+          <AlertDescription>
+            {data.missing_tools.map((t) => (
+              <div key={t.name} className="mt-1">
+                <strong>{t.name}</strong> not found on PATH.
+                {t.install_hint && (
+                  <code className="ml-2 rounded bg-muted px-1.5 py-0.5 text-xs">
+                    {t.install_hint}
+                  </code>
+                )}
+              </div>
+            ))}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {data.setup_command && (
+        <Alert>
+          <Terminal className="h-4 w-4" />
+          <AlertTitle>Setup</AlertTitle>
+          <AlertDescription>
+            <p>
+              {data.setup_description ||
+                "Run initial authentication in your terminal:"}
+            </p>
+            <code className="mt-1 block rounded bg-muted px-2 py-1 text-xs">
+              {data.setup_command}
+            </code>
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/gui/frontend/src/components/ResourceDetailSheet.tsx
+++ b/gui/frontend/src/components/ResourceDetailSheet.tsx
@@ -20,6 +20,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import AgentSetupGuide from "@/components/AgentSetupGuide";
 import ResourceConfigForm from "@/components/ResourceConfigForm";
 import { toast } from "sonner";
 
@@ -151,6 +152,9 @@ export default function ResourceDetailSheet({
         </div>
 
         <ScrollArea className="min-h-0 flex-1 px-4">
+          {resourceType === "agents" && (
+            <AgentSetupGuide agentName={resource.name} />
+          )}
           <ResourceConfigForm
             resourceType={resourceType}
             resourceName={resource.name}

--- a/gui/frontend/src/hooks/queries/use-registry.ts
+++ b/gui/frontend/src/hooks/queries/use-registry.ts
@@ -1,7 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { queryKeys } from "@/lib/query-keys";
-import type { Resource, ResourceDetail } from "@/api/types";
+import type { AgentValidation, Resource, ResourceDetail } from "@/api/types";
+
+export function useAgentValidation(name: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.registry.validate(name ?? ""),
+    queryFn: () => api.get<AgentValidation>(`/registry/agents/${name}/validate`),
+    enabled: !!name,
+  });
+}
 
 export function useResources(
   type: string,

--- a/gui/frontend/src/lib/query-keys.ts
+++ b/gui/frontend/src/lib/query-keys.ts
@@ -28,5 +28,7 @@ export const queryKeys = {
     detail: (type: string, name: string) => ["registry", type, name] as const,
     config: (type: string, name: string) =>
       ["registry", type, name, "config"] as const,
+    validate: (name: string) =>
+      ["registry", "agents", name, "validate"] as const,
   },
 };

--- a/gui/src/strawpot_gui/routers/registry.py
+++ b/gui/src/strawpot_gui/routers/registry.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 from fastapi import APIRouter, Body, HTTPException
 
-from strawpot.agents.registry import parse_agent_md
+from strawpot.agents.registry import (
+    AgentSpec,
+    _current_os,
+    parse_agent_md,
+    validate_agent,
+)
 from strawpot.config import _read_toml, get_strawpot_home, save_resource_config
 from strawpot.context import parse_frontmatter
 from strawpot.memory.registry import parse_memory_md
@@ -204,6 +209,45 @@ def get_resource_config(resource_type: str, name: str):
     }
 
 
+@router.get("/agents/{name}/validate")
+def validate_agent_status(name: str):
+    """Check if an agent's prerequisites are satisfied."""
+    home = get_strawpot_home()
+    agent_dir = home / "agents" / name
+    manifest_path = agent_dir / "AGENT.md"
+    if not manifest_path.is_file():
+        raise HTTPException(404, f"Agent not found: {name}")
+
+    fm, _ = parse_agent_md(manifest_path)
+    strawpot_meta = fm.get("metadata", {}).get("strawpot", {})
+
+    spec = AgentSpec(
+        name=fm.get("name", name),
+        version="0",
+        wrapper_cmd=[],
+        tools=strawpot_meta.get("tools", {}),
+        env_schema=strawpot_meta.get("env", {}),
+    )
+    result = validate_agent(spec)
+
+    bin_map = strawpot_meta.get("bin", {})
+    os_key = _current_os()
+    bin_name = bin_map.get(os_key)
+    setup_command = f"{bin_name} setup" if bin_name else None
+    setup_description = strawpot_meta.get("setup", {}).get("description")
+
+    return {
+        "tools_ok": len(result.missing_tools) == 0,
+        "missing_tools": [
+            {"name": t[0], "install_hint": t[1]} for t in result.missing_tools
+        ],
+        "env_ok": len(result.missing_env) == 0,
+        "missing_env": result.missing_env,
+        "setup_command": setup_command,
+        "setup_description": setup_description,
+    }
+
+
 @router.put("/{resource_type}/{name}/config")
 def put_resource_config(resource_type: str, name: str, data: dict = Body(...)):
     """Save env and param values for a resource."""
@@ -287,7 +331,7 @@ def update_resource(data: dict = Body(...)):
     if not resource_type or not name:
         raise HTTPException(400, "Both 'type' and 'name' are required")
     singular = singular_type(resource_type)
-    return run_strawhub("update", singular, name, "--global")
+    return run_strawhub("update", "-y", singular, name, "--global")
 
 
 @router.post("/reinstall")


### PR DESCRIPTION
## Summary
- Add `GET /api/registry/agents/{name}/validate` endpoint that checks tool prerequisites and returns setup command
- Add `AgentSetupGuide` component in agent detail sheet showing missing tools (with install hints) and terminal setup command
- Fix `strawhub update` missing `-y` flag — caused "Aborted" on first click when tool install prompts with `stdin=DEVNULL`

## Test plan
- [ ] Open agent detail sheet — verify setup guidance appears
- [ ] Verify missing tool alert shows when prerequisite CLI is not on PATH
- [ ] Verify setup command shows correct `<binary> setup` command
- [ ] Click Update on an agent — verify it no longer fails with "Aborted"
- [ ] Click Reinstall on an agent — verify it works without abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)