### PR TITLE
Add custom system prompt support to Launch Session

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -281,7 +281,8 @@ def _ensure_role_installed(name: str, working_dir: str, *, auto_setup: bool = Fa
     help="Run detached with output to log file (requires --task).",
 )
 @click.option("--run-id", "run_id", default=None, help="Pre-assigned run ID (used by GUI).")
-def start(role, runtime, isolation, merge_strategy, pull, host, port, task, headless, run_id):
+@click.option("--system-prompt", "system_prompt", default=None, help="Custom system prompt appended to role instructions.")
+def start(role, runtime, isolation, merge_strategy, pull, host, port, task, headless, run_id, system_prompt):
     """Start an orchestration session.
 
     Runs in the foreground — creates an isolated environment (if configured),
@@ -431,6 +432,7 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task, head
         task=task or "",
         run_id=run_id,
         headless=headless,
+        system_prompt=system_prompt or "",
     )
     session.start(working_dir)
 

--- a/cli/src/strawpot/context.py
+++ b/cli/src/strawpot/context.py
@@ -56,6 +56,7 @@ def build_prompt(
     delegatable_roles: list[tuple[str, str]] | None = None,
     requester_role: str | None = None,
     global_skills: list[tuple[str, str]] | None = None,
+    custom_prompt: str | None = None,
 ) -> str:
     """Build a system prompt from a resolved role and its dependencies.
 
@@ -99,6 +100,9 @@ def build_prompt(
 
     if requester_role:
         sections.append(_build_requester_section(requester_role))
+
+    if custom_prompt:
+        sections.append(f"## Custom Instructions\n\n{custom_prompt}")
 
     return "\n---\n\n".join(sections)
 

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -284,12 +284,14 @@ class Session:
         run_id: str | None = None,
         ask_user_handler: Callable[[AskUserRequest], AskUserResponse] | None = None,
         headless: bool = False,
+        system_prompt: str = "",
     ) -> None:
         self.config = config
         self.wrapper = wrapper
         self.runtime = runtime
         self.isolator = isolator
         self.task = task
+        self.system_prompt = system_prompt
         self._resolve_role = resolve_role
         self._resolve_role_dirs = resolve_role_dirs
         self._ask_user_handler = ask_user_handler or _default_ask_user_handler
@@ -387,6 +389,7 @@ class Session:
                 resolved,
                 delegatable_roles=delegatable or None,
                 global_skills=[(s, d) for s, d, _ in global_skills] or None,
+                custom_prompt=self.system_prompt or None,
             )
             self._orchestrator_role_prompt = role_prompt
 

--- a/gui/frontend/src/components/LaunchDialog.tsx
+++ b/gui/frontend/src/components/LaunchDialog.tsx
@@ -61,6 +61,7 @@ export default function LaunchDialog({
   const [runtime, setRuntime] = useState("");
   const [isolation, setIsolation] = useState("");
   const [mergeStrategy, setMergeStrategy] = useState("");
+  const [systemPrompt, setSystemPrompt] = useState("");
   const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
   const [fileFilter, setFileFilter] = useState("");
 
@@ -70,6 +71,7 @@ export default function LaunchDialog({
     setRuntime("");
     setIsolation("");
     setMergeStrategy("");
+    setSystemPrompt("");
     setSelectedFiles([]);
   };
 
@@ -88,6 +90,7 @@ export default function LaunchDialog({
         role?: string;
         overrides?: Record<string, string>;
         context_files?: string[];
+        system_prompt?: string;
       } = {
         project_id: projectId,
         task: task.trim(),
@@ -100,6 +103,7 @@ export default function LaunchDialog({
       if (mergeStrategy.trim()) overrides.merge_strategy = mergeStrategy.trim();
       if (Object.keys(overrides).length > 0) body.overrides = overrides;
       if (selectedFiles.length > 0) body.context_files = selectedFiles;
+      if (systemPrompt.trim()) body.system_prompt = systemPrompt.trim();
 
       const result = await launchSession.mutateAsync(body);
       resetForm();
@@ -294,6 +298,16 @@ export default function LaunchDialog({
                     </SelectContent>
                   </Select>
                 </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="system-prompt">System Prompt</Label>
+                <Textarea
+                  id="system-prompt"
+                  value={systemPrompt}
+                  onChange={(e) => setSystemPrompt(e.target.value)}
+                  placeholder="Additional instructions for the agent..."
+                  rows={3}
+                />
               </div>
             </CollapsibleContent>
           </Collapsible>

--- a/gui/frontend/src/hooks/mutations/use-sessions.ts
+++ b/gui/frontend/src/hooks/mutations/use-sessions.ts
@@ -8,6 +8,7 @@ interface LaunchSessionBody {
   role?: string;
   overrides?: Record<string, string>;
   context_files?: string[];
+  system_prompt?: string;
 }
 
 export function useLaunchSession() {

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -123,6 +123,7 @@ class SessionLaunch(BaseModel):
     role: str | None = None
     overrides: SessionOverrides | None = None
     context_files: list[str] | None = None
+    system_prompt: str | None = None
 
     @field_validator("task")
     @classmethod
@@ -216,6 +217,8 @@ def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
             cmd.extend(["--isolation", body.overrides.isolation])
         if body.overrides.merge_strategy:
             cmd.extend(["--merge-strategy", body.overrides.merge_strategy])
+    if body.system_prompt:
+        cmd.extend(["--system-prompt", body.system_prompt])
 
     # Ensure subprocess can find user-installed tools (claude, etc.)
     # even when the server was started from a limited-PATH context.


### PR DESCRIPTION
## Summary
- Add **System Prompt** textarea in the Launch Session dialog (under Advanced Options) for ad-hoc agent instructions
- Flow: Frontend → GUI API (`system_prompt` field) → CLI (`--system-prompt` option) → `build_prompt()` in `context.py` appends as "## Custom Instructions" section
- No changes needed in agent wrappers/runtimes — the custom prompt is transparently included in the role prompt

## Test plan
- [x] All 125 GUI tests pass
- [ ] Open Launch Session dialog → expand Advanced Options → verify System Prompt textarea appears
- [ ] Launch session with custom prompt → verify it appears in agent's system prompt context
- [ ] Launch session without custom prompt → verify no "Custom Instructions" section added

🤖 Generated with [Claude Code](https://claude.com/claude-code)