### PR TITLE
Add scheduled tasks: cron scheduler, CRUD API, and GUI page

### DIFF
--- a/gui/frontend/package-lock.json
+++ b/gui/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "cronstrue": "^3.13.0",
         "lucide-react": "^0.577.0",
         "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
@@ -3238,6 +3239,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cronstrue": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-3.13.0.tgz",
+      "integrity": "sha512-M06cKwRIN46AyuM8BOmF1HUkBTkd3/h7uYImnrH1T3wtRKBGOibVo3jZ42VheEvx8LtgZbG/4GI35vfIxYxMug==",
+      "license": "MIT",
+      "bin": {
+        "cronstrue": "bin/cli.js"
       }
     },
     "node_modules/csstype": {

--- a/gui/frontend/package.json
+++ b/gui/frontend/package.json
@@ -14,6 +14,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "cronstrue": "^3.13.0",
     "lucide-react": "^0.577.0",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",

--- a/gui/frontend/src/App.tsx
+++ b/gui/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import ProjectList from "./pages/ProjectList";
 import ProjectDetail from "./pages/ProjectDetail";
 import SessionDetail from "./pages/SessionDetail";
 import ResourceBrowser from "./pages/ResourceBrowser";
+import ScheduledTasks from "./pages/ScheduledTasks";
 import Settings from "./pages/Settings";
 import NotFound from "./pages/NotFound";
 import { useGlobalSSE } from "./hooks/useGlobalSSE";
@@ -22,6 +23,7 @@ export default function App() {
           path="projects/:projectId/sessions/:runId"
           element={<SessionDetail />}
         />
+        <Route path="schedules" element={<ScheduledTasks />} />
         <Route
           path="resources/:resourceType"
           element={<ResourceBrowser />}

--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -135,3 +135,19 @@ export interface AgentValidation {
   setup_command: string | null;
   setup_description: string | null;
 }
+
+export interface Schedule {
+  id: number;
+  name: string;
+  project_id: number;
+  project_name: string;
+  role: string | null;
+  task: string;
+  cron_expr: string;
+  enabled: boolean;
+  system_prompt: string | null;
+  last_run_at: string | null;
+  next_run_at: string | null;
+  last_error: string | null;
+  created_at: string;
+}

--- a/gui/frontend/src/components/CreateScheduleDialog.tsx
+++ b/gui/frontend/src/components/CreateScheduleDialog.tsx
@@ -1,0 +1,298 @@
+import { useEffect, useMemo, useState } from "react";
+import cronstrue from "cronstrue";
+import { useProjects } from "@/hooks/queries/use-projects";
+import { useRoles } from "@/hooks/queries/use-roles";
+import { useCreateSchedule, useUpdateSchedule } from "@/hooks/mutations/use-schedules";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { ChevronDown } from "lucide-react";
+import type { Schedule } from "@/api/types";
+
+const CRON_PRESETS = [
+  { label: "Every 1 minute", value: "* * * * *" },
+  { label: "Every 5 minutes", value: "*/5 * * * *" },
+  { label: "Every hour", value: "0 * * * *" },
+  { label: "Daily at midnight", value: "0 0 * * *" },
+  { label: "Weekdays at 9am", value: "0 9 * * 1-5" },
+  { label: "Weekly Monday 9am", value: "0 9 * * 1" },
+];
+
+interface CreateScheduleDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  editing: Schedule | null;
+}
+
+export default function CreateScheduleDialog({
+  open,
+  onOpenChange,
+  editing,
+}: CreateScheduleDialogProps) {
+  const { data: projects } = useProjects();
+  const { data: roles } = useRoles();
+  const createSchedule = useCreateSchedule();
+  const updateSchedule = useUpdateSchedule();
+
+  const [name, setName] = useState("");
+  const [projectId, setProjectId] = useState<string>("");
+  const [task, setTask] = useState("");
+  const [cronExpr, setCronExpr] = useState("");
+  const [role, setRole] = useState("");
+  const [systemPrompt, setSystemPrompt] = useState("");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  useEffect(() => {
+    if (open && editing) {
+      setName(editing.name);
+      setProjectId(String(editing.project_id));
+      setTask(editing.task);
+      setCronExpr(editing.cron_expr);
+      setRole(editing.role ?? "");
+      setSystemPrompt(editing.system_prompt ?? "");
+    } else if (open && !editing) {
+      resetForm();
+    }
+  }, [open, editing]);
+
+  function resetForm() {
+    setName("");
+    setProjectId("");
+    setTask("");
+    setCronExpr("");
+    setRole("");
+    setSystemPrompt("");
+    setAdvancedOpen(false);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      const body = {
+        name: name.trim(),
+        task: task.trim(),
+        cron_expr: cronExpr.trim(),
+        role: role.trim() || undefined,
+        system_prompt: systemPrompt.trim() || undefined,
+      };
+      if (editing) {
+        await updateSchedule.mutateAsync({ id: editing.id, ...body });
+      } else {
+        await createSchedule.mutateAsync({
+          ...body,
+          project_id: Number(projectId),
+        });
+      }
+      resetForm();
+      onOpenChange(false);
+    } catch {
+      // error displayed via mutation state
+    }
+  }
+
+  const cronDescription = useMemo(() => {
+    if (!cronExpr.trim()) return null;
+    try {
+      return cronstrue.toString(cronExpr.trim());
+    } catch {
+      return null;
+    }
+  }, [cronExpr]);
+
+  const isPending = createSchedule.isPending || updateSchedule.isPending;
+  const mutationError = createSchedule.error || updateSchedule.error;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {editing ? "Edit Schedule" : "Create Schedule"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="sched-name">
+              Name <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="sched-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. github-issue-checker"
+              required
+              autoFocus
+            />
+          </div>
+
+          {!editing && (
+            <div className="space-y-2">
+              <Label htmlFor="sched-project">
+                Project <span className="text-destructive">*</span>
+              </Label>
+              <Select value={projectId} onValueChange={setProjectId} required>
+                <SelectTrigger id="sched-project">
+                  <SelectValue placeholder="Select a project" />
+                </SelectTrigger>
+                <SelectContent>
+                  {(projects ?? []).map((p) => (
+                    <SelectItem key={p.id} value={String(p.id)}>
+                      {p.display_name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="sched-task">
+              Task <span className="text-destructive">*</span>
+            </Label>
+            <Textarea
+              id="sched-task"
+              value={task}
+              onChange={(e) => setTask(e.target.value)}
+              placeholder="What should the agent do each time this runs?"
+              required
+              rows={3}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="sched-cron">
+                Cron Expression <span className="text-destructive">*</span>
+              </Label>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="sm" className="h-6 text-xs">
+                    Presets
+                    <ChevronDown className="ml-1 h-3 w-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {CRON_PRESETS.map((p) => (
+                    <DropdownMenuItem
+                      key={p.value}
+                      onClick={() => setCronExpr(p.value)}
+                    >
+                      <span className="mr-3 font-mono text-xs text-muted-foreground">
+                        {p.value}
+                      </span>
+                      {p.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+            <Input
+              id="sched-cron"
+              value={cronExpr}
+              onChange={(e) => setCronExpr(e.target.value)}
+              placeholder="*/5 * * * *"
+              required
+              className="font-mono"
+            />
+            {cronDescription && (
+              <p className="text-xs text-muted-foreground">{cronDescription}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="sched-role">Role</Label>
+            <Input
+              id="sched-role"
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              placeholder={roles?.[0] ?? "orchestrator"}
+              list="sched-role-list"
+            />
+            <datalist id="sched-role-list">
+              {(roles ?? []).map((r) => (
+                <option key={r} value={r} />
+              ))}
+            </datalist>
+          </div>
+
+          <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+            <CollapsibleTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="flex items-center gap-1 px-0 text-xs text-muted-foreground"
+              >
+                <ChevronDown
+                  className={`h-3 w-3 transition-transform ${advancedOpen ? "rotate-180" : ""}`}
+                />
+                Advanced Options
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="space-y-4 pt-2">
+              <div className="space-y-2">
+                <Label htmlFor="sched-prompt">System Prompt</Label>
+                <Textarea
+                  id="sched-prompt"
+                  value={systemPrompt}
+                  onChange={(e) => setSystemPrompt(e.target.value)}
+                  placeholder="Additional instructions for the agent..."
+                  rows={3}
+                />
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+
+          {mutationError && (
+            <p className="text-sm text-destructive">
+              {(mutationError as Error).message}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending
+                ? "Saving..."
+                : editing
+                  ? "Update"
+                  : "Create"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/gui/frontend/src/hooks/mutations/use-schedules.ts
+++ b/gui/frontend/src/hooks/mutations/use-schedules.ts
@@ -1,0 +1,64 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import { queryKeys } from "@/lib/query-keys";
+import type { Schedule } from "@/api/types";
+
+interface CreateScheduleBody {
+  name: string;
+  project_id: number;
+  task: string;
+  cron_expr: string;
+  role?: string;
+  system_prompt?: string;
+}
+
+interface UpdateScheduleBody {
+  name?: string;
+  task?: string;
+  cron_expr?: string;
+  role?: string;
+  system_prompt?: string;
+}
+
+export function useCreateSchedule() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateScheduleBody) =>
+      api.post<Schedule>("/schedules", body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.schedules.all });
+    },
+  });
+}
+
+export function useUpdateSchedule() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...body }: { id: number } & UpdateScheduleBody) =>
+      api.put<Schedule>(`/schedules/${id}`, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.schedules.all });
+    },
+  });
+}
+
+export function useDeleteSchedule() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => api.delete(`/schedules/${id}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.schedules.all });
+    },
+  });
+}
+
+export function useToggleSchedule() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, enable }: { id: number; enable: boolean }) =>
+      api.post<Schedule>(`/schedules/${id}/${enable ? "enable" : "disable"}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.schedules.all });
+    },
+  });
+}

--- a/gui/frontend/src/hooks/queries/use-schedules.ts
+++ b/gui/frontend/src/hooks/queries/use-schedules.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import { queryKeys } from "@/lib/query-keys";
+import type { Schedule, Session } from "@/api/types";
+
+export function useSchedules() {
+  return useQuery({
+    queryKey: queryKeys.schedules.all,
+    queryFn: () => api.get<Schedule[]>("/schedules"),
+  });
+}
+
+export function useSchedule(id: number) {
+  return useQuery({
+    queryKey: queryKeys.schedules.detail(id),
+    queryFn: () => api.get<Schedule>(`/schedules/${id}`),
+    enabled: id > 0,
+  });
+}
+
+export function useScheduleHistory(id: number) {
+  return useQuery({
+    queryKey: queryKeys.schedules.history(id),
+    queryFn: () => api.get<Session[]>(`/schedules/${id}/history`),
+    enabled: id > 0,
+  });
+}

--- a/gui/frontend/src/layouts/AppLayout.tsx
+++ b/gui/frontend/src/layouts/AppLayout.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Link, NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useTheme } from "next-themes";
-import { LayoutDashboard, FolderKanban, Users, Wrench, Bot, Brain, Settings, Sun, Moon, Check, ChevronsUpDown } from "lucide-react";
+import { LayoutDashboard, FolderKanban, Clock, Users, Wrench, Bot, Brain, Settings, Sun, Moon, Check, ChevronsUpDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useProject, useProjects } from "@/hooks/queries/use-projects";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -27,6 +27,7 @@ import { Separator } from "@/components/ui/separator";
 const navItems = [
   { to: "/", label: "Dashboard", icon: LayoutDashboard, end: true },
   { to: "/projects", label: "Projects", icon: FolderKanban },
+  { to: "/schedules", label: "Schedules", icon: Clock },
   { to: "/settings", label: "Settings", icon: Settings },
 ];
 
@@ -60,6 +61,10 @@ function useBreadcrumbs() {
         crumbs.push({ label: `Session ${segments[3].slice(0, 8)}…` });
       }
     }
+  }
+
+  if (segments[0] === "schedules") {
+    crumbs.push({ label: "Scheduled Tasks" });
   }
 
   if (segments[0] === "settings") {

--- a/gui/frontend/src/lib/query-keys.ts
+++ b/gui/frontend/src/lib/query-keys.ts
@@ -31,4 +31,9 @@ export const queryKeys = {
     validate: (name: string) =>
       ["registry", "agents", name, "validate"] as const,
   },
+  schedules: {
+    all: ["schedules"] as const,
+    detail: (id: number) => ["schedules", id] as const,
+    history: (id: number) => ["schedules", id, "history"] as const,
+  },
 };

--- a/gui/frontend/src/pages/ScheduledTasks.tsx
+++ b/gui/frontend/src/pages/ScheduledTasks.tsx
@@ -1,0 +1,209 @@
+import { useState } from "react";
+import { useSchedules } from "@/hooks/queries/use-schedules";
+import { useDeleteSchedule, useToggleSchedule } from "@/hooks/mutations/use-schedules";
+import CreateScheduleDialog from "@/components/CreateScheduleDialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { AlertCircle, Pause, Pencil, Play, Plus, Trash2 } from "lucide-react";
+import type { Schedule } from "@/api/types";
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    const d = new Date(iso);
+    const now = new Date();
+    const diffMs = d.getTime() - now.getTime();
+    const absDiff = Math.abs(diffMs);
+    if (absDiff < 60_000) return diffMs > 0 ? "in < 1m" : "< 1m ago";
+    if (absDiff < 3_600_000) {
+      const mins = Math.round(absDiff / 60_000);
+      return diffMs > 0 ? `in ${mins}m` : `${mins}m ago`;
+    }
+    if (absDiff < 86_400_000) {
+      const hours = Math.round(absDiff / 3_600_000);
+      return diffMs > 0 ? `in ${hours}h` : `${hours}h ago`;
+    }
+    return d.toLocaleDateString();
+  } catch {
+    return "—";
+  }
+}
+
+function StatusBadge({ schedule }: { schedule: Schedule }) {
+  if (!schedule.enabled) {
+    return <Badge variant="secondary">Disabled</Badge>;
+  }
+  if (schedule.last_error) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger>
+            <Badge variant="destructive">Error</Badge>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">
+            <p className="text-xs">{schedule.last_error}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+  return <Badge className="bg-emerald-600 hover:bg-emerald-600">Active</Badge>;
+}
+
+export default function ScheduledTasks() {
+  const { data: schedules, isLoading, error } = useSchedules();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<Schedule | null>(null);
+  const deleteSchedule = useDeleteSchedule();
+  const toggleSchedule = useToggleSchedule();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 rounded-lg" />
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 text-destructive">
+        <AlertCircle className="h-4 w-4" />
+        <span>Error: {error.message}</span>
+      </div>
+    );
+  }
+
+  const list = schedules ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">Scheduled Tasks</h1>
+        <Button onClick={() => { setEditing(null); setDialogOpen(true); }}>
+          <Plus className="mr-2 h-4 w-4" />
+          Create Schedule
+        </Button>
+      </div>
+
+      {list.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center">
+          <p className="text-muted-foreground">No scheduled tasks yet.</p>
+          <Button
+            variant="outline"
+            className="mt-4"
+            onClick={() => { setEditing(null); setDialogOpen(true); }}
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            Create your first schedule
+          </Button>
+        </div>
+      ) : (
+        <div className="rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Project</TableHead>
+                <TableHead>Cron</TableHead>
+                <TableHead>Next Run</TableHead>
+                <TableHead>Last Run</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="w-[120px]">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {list.map((s) => (
+                <TableRow key={s.id}>
+                  <TableCell className="font-medium">{s.name}</TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {s.project_name}
+                  </TableCell>
+                  <TableCell>
+                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                      {s.cron_expr}
+                    </code>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {formatRelative(s.next_run_at)}
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {formatRelative(s.last_run_at)}
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge schedule={s} />
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => {
+                          setEditing(s);
+                          setDialogOpen(true);
+                        }}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() =>
+                          toggleSchedule.mutate({
+                            id: s.id,
+                            enable: !s.enabled,
+                          })
+                        }
+                      >
+                        {s.enabled ? (
+                          <Pause className="h-3.5 w-3.5" />
+                        ) : (
+                          <Play className="h-3.5 w-3.5" />
+                        )}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-destructive hover:text-destructive"
+                        onClick={() => {
+                          if (confirm(`Delete schedule "${s.name}"?`)) {
+                            deleteSchedule.mutate(s.id);
+                          }
+                        }}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <CreateScheduleDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        editing={editing}
+      />
+    </div>
+  );
+}

--- a/gui/pyproject.toml
+++ b/gui/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "tomli_w>=1.0",
     "watchfiles>=1.0",
     "python-multipart>=0.0.9",
+    "croniter>=2.0",
 ]
 
 [project.scripts]

--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -15,9 +15,10 @@ from strawpot.config import get_strawpot_home
 
 from strawpot_gui.db import init_db, sync_sessions
 from strawpot_gui.event_bus import event_bus
+from strawpot_gui.scheduler import Scheduler
 
 logger = logging.getLogger(__name__)
-from strawpot_gui.routers import config, files, fs, health, logs, project_resources, projects, registry, sessions, sse
+from strawpot_gui.routers import config, files, fs, health, logs, project_resources, projects, registry, schedules, sessions, sse
 
 
 def _auto_rebuild_frontend(dist_dir: Path) -> None:
@@ -70,7 +71,12 @@ def create_app(db_path: str | None = None) -> FastAPI:
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         init_db(db_path)
         sync_sessions(db_path)
+        from strawpot_gui.routers.sessions import launch_session_subprocess
+        scheduler = Scheduler(db_path, launch_fn=launch_session_subprocess)
+        app.state.scheduler = scheduler
+        await scheduler.start()
         yield
+        await scheduler.stop()
 
     app = FastAPI(title="StrawPot GUI", version="0.1.0", lifespan=lifespan)
     app.state.db_path = db_path
@@ -97,6 +103,7 @@ def create_app(db_path: str | None = None) -> FastAPI:
     app.include_router(fs.router)
     app.include_router(registry.router)
     app.include_router(project_resources.router)
+    app.include_router(schedules.router)
 
     # Serve built frontend — check installed package path then dev path
     static_dir = Path(__file__).resolve().parent / "static"

--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -32,22 +32,26 @@ CREATE TABLE IF NOT EXISTS sessions (
     exit_code   INTEGER,
     session_dir TEXT NOT NULL,
     task        TEXT,
-    summary     TEXT
+    summary     TEXT,
+    schedule_id INTEGER REFERENCES scheduled_tasks(id) ON DELETE SET NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_status  ON sessions(status);
 
-CREATE TABLE IF NOT EXISTS trigger_instances (
-    id          INTEGER PRIMARY KEY,
-    name        TEXT NOT NULL UNIQUE,
-    adapter     TEXT NOT NULL,
-    project_id  INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-    role        TEXT NOT NULL,
-    config      TEXT NOT NULL DEFAULT '{}',
-    status      TEXT NOT NULL DEFAULT 'stopped',
-    last_error  TEXT,
-    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+CREATE TABLE IF NOT EXISTS scheduled_tasks (
+    id            INTEGER PRIMARY KEY,
+    name          TEXT NOT NULL UNIQUE,
+    project_id    INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    role          TEXT,
+    task          TEXT NOT NULL,
+    cron_expr     TEXT NOT NULL,
+    enabled       INTEGER NOT NULL DEFAULT 1,
+    system_prompt TEXT,
+    last_run_at   TEXT,
+    next_run_at   TEXT,
+    last_error    TEXT,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now'))
 );
 """
 

--- a/gui/src/strawpot_gui/routers/schedules.py
+++ b/gui/src/strawpot_gui/routers/schedules.py
@@ -1,0 +1,286 @@
+"""Scheduled tasks CRUD endpoints."""
+
+import sqlite3
+from datetime import datetime, timezone
+
+from croniter import croniter
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, field_validator
+
+from strawpot_gui.db import get_db_conn
+
+router = APIRouter(prefix="/api", tags=["schedules"])
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class ScheduleCreate(BaseModel):
+    name: str
+    project_id: int
+    task: str
+    cron_expr: str
+    role: str | None = None
+    system_prompt: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def name_nonempty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("name must be non-empty")
+        return v.strip()
+
+    @field_validator("task")
+    @classmethod
+    def task_nonempty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("task must be non-empty")
+        return v.strip()
+
+    @field_validator("cron_expr")
+    @classmethod
+    def cron_valid(cls, v: str) -> str:
+        v = v.strip()
+        if not croniter.is_valid(v):
+            raise ValueError(f"Invalid cron expression: {v}")
+        return v
+
+
+class ScheduleUpdate(BaseModel):
+    name: str | None = None
+    task: str | None = None
+    cron_expr: str | None = None
+    role: str | None = None
+    system_prompt: str | None = None
+
+    @field_validator("cron_expr")
+    @classmethod
+    def cron_valid(cls, v: str | None) -> str | None:
+        if v is not None:
+            v = v.strip()
+            if not croniter.is_valid(v):
+                raise ValueError(f"Invalid cron expression: {v}")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_dict(row: sqlite3.Row) -> dict:
+    d = dict(row)
+    d["enabled"] = bool(d.get("enabled", 0))
+    return d
+
+
+def _compute_next_run(cron_expr: str) -> str | None:
+    try:
+        now = datetime.now(timezone.utc)
+        return croniter(cron_expr, now).get_next(datetime).isoformat()
+    except (ValueError, KeyError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/schedules")
+def list_schedules(conn=Depends(get_db_conn)):
+    """List all scheduled tasks with project names."""
+    rows = conn.execute(
+        "SELECT s.*, p.display_name AS project_name "
+        "FROM scheduled_tasks s "
+        "LEFT JOIN projects p ON s.project_id = p.id "
+        "ORDER BY s.created_at DESC"
+    ).fetchall()
+    return [_row_to_dict(row) for row in rows]
+
+
+@router.post("/schedules", status_code=201)
+def create_schedule(body: ScheduleCreate, conn=Depends(get_db_conn)):
+    """Create a new scheduled task."""
+    # Verify project exists
+    project = conn.execute(
+        "SELECT id FROM projects WHERE id = ?", (body.project_id,)
+    ).fetchone()
+    if not project:
+        raise HTTPException(404, "Project not found")
+
+    next_run = _compute_next_run(body.cron_expr)
+
+    try:
+        cursor = conn.execute(
+            """INSERT INTO scheduled_tasks
+               (name, project_id, role, task, cron_expr, system_prompt, next_run_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (body.name, body.project_id, body.role, body.task,
+             body.cron_expr, body.system_prompt, next_run),
+        )
+    except sqlite3.IntegrityError:
+        raise HTTPException(409, "A schedule with this name already exists")
+
+    row = conn.execute(
+        "SELECT s.*, p.display_name AS project_name "
+        "FROM scheduled_tasks s "
+        "LEFT JOIN projects p ON s.project_id = p.id "
+        "WHERE s.id = ?",
+        (cursor.lastrowid,),
+    ).fetchone()
+    return _row_to_dict(row)
+
+
+@router.get("/schedules/{schedule_id}")
+def get_schedule(schedule_id: int, conn=Depends(get_db_conn)):
+    """Get a single scheduled task."""
+    row = conn.execute(
+        "SELECT s.*, p.display_name AS project_name "
+        "FROM scheduled_tasks s "
+        "LEFT JOIN projects p ON s.project_id = p.id "
+        "WHERE s.id = ?",
+        (schedule_id,),
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, "Schedule not found")
+    return _row_to_dict(row)
+
+
+@router.put("/schedules/{schedule_id}")
+def update_schedule(
+    schedule_id: int, body: ScheduleUpdate, conn=Depends(get_db_conn),
+):
+    """Update a scheduled task."""
+    existing = conn.execute(
+        "SELECT * FROM scheduled_tasks WHERE id = ?", (schedule_id,)
+    ).fetchone()
+    if not existing:
+        raise HTTPException(404, "Schedule not found")
+
+    updates: list[str] = []
+    params: list = []
+
+    if body.name is not None:
+        updates.append("name = ?")
+        params.append(body.name.strip())
+    if body.task is not None:
+        updates.append("task = ?")
+        params.append(body.task.strip())
+    if body.role is not None:
+        updates.append("role = ?")
+        params.append(body.role.strip() or None)
+    if body.system_prompt is not None:
+        updates.append("system_prompt = ?")
+        params.append(body.system_prompt.strip() or None)
+    if body.cron_expr is not None:
+        updates.append("cron_expr = ?")
+        params.append(body.cron_expr)
+        # Recompute next_run_at if cron changed and schedule is enabled
+        if existing["enabled"]:
+            next_run = _compute_next_run(body.cron_expr)
+            updates.append("next_run_at = ?")
+            params.append(next_run)
+
+    if not updates:
+        raise HTTPException(422, "No fields to update")
+
+    params.append(schedule_id)
+    try:
+        conn.execute(
+            f"UPDATE scheduled_tasks SET {', '.join(updates)} WHERE id = ?",
+            params,
+        )
+    except sqlite3.IntegrityError:
+        raise HTTPException(409, "A schedule with this name already exists")
+
+    row = conn.execute(
+        "SELECT s.*, p.display_name AS project_name "
+        "FROM scheduled_tasks s "
+        "LEFT JOIN projects p ON s.project_id = p.id "
+        "WHERE s.id = ?",
+        (schedule_id,),
+    ).fetchone()
+    return _row_to_dict(row)
+
+
+@router.delete("/schedules/{schedule_id}")
+def delete_schedule(schedule_id: int, conn=Depends(get_db_conn)):
+    """Delete a scheduled task."""
+    row = conn.execute(
+        "SELECT id FROM scheduled_tasks WHERE id = ?", (schedule_id,)
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, "Schedule not found")
+    conn.execute("DELETE FROM scheduled_tasks WHERE id = ?", (schedule_id,))
+    return {"ok": True}
+
+
+@router.post("/schedules/{schedule_id}/enable")
+def enable_schedule(schedule_id: int, conn=Depends(get_db_conn)):
+    """Enable a scheduled task."""
+    row = conn.execute(
+        "SELECT * FROM scheduled_tasks WHERE id = ?", (schedule_id,)
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, "Schedule not found")
+
+    next_run = _compute_next_run(row["cron_expr"])
+    conn.execute(
+        "UPDATE scheduled_tasks SET enabled = 1, next_run_at = ? WHERE id = ?",
+        (next_run, schedule_id),
+    )
+
+    updated = conn.execute(
+        "SELECT s.*, p.display_name AS project_name "
+        "FROM scheduled_tasks s "
+        "LEFT JOIN projects p ON s.project_id = p.id "
+        "WHERE s.id = ?",
+        (schedule_id,),
+    ).fetchone()
+    return _row_to_dict(updated)
+
+
+@router.post("/schedules/{schedule_id}/disable")
+def disable_schedule(schedule_id: int, conn=Depends(get_db_conn)):
+    """Disable a scheduled task."""
+    row = conn.execute(
+        "SELECT id FROM scheduled_tasks WHERE id = ?", (schedule_id,)
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, "Schedule not found")
+
+    conn.execute(
+        "UPDATE scheduled_tasks SET enabled = 0, next_run_at = NULL WHERE id = ?",
+        (schedule_id,),
+    )
+
+    updated = conn.execute(
+        "SELECT s.*, p.display_name AS project_name "
+        "FROM scheduled_tasks s "
+        "LEFT JOIN projects p ON s.project_id = p.id "
+        "WHERE s.id = ?",
+        (schedule_id,),
+    ).fetchone()
+    return _row_to_dict(updated)
+
+
+@router.get("/schedules/{schedule_id}/history")
+def schedule_history(schedule_id: int, conn=Depends(get_db_conn)):
+    """List sessions spawned by this schedule."""
+    row = conn.execute(
+        "SELECT id FROM scheduled_tasks WHERE id = ?", (schedule_id,)
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, "Schedule not found")
+
+    rows = conn.execute(
+        "SELECT run_id, project_id, role, runtime, isolation, status,"
+        "       started_at, ended_at, duration_ms, exit_code, task, summary"
+        "  FROM sessions WHERE schedule_id = ? ORDER BY started_at DESC"
+        "  LIMIT 50",
+        (schedule_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -133,33 +133,40 @@ class SessionLaunch(BaseModel):
         return v.strip()
 
 
-@router.post("/sessions", status_code=201)
-def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
-    """Launch a new headless session as a detached subprocess."""
+def launch_session_subprocess(
+    conn,
+    project_id: int,
+    task: str,
+    *,
+    role: str | None = None,
+    system_prompt: str | None = None,
+    runtime_override: str | None = None,
+    isolation_override: str | None = None,
+    merge_strategy_override: str | None = None,
+    context_files: list[str] | None = None,
+    schedule_id: int | None = None,
+) -> str:
+    """Launch a headless session subprocess. Returns run_id.
+
+    Shared by the HTTP endpoint and the cron scheduler.
+    Raises RuntimeError on failure (caller decides HTTP vs log response).
+    """
     project = conn.execute(
         "SELECT id, working_dir FROM projects WHERE id = ?",
-        (body.project_id,),
+        (project_id,),
     ).fetchone()
     if not project:
-        raise HTTPException(404, "Project not found")
+        raise RuntimeError("Project not found")
 
     working_dir = project["working_dir"]
     if not Path(working_dir).is_dir():
-        raise HTTPException(
-            422, "Project working directory does not exist"
-        )
+        raise RuntimeError("Project working directory does not exist")
 
     # Load project config for defaults
     config = load_config(Path(working_dir))
-    role = body.role or config.orchestrator_role
-    runtime = config.runtime
-    isolation = config.isolation
-
-    if body.overrides:
-        if body.overrides.runtime:
-            runtime = body.overrides.runtime
-        if body.overrides.isolation:
-            isolation = body.overrides.isolation
+    resolved_role = role or config.orchestrator_role
+    runtime = runtime_override or config.runtime
+    isolation = isolation_override or config.isolation
 
     # Pre-generate run_id
     run_id = f"run_{uuid.uuid4().hex[:12]}"
@@ -169,23 +176,23 @@ def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
     conn.execute(
         """INSERT INTO sessions
            (run_id, project_id, role, runtime, isolation, status,
-            started_at, session_dir, task)
-           VALUES (?, ?, ?, ?, ?, 'starting', ?, ?, ?)""",
-        (run_id, body.project_id, role, runtime, isolation, now,
-         session_dir, body.task),
+            started_at, session_dir, task, schedule_id)
+           VALUES (?, ?, ?, ?, ?, 'starting', ?, ?, ?, ?)""",
+        (run_id, project_id, resolved_role, runtime, isolation, now,
+         session_dir, task, schedule_id),
     )
 
     # Resolve context files and append to task
-    task_text = body.task
-    if body.context_files:
+    task_text = task
+    if context_files:
         files_dir = Path(working_dir) / ".strawpot" / "files"
         resolved: list[str] = []
-        for rel_path in body.context_files:
+        for rel_path in context_files:
             fp = (files_dir / rel_path).resolve()
             if not fp.is_relative_to(files_dir.resolve()):
-                raise HTTPException(400, f"Invalid file path: {rel_path}")
+                raise RuntimeError(f"Invalid file path: {rel_path}")
             if not fp.is_file():
-                raise HTTPException(404, f"File not found: {rel_path}")
+                raise RuntimeError(f"File not found: {rel_path}")
             resolved.append(str(fp))
         if resolved:
             listing = "\n".join(f"- {p}" for p in resolved)
@@ -200,7 +207,7 @@ def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
     # Build CLI command
     strawpot_cmd = shutil.which("strawpot")
     if strawpot_cmd is None:
-        raise HTTPException(500, "strawpot CLI not found on PATH")
+        raise RuntimeError("strawpot CLI not found on PATH")
 
     cmd = [
         strawpot_cmd, "start",
@@ -208,17 +215,16 @@ def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
         "--task", task_text,
         "--run-id", run_id,
     ]
-    if body.role:
-        cmd.extend(["--role", body.role])
-    if body.overrides:
-        if body.overrides.runtime:
-            cmd.extend(["--runtime", body.overrides.runtime])
-        if body.overrides.isolation:
-            cmd.extend(["--isolation", body.overrides.isolation])
-        if body.overrides.merge_strategy:
-            cmd.extend(["--merge-strategy", body.overrides.merge_strategy])
-    if body.system_prompt:
-        cmd.extend(["--system-prompt", body.system_prompt])
+    if role:
+        cmd.extend(["--role", role])
+    if runtime_override:
+        cmd.extend(["--runtime", runtime_override])
+    if isolation_override:
+        cmd.extend(["--isolation", isolation_override])
+    if merge_strategy_override:
+        cmd.extend(["--merge-strategy", merge_strategy_override])
+    if system_prompt:
+        cmd.extend(["--system-prompt", system_prompt])
 
     # Ensure subprocess can find user-installed tools (claude, etc.)
     # even when the server was started from a limited-PATH context.
@@ -244,13 +250,39 @@ def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
         )
     except OSError:
         conn.execute("DELETE FROM sessions WHERE run_id = ?", (run_id,))
-        raise HTTPException(500, "Failed to start session subprocess")
+        raise RuntimeError("Failed to start session subprocess")
 
     event_bus.publish(SessionEvent(
         kind="session_started",
         run_id=run_id,
-        project_id=body.project_id,
+        project_id=project_id,
     ))
+
+    return run_id
+
+
+@router.post("/sessions", status_code=201)
+def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
+    """Launch a new headless session as a detached subprocess."""
+    _ERROR_STATUS = {
+        "Project not found": 404,
+        "Project working directory does not exist": 422,
+    }
+    try:
+        run_id = launch_session_subprocess(
+            conn,
+            body.project_id,
+            body.task,
+            role=body.role,
+            system_prompt=body.system_prompt,
+            runtime_override=body.overrides.runtime if body.overrides else None,
+            isolation_override=body.overrides.isolation if body.overrides else None,
+            merge_strategy_override=body.overrides.merge_strategy if body.overrides else None,
+            context_files=body.context_files,
+        )
+    except RuntimeError as e:
+        status = _ERROR_STATUS.get(str(e), 500)
+        raise HTTPException(status, str(e))
 
     return {"run_id": run_id, "status": "starting"}
 

--- a/gui/src/strawpot_gui/scheduler.py
+++ b/gui/src/strawpot_gui/scheduler.py
@@ -1,0 +1,122 @@
+"""Cron-based scheduled task runner.
+
+Runs as an asyncio background task inside the FastAPI event loop.
+Checks for due schedules every 30 seconds and fires sessions via
+the shared launch_session_subprocess() function.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from croniter import croniter
+
+from strawpot_gui.db import get_db
+
+logger = logging.getLogger(__name__)
+
+
+class Scheduler:
+    """Manages scheduled task execution."""
+
+    def __init__(self, db_path: str, launch_fn) -> None:
+        self._db_path = db_path
+        self._launch_fn = launch_fn
+        self._task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        """Start the scheduler background loop."""
+        self._init_next_run_times()
+        self._task = asyncio.create_task(self._run_loop())
+        logger.info("Scheduler started")
+
+    async def stop(self) -> None:
+        """Stop the scheduler background loop."""
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            logger.info("Scheduler stopped")
+
+    def _init_next_run_times(self) -> None:
+        """Compute next_run_at for enabled schedules that don't have one."""
+        now = datetime.now(timezone.utc)
+        with get_db(self._db_path) as conn:
+            rows = conn.execute(
+                "SELECT id, cron_expr FROM scheduled_tasks "
+                "WHERE enabled = 1 AND next_run_at IS NULL"
+            ).fetchall()
+            for row in rows:
+                next_run = _next_run(row["cron_expr"], now)
+                if next_run:
+                    conn.execute(
+                        "UPDATE scheduled_tasks SET next_run_at = ? WHERE id = ?",
+                        (next_run, row["id"]),
+                    )
+
+    async def _run_loop(self) -> None:
+        """Main loop: check for due schedules every 30 seconds."""
+        while True:
+            try:
+                self._check_and_fire()
+            except Exception:
+                logger.exception("Scheduler tick error")
+            await asyncio.sleep(30)
+
+    def _check_and_fire(self) -> None:
+        """Check all enabled schedules and fire any that are due."""
+        now = datetime.now(timezone.utc)
+        with get_db(self._db_path) as conn:
+            rows = conn.execute(
+                "SELECT * FROM scheduled_tasks "
+                "WHERE enabled = 1 AND next_run_at IS NOT NULL"
+            ).fetchall()
+            for row in rows:
+                next_run_str = row["next_run_at"]
+                try:
+                    next_run = datetime.fromisoformat(next_run_str)
+                except (ValueError, TypeError):
+                    continue
+                if next_run <= now:
+                    self._fire(conn, dict(row), now)
+
+    def _fire(self, conn, schedule: dict, now: datetime) -> None:
+        """Fire a single scheduled task."""
+        schedule_id = schedule["id"]
+        name = schedule["name"]
+        try:
+            run_id = self._launch_fn(
+                conn,
+                schedule["project_id"],
+                schedule["task"],
+                role=schedule["role"],
+                system_prompt=schedule["system_prompt"],
+                schedule_id=schedule_id,
+            )
+            next_run = _next_run(schedule["cron_expr"], now)
+            conn.execute(
+                "UPDATE scheduled_tasks "
+                "SET last_run_at = ?, next_run_at = ?, last_error = NULL "
+                "WHERE id = ?",
+                (now.isoformat(), next_run, schedule_id),
+            )
+            logger.info(
+                "Schedule '%s' fired session %s, next run: %s",
+                name, run_id, next_run,
+            )
+        except Exception as exc:
+            conn.execute(
+                "UPDATE scheduled_tasks SET last_error = ? WHERE id = ?",
+                (str(exc), schedule_id),
+            )
+            logger.warning("Schedule '%s' failed: %s", name, exc)
+
+
+def _next_run(cron_expr: str, after: datetime) -> str | None:
+    """Compute the next run time for a cron expression."""
+    try:
+        return croniter(cron_expr, after).get_next(datetime).isoformat()
+    except (ValueError, KeyError):
+        return None


### PR DESCRIPTION
## Summary

- Implements gui/DESIGN.md item 9: scheduled tasks with cron-based session launching
- Backend: `scheduled_tasks` DB table, asyncio `Scheduler` (30s interval, croniter), full CRUD router (8 endpoints), shared `launch_session_subprocess()` function
- Frontend: ScheduledTasks page with table/status badges/actions, CreateScheduleDialog with cron presets and human-readable descriptions (cronstrue), query/mutation hooks
- Adds `croniter` (Python) and `cronstrue` (npm) dependencies

## Test plan

- [x] All 125 existing tests pass
- [x] Frontend builds cleanly (tsc + vite)
- [ ] Verify "Schedules" appears in sidebar navigation
- [ ] Create a schedule with cron preset, confirm human-readable description shows
- [ ] Toggle enable/disable, verify next_run_at updates
- [ ] Wait for schedule to fire, confirm session appears in project
- [ ] Check schedule history shows spawned sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)