### PR TITLE
Update roadmap: mark scheduled tasks done, move cost tracking to TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,6 +21,16 @@
   Pre/post spawn, pre/post cleanup extension points. Allow users to run
   custom scripts at key session lifecycle events.
 
+- [ ] **Cost / token tracking**
+  Requires wrapper protocol extension. The wrapper protocol is stateless
+  (called once to translate args to CLI command) — no callback to return
+  metrics. Needs a sidecar file approach: wrapper writes
+  `<workspace>/.metrics.json` after agent exits, `WrapperRuntime` reads
+  it and passes to tracer via extended `AgentResult.metrics` field.
+  Each runtime reports usage differently (Claude Code, Gemini, etc.),
+  so per-wrapper parsing is needed. GUI side is straightforward once
+  trace events carry the data.
+
 ## Security
 
 - [ ] **Sanitize summary field in session API responses**

--- a/gui/DESIGN.md
+++ b/gui/DESIGN.md
@@ -1371,7 +1371,6 @@ through the UI.
 | 7.8 | Frontend: breadcrumb project switcher dropdown | **Done** |
 | 7.9 | Backend + frontend: server-side session pagination for project detail | **Done** |
 | 8.0 | Backend + frontend + CLI: custom system prompt in launch dialog | **Done** |
-| 9 | Scheduled tasks — cron scheduler + CRUD API + GUI page | Planned |
+| 9 | Scheduled tasks — cron scheduler + CRUD API + GUI page | **Done** |
 | 10 | Interactive sessions (ask_user bridge + chat panel) | Planned |
 | 11 | Activity charts (run frequency, success rate, duration trends) | Planned |
-| 12 | Cost / token tracking (requires wrapper protocol extension) | Planned |


### PR DESCRIPTION
## Summary
- Mark DESIGN.md item 9 (scheduled tasks) as **Done** after PR #169
- Move item 12 (cost/token tracking) from DESIGN.md roadmap to TODO.md since it requires wrapper protocol changes outside the GUI scope

## Test plan
- [ ] Verify TODO.md has the cost/token tracking entry
- [ ] Verify DESIGN.md item 9 shows Done and item 12 is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)