### PR TITLE
Drop Intel macOS binary from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,8 +83,6 @@ jobs:
             asset_name: strawpot-linux-arm64
           - os: macos-latest
             asset_name: strawpot-darwin-arm64
-          - os: macos-15-large
-            asset_name: strawpot-darwin-amd64
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Remove `strawpot-darwin-amd64` binary build from the release workflow
- The `macos-13` runner is deprecated and replacements (`macos-15-large`) are paid larger runners
- Intel Mac users can still install via `pip install strawpot` (pure Python package)

## Test plan
- [ ] Verify release workflow runs successfully without the Intel macOS matrix entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)