### PR TITLE
Add delete session endpoint and UI

### DIFF
--- a/gui/frontend/src/components/SessionTable.tsx
+++ b/gui/frontend/src/components/SessionTable.tsx
@@ -1,6 +1,9 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import type { Session } from "@/api/types";
+import { useDeleteSession } from "@/hooks/mutations/use-sessions";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -10,6 +13,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
+import { Trash2 } from "lucide-react";
 
 export default function SessionTable({
   sessions,
@@ -29,6 +33,7 @@ export default function SessionTable({
           <TableHead>Started</TableHead>
           <TableHead>Duration</TableHead>
           <TableHead>Task</TableHead>
+          <TableHead className="w-[80px]" />
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -64,6 +69,12 @@ export default function SessionTable({
             </TableCell>
             <TableCell className="max-w-[300px] truncate text-sm">
               {s.task ?? "—"}
+            </TableCell>
+            <TableCell>
+              <DeleteSessionButton
+                runId={s.run_id}
+                disabled={s.status === "starting" || s.status === "running"}
+              />
             </TableCell>
           </TableRow>
         ))}
@@ -133,4 +144,57 @@ export function formatDuration(ms: number | null): string {
   const mins = Math.floor(secs / 60);
   const rem = secs % 60;
   return `${mins}m ${rem}s`;
+}
+
+function DeleteSessionButton({
+  runId,
+  disabled,
+}: {
+  runId: string;
+  disabled: boolean;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const deleteSession = useDeleteSession();
+
+  const handleDelete = async () => {
+    try {
+      await deleteSession.mutateAsync(runId);
+    } catch {
+      // error state handled by mutation
+    }
+  };
+
+  if (confirming) {
+    return (
+      <div className="flex gap-1">
+        <Button
+          size="sm"
+          variant="destructive"
+          onClick={handleDelete}
+          disabled={deleteSession.isPending}
+        >
+          Confirm
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => setConfirming(false)}
+        >
+          No
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      className="text-muted-foreground hover:text-destructive"
+      onClick={() => setConfirming(true)}
+      disabled={disabled}
+    >
+      <Trash2 className="h-4 w-4" />
+    </Button>
+  );
 }

--- a/gui/frontend/src/hooks/mutations/use-sessions.ts
+++ b/gui/frontend/src/hooks/mutations/use-sessions.ts
@@ -34,3 +34,13 @@ export function useStopSession() {
     },
   });
 }
+
+export function useDeleteSession() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (runId: string) => api.delete(`/sessions/${runId}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["sessions"] });
+    },
+  });
+}

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -504,6 +504,48 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
     return {"run_id": run_id, "status": "stopped"}
 
 
+@router.delete("/sessions/{run_id}")
+def delete_session(run_id: str, conn=Depends(get_db_conn)):
+    """Delete an archived session (DB row + on-disk files)."""
+    row = conn.execute(
+        "SELECT run_id, status, session_dir, project_id FROM sessions WHERE run_id = ?",
+        (run_id,),
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, "Session not found")
+
+    if row["status"] in ("starting", "running"):
+        raise HTTPException(409, "Cannot delete a running session — stop it first")
+
+    session_dir = row["session_dir"]
+    project_id = row["project_id"]
+
+    # Remove DB row
+    conn.execute("DELETE FROM sessions WHERE run_id = ?", (run_id,))
+    conn.commit()
+
+    # Remove on-disk session directory
+    if session_dir:
+        shutil.rmtree(session_dir, ignore_errors=True)
+
+        # Clean up symlinks in archive/ and running/
+        strawpot_dir = str(Path(session_dir).parent.parent)
+        for subdir in ("archive", "running"):
+            link = os.path.join(strawpot_dir, subdir, run_id)
+            try:
+                os.remove(link)
+            except OSError:
+                pass
+
+    event_bus.publish(SessionEvent(
+        kind="session_deleted",
+        run_id=run_id,
+        project_id=project_id,
+    ))
+
+    return {"ok": True}
+
+
 _ARTIFACT_HASH_RE = re.compile(r"^[0-9a-f]{12}$")
 
 

--- a/gui/tests/test_session_delete.py
+++ b/gui/tests/test_session_delete.py
@@ -1,0 +1,90 @@
+"""Tests for session delete endpoint."""
+
+import os
+
+from strawpot_gui.db import sync_sessions
+
+from test_sessions_sync import _register_project, _write_session, _write_trace
+
+
+def _create_completed_session(client, tmp_path, run_id="run_test123"):
+    """Register a project, create an archived session, sync, and return (project_id, run_id)."""
+    pid = _register_project(client, tmp_path)
+    session_dir = _write_session(tmp_path, run_id, archived=True)
+    _write_trace(session_dir, [
+        {"event": "delegate_end", "ts": "2026-01-01T12:05:00+00:00", "data": {"exit_code": 0}},
+        {"event": "session_end", "ts": "2026-01-01T12:05:00+00:00", "data": {"duration_ms": 300000}},
+    ])
+    sync_sessions(client.app.state.db_path)
+    return pid, run_id
+
+
+class TestDeleteSession:
+    def test_not_found(self, client):
+        resp = client.delete("/api/sessions/run_nonexistent")
+        assert resp.status_code == 404
+
+    def test_cannot_delete_running(self, client, tmp_path):
+        """Sessions with starting/running status cannot be deleted."""
+        pid = _register_project(client, tmp_path)
+        _write_session(tmp_path, "run_active1", archived=False)
+        sync_sessions(client.app.state.db_path)
+
+        # Force status back to running (sync marks dead PIDs as failed)
+        from strawpot_gui.db import get_db
+        with get_db(client.app.state.db_path) as conn:
+            conn.execute(
+                "UPDATE sessions SET status = 'running' WHERE run_id = 'run_active1'"
+            )
+
+        resp = client.delete("/api/sessions/run_active1")
+        assert resp.status_code == 409
+
+    def test_delete_removes_db_row(self, client, tmp_path):
+        pid, run_id = _create_completed_session(client, tmp_path)
+
+        # Verify session exists
+        resp = client.get(f"/api/projects/{pid}/sessions")
+        assert resp.json()["total"] == 1
+
+        # Delete
+        resp = client.delete(f"/api/sessions/{run_id}")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+        # Verify gone
+        resp = client.get(f"/api/projects/{pid}/sessions")
+        assert resp.json()["total"] == 0
+
+    def test_delete_removes_disk_files(self, client, tmp_path):
+        pid, run_id = _create_completed_session(client, tmp_path)
+        session_dir = os.path.join(str(tmp_path), ".strawpot", "sessions", run_id)
+        assert os.path.isdir(session_dir)
+
+        client.delete(f"/api/sessions/{run_id}")
+        assert not os.path.isdir(session_dir)
+
+    def test_delete_removes_symlinks(self, client, tmp_path):
+        pid, run_id = _create_completed_session(client, tmp_path)
+        archive_link = os.path.join(str(tmp_path), ".strawpot", "archive", run_id)
+        assert os.path.exists(archive_link)
+
+        client.delete(f"/api/sessions/{run_id}")
+        assert not os.path.exists(archive_link)
+
+    def test_delete_with_missing_directory(self, client, tmp_path):
+        """Deleting a session whose directory is already gone should still succeed."""
+        pid, run_id = _create_completed_session(client, tmp_path)
+
+        # Remove directory before API call
+        session_dir = os.path.join(str(tmp_path), ".strawpot", "sessions", run_id)
+        import shutil
+        shutil.rmtree(session_dir)
+
+        resp = client.delete(f"/api/sessions/{run_id}")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+        # DB row should still be gone
+        resp = client.get(f"/api/projects/{pid}/sessions")
+        assert resp.json()["total"] == 0


### PR DESCRIPTION
## Summary
- Add `DELETE /api/sessions/{run_id}` endpoint — removes DB row, on-disk session directory, and archive/running symlinks
- Rejects deletion of running/starting sessions with 409
- Add `useDeleteSession()` mutation hook
- Add trash button with two-step confirm to `SessionTable`, disabled for active sessions
- 6 backend tests covering 404, 409, DB cleanup, disk cleanup, symlink cleanup, and graceful missing-directory handling

## Test plan
- [ ] All 141 backend tests pass (`python -m pytest tests/ -v`)
- [ ] Frontend type-checks clean (`npx tsc --noEmit`)
- [ ] Delete a completed session — verify it disappears from the list and disk
- [ ] Trash button is disabled for running sessions
- [ ] Two-step confirm works (click trash → Confirm/No)

🤖 Generated with [Claude Code](https://claude.com/claude-code)