### PR TITLE
Simplify DelegateResult, remove summary, add output to overview

### DIFF
--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -777,8 +777,7 @@ class Session:
         payload = request.delegate
         trace = request.trace
 
-        fmt = payload.task.return_format
-        return_format = "JSON" if fmt == denden_pb2.JSON else "TEXT"
+        return_format = "JSON" if payload.task.return_format == denden_pb2.JSON else "TEXT"
 
         delegate_req = DelegateRequest(
             role_slug=payload.delegate_to,
@@ -822,19 +821,19 @@ class Session:
                     msg,
                 )
             # Build DelegateResult with output
-            delegate_res = denden_pb2.DelegateResult(
-                output_format=fmt,
-            )
+            delegate_res = denden_pb2.DelegateResult()
             if result.output:
                 if return_format == "JSON":
                     try:
                         parsed = json.loads(result.output)
                         if isinstance(parsed, dict):
-                            delegate_res.output.update(parsed)
+                            delegate_res.json.update(parsed)
+                        else:
+                            delegate_res.text = result.output
                     except (json.JSONDecodeError, ValueError):
-                        delegate_res.output.update({"text": result.output})
+                        delegate_res.text = result.output
                 else:
-                    delegate_res.output.update({"text": result.output})
+                    delegate_res.text = result.output
             return ok_response(
                 request.request_id,
                 delegate_result=delegate_res,

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -2433,6 +2433,7 @@ class TestHandleDelegateDefaultAgent:
         # Alt runtime was used, not the session default
         mock_alt_runtime.spawn.assert_called_once()
         session_runtime.spawn.assert_not_called()
+        assert result.output == "alt ok"
 
     def test_falls_back_on_missing_agent(self, tmp_path, monkeypatch):
         """When default_agent is not found, falls back to session runtime."""
@@ -2476,6 +2477,7 @@ class TestHandleDelegateDefaultAgent:
 
         # Session default runtime was used
         session_runtime.spawn.assert_called_once()
+        assert result.output == "ok"
 
     def test_skips_when_same_as_current(self, tmp_path, monkeypatch):
         """When default_agent matches current runtime, no re-resolution happens."""
@@ -2519,6 +2521,7 @@ class TestHandleDelegateDefaultAgent:
 
         assert resolve_called == []
         session_runtime.spawn.assert_called_once()
+        assert result.output == "ok"
 
 
 # ---------------------------------------------------------------------------
@@ -2634,6 +2637,7 @@ class TestHandleDelegateSkillEnvSaved:
             resolve_role=mock_resolve,
             resolve_role_dirs=lambda s: None,
         )
+        assert result.output == "ok"
 
 
 class TestHandleDelegateDefaultAgentConfigOverride:
@@ -2700,3 +2704,4 @@ class TestHandleDelegateDefaultAgentConfigOverride:
         assert resolve_calls == ["config_agent"]
         mock_config_runtime.spawn.assert_called_once()
         session_runtime.spawn.assert_not_called()
+        assert result.output == "ok"

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -103,6 +103,7 @@ export default function SessionDetail() {
   }
 
   const artifacts = extractArtifacts(displayEvents);
+  const outputRef = extractOutputRef(displayEvents);
   const defaultTab =
     searchParams.get("tab") ?? (active ? "agent-tree" : "overview");
 
@@ -157,7 +158,25 @@ export default function SessionDetail() {
             </section>
           )}
 
-          {!sessionData.task && (
+          {outputRef && (
+            <section className="space-y-2">
+              <h2 className="text-sm font-medium text-muted-foreground">
+                Output
+              </h2>
+              <Card>
+                <CardContent className="pt-4">
+                  <pre className="whitespace-pre-wrap break-words text-sm leading-relaxed">
+                    <ArtifactText
+                      runId={sessionData.run_id}
+                      hash={outputRef}
+                    />
+                  </pre>
+                </CardContent>
+              </Card>
+            </section>
+          )}
+
+          {!sessionData.task && !outputRef && (
             <p className="text-sm text-muted-foreground">
               No overview information available yet.
             </p>
@@ -376,6 +395,35 @@ interface ArtifactEntry {
   hash: string;
   event: string;
   agentId?: string;
+}
+
+function ArtifactText({ runId, hash }: { runId: string; hash: string }) {
+  const [content, setContent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/sessions/${runId}/artifacts/${hash}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+        return res.text();
+      })
+      .then(setContent)
+      .catch((err) => setError(err.message));
+  }, [runId, hash]);
+
+  if (error) return <span className="text-destructive">Error: {error}</span>;
+  if (content === null)
+    return <span className="text-muted-foreground">Loading...</span>;
+  return <>{content}</>;
+}
+
+function extractOutputRef(events: TraceEvent[]): string | null {
+  for (const e of events) {
+    if (e.event === "session_end" && e.data.output_ref) {
+      return String(e.data.output_ref);
+    }
+  }
+  return null;
 }
 
 function extractArtifacts(events: TraceEvent[]): ArtifactEntry[] {

--- a/gui/src/strawpot_gui/routers/schedules.py
+++ b/gui/src/strawpot_gui/routers/schedules.py
@@ -286,7 +286,7 @@ def schedule_history(schedule_id: int, conn=Depends(get_db_conn)):
 
     rows = conn.execute(
         "SELECT run_id, project_id, role, runtime, isolation, status,"
-        "       started_at, ended_at, duration_ms, exit_code, task, summary"
+        "       started_at, ended_at, duration_ms, exit_code, task"
         "  FROM sessions WHERE schedule_id = ? ORDER BY started_at DESC"
         "  LIMIT 50",
         (schedule_id,),


### PR DESCRIPTION
## Summary
- Update `session.py` to use new DelegateResult `oneof { text, json }` proto pattern (companion to strawpot/denden#24)
- Remove `summary` field from DelegateResult dataclass, trace events, DB schema, SQL queries, and frontend types
- Add orchestrator output section to session detail Overview tab (fetches `output_ref` artifact from `session_end` trace event)

## Test plan
- [x] CLI tests pass (510 passed)
- [x] GUI backend tests pass (146 passed)
- [x] Frontend compiles (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)