### PR TITLE
Update Quick Start install to strawpot-gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You're an engineer, not a CEO. Building technology is the easy part — strategy
 ## Quick Start
 
 ```bash
-pip install strawpot
+pip install strawpot-gui
 strawpot gui
 ```
 


### PR DESCRIPTION
## Summary
- Update `pip install strawpot` to `pip install strawpot-gui` in Quick Start section of README since the GUI requires the separate `strawpot-gui` package

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)