### PR TITLE
Add delegation cache and prepend skill dirs to agent PATH

### DIFF
--- a/cli/src/strawpot/agents/wrapper.py
+++ b/cli/src/strawpot/agents/wrapper.py
@@ -199,6 +199,18 @@ class WrapperRuntime:
         log_path = self._log_file(agent_id)
         os.makedirs(os.path.dirname(log_path), exist_ok=True)
 
+        # Prepend skill directories to PATH so agents find staged binaries
+        # (e.g. denden) before any stale global installs.
+        skill_bin_paths: list[str] = []
+        for sd in skills_dirs:
+            if os.path.isdir(sd):
+                for entry in os.scandir(sd):
+                    if entry.is_dir(follow_symlinks=True):
+                        skill_bin_paths.append(entry.path)
+        if skill_bin_paths:
+            parent_path = os.environ.get("PATH", "")
+            env["PATH"] = os.pathsep.join(skill_bin_paths) + os.pathsep + parent_path
+
         full_env = {**os.environ, **env} if env else None
         with open(log_path, "w", encoding="utf-8") as log_fh:
             proc = subprocess.Popen(

--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -282,7 +282,8 @@ def _ensure_role_installed(name: str, working_dir: str, *, auto_setup: bool = Fa
 )
 @click.option("--run-id", "run_id", default=None, help="Pre-assigned run ID (used by GUI).")
 @click.option("--system-prompt", "system_prompt", default=None, help="Custom system prompt appended to role instructions.")
-def start(role, runtime, isolation, merge_strategy, pull, host, port, task, headless, run_id, system_prompt):
+@click.option("--no-cache-delegations", "no_cache_delegations", is_flag=True, default=False, help="Disable caching of delegation results within the session.")
+def start(role, runtime, isolation, merge_strategy, pull, host, port, task, headless, run_id, system_prompt, no_cache_delegations):
     """Start an orchestration session.
 
     Runs in the foreground — creates an isolated environment (if configured),
@@ -300,6 +301,8 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task, head
         config.merge_strategy = merge_strategy
     if pull:
         config.pull_before_session = pull
+    if no_cache_delegations:
+        config.cache_delegations = False
     if host or port:
         current_host, current_port = config.denden_addr.rsplit(":", 1)
         config.denden_addr = f"{host or current_host}:{port or current_port}"

--- a/cli/src/strawpot/config.py
+++ b/cli/src/strawpot/config.py
@@ -30,6 +30,7 @@ class StrawPotConfig:
     permission_mode: str = "default"
     agent_timeout: int | None = None
     max_delegate_retries: int = 0
+    cache_delegations: bool = True
     agents: dict[str, dict] = field(default_factory=dict)
     skills: dict[str, dict[str, str]] = field(default_factory=dict)
     roles: dict[str, dict] = field(default_factory=dict)
@@ -73,6 +74,8 @@ def _apply(config: StrawPotConfig, data: dict) -> None:
         config.agent_timeout = policy["agent_timeout"]
     if "max_delegate_retries" in policy:
         config.max_delegate_retries = policy["max_delegate_retries"]
+    if "cache_delegations" in policy:
+        config.cache_delegations = policy["cache_delegations"]
 
     agents = data.get("agents", {})
     for name, agent_data in agents.items():

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -1,5 +1,6 @@
 """Session lifecycle — owns denden server, isolation, orchestrator, and delegation."""
 
+import hashlib
 import json
 import logging
 import os
@@ -316,6 +317,7 @@ class Session:
         self._orchestrator_result: AgentResult | None = None
         self._orchestrator_role_prompt: str = ""
         self._files_dirs: list[str] = []
+        self._delegation_cache: dict[str, tuple[str, "denden_pb2.DelegateResult"]] = {}
         self._shutting_down: bool = False
         self._interrupted: bool = False
         self._last_sigint_time: float = 0.0
@@ -789,11 +791,51 @@ class Session:
             return_format=return_format,
         )
 
-        try:
-            # Look up the span for the requesting agent (for call tree)
-            requester_span = self._agent_spans.get(
-                trace.agent_instance_id, self._session_span_id
+        # Look up the span for the requesting agent (for call tree)
+        requester_span = self._agent_spans.get(
+            trace.agent_instance_id, self._session_span_id
+        )
+
+        # --- Cache check ---
+        cache_key: str | None = None
+        if self.config.cache_delegations:
+            cache_key = self._delegation_cache_key(
+                delegate_req.role_slug,
+                delegate_req.task_text,
+                return_format,
             )
+            cached = self._delegation_cache.get(cache_key)
+            if cached is not None:
+                cached_output, cached_delegate_res = cached
+                logger.info(
+                    "Delegation cache hit for role=%s, output_len=%d, format=%s",
+                    delegate_req.role_slug,
+                    len(cached_output),
+                    return_format,
+                )
+                if self._tracer is not None:
+                    span = self._tracer.delegate_start(
+                        role=delegate_req.role_slug,
+                        parent_span=requester_span,
+                        context=delegate_req.task_text,
+                        depth=delegate_req.depth,
+                        parent_agent_id=delegate_req.parent_agent_id,
+                        cache_hit=True,
+                    )
+                    self._tracer.delegate_end(
+                        span_id=span,
+                        exit_code=0,
+                        duration_ms=0,
+                        output=cached_output,
+                        role=delegate_req.role_slug,
+                        cache_hit=True,
+                    )
+                return ok_response(
+                    request.request_id,
+                    delegate_result=cached_delegate_res,
+                )
+
+        try:
             result = handle_delegate(
                 request=delegate_req,
                 config=self.config,
@@ -820,20 +862,16 @@ class Session:
                     "ERR_SUBAGENT_NONZERO_EXIT",
                     msg,
                 )
-            # Build DelegateResult with output
-            delegate_res = denden_pb2.DelegateResult()
-            if result.output:
-                if return_format == "JSON":
-                    try:
-                        parsed = json.loads(result.output)
-                        if isinstance(parsed, dict):
-                            delegate_res.json.update(parsed)
-                        else:
-                            delegate_res.text = result.output
-                    except (json.JSONDecodeError, ValueError):
-                        delegate_res.text = result.output
-                else:
-                    delegate_res.text = result.output
+            # Build protobuf delegate result
+            delegate_res = self._build_delegate_result(
+                result.output, return_format
+            )
+            # Cache successful results with non-empty output
+            if cache_key is not None and result.output:
+                self._delegation_cache[cache_key] = (
+                    result.output,
+                    delegate_res,
+                )
             return ok_response(
                 request.request_id,
                 delegate_result=delegate_res,
@@ -1055,3 +1093,29 @@ class Session:
             else:
                 break
         return depth
+
+    @staticmethod
+    def _delegation_cache_key(
+        role_slug: str, task_text: str, return_format: str
+    ) -> str:
+        raw = f"{role_slug}\0{task_text}\0{return_format}"
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _build_delegate_result(
+        output: str, return_format: str
+    ) -> "denden_pb2.DelegateResult":
+        delegate_res = denden_pb2.DelegateResult()
+        if output:
+            if return_format == "JSON":
+                try:
+                    parsed = json.loads(output)
+                    if isinstance(parsed, dict):
+                        delegate_res.json.update(parsed)
+                    else:
+                        delegate_res.text = output
+                except (json.JSONDecodeError, ValueError):
+                    delegate_res.text = output
+            else:
+                delegate_res.text = output
+        return delegate_res

--- a/cli/src/strawpot/trace.py
+++ b/cli/src/strawpot/trace.py
@@ -143,6 +143,7 @@ class Tracer:
         depth: int = 0,
         session_id: str = "",
         parent_agent_id: str | None = None,
+        cache_hit: bool = False,
     ) -> str:
         """Emit ``delegate_start``.  Stores context as artifact.  Returns new span_id."""
         span_id = self._new_span_id()
@@ -156,6 +157,7 @@ class Tracer:
             context_ref=context_ref,
             session_id=session_id,
             parent_agent_id=parent_agent_id,
+            cache_hit=cache_hit,
         )
         return span_id
 
@@ -169,6 +171,7 @@ class Tracer:
         role: str = "",
         session_id: str = "",
         agent_id: str = "",
+        cache_hit: bool = False,
     ) -> None:
         """Emit ``delegate_end``.  Stores output as artifact."""
         output_ref = self.store_artifact(output)
@@ -181,6 +184,7 @@ class Tracer:
             role=role,
             session_id=session_id,
             agent_id=agent_id,
+            cache_hit=cache_hit,
         )
 
     def delegate_denied(

--- a/cli/tests/test_agents_wrapper.py
+++ b/cli/tests/test_agents_wrapper.py
@@ -587,3 +587,118 @@ def test_setup_failure(monkeypatch):
     monkeypatch.setattr("subprocess.run", fake_run)
     rt = WrapperRuntime(_make_spec())
     assert rt.setup() is False
+
+
+# --- skill bin PATH prepending ---
+
+
+def test_spawn_prepends_skill_dirs_to_path(tmp_path, monkeypatch):
+    """spawn prepends skill subdirectories to PATH so agents find staged binaries."""
+    # Create a skills dir with two skill subdirectories
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "denden").mkdir(parents=True)
+    (skills_dir / "other-tool").mkdir(parents=True)
+    # Regular file (not a dir) should be ignored
+    (skills_dir / "README.md").write_text("ignore me")
+
+    popen_captured = {}
+
+    def fake_run(cmd, **kwargs):
+        return _mock_run(json.dumps({"cmd": ["agent"], "cwd": "/w"}))
+
+    def fake_popen(cmd, **kwargs):
+        popen_captured["env"] = kwargs.get("env")
+        return MagicMock(pid=1)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    rt = WrapperRuntime(_make_spec(), session_dir=str(tmp_path))
+    rt.spawn(
+        agent_id="a1",
+        working_dir="/w",
+        agent_workspace_dir=str(tmp_path / "workspace"),
+        role_prompt="",
+        memory_prompt="",
+        skills_dirs=[str(skills_dir)],
+        roles_dirs=[],
+        files_dirs=[],
+        task="test",
+        env={"DENDEN_ADDR": "127.0.0.1:9700"},
+    )
+
+    path = popen_captured["env"]["PATH"]
+    path_entries = path.split(os.pathsep)
+    # First two entries should be the skill subdirectories
+    skill_paths = {str(skills_dir / "denden"), str(skills_dir / "other-tool")}
+    assert set(path_entries[:2]) == skill_paths
+
+
+def test_spawn_no_skill_dirs_leaves_path_unchanged(tmp_path, monkeypatch):
+    """spawn with empty skills_dirs does not modify PATH."""
+    popen_captured = {}
+
+    def fake_run(cmd, **kwargs):
+        return _mock_run(json.dumps({"cmd": ["agent"], "cwd": "/w"}))
+
+    def fake_popen(cmd, **kwargs):
+        popen_captured["env"] = kwargs.get("env")
+        return MagicMock(pid=1)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    rt = WrapperRuntime(_make_spec(), session_dir=str(tmp_path))
+    rt.spawn(
+        agent_id="a1",
+        working_dir="/w",
+        agent_workspace_dir=str(tmp_path / "workspace"),
+        role_prompt="",
+        memory_prompt="",
+        skills_dirs=[],
+        roles_dirs=[],
+        files_dirs=[],
+        task="test",
+        env={"DENDEN_ADDR": "127.0.0.1:9700"},
+    )
+
+    # PATH should not have been set in env (falls through from os.environ)
+    assert "PATH" not in {"DENDEN_ADDR": "127.0.0.1:9700"}
+
+
+def test_spawn_skill_dirs_precede_system_path(tmp_path, monkeypatch):
+    """Skill dirs appear before the parent process PATH."""
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "mytool").mkdir(parents=True)
+
+    popen_captured = {}
+    original_path = "/usr/bin:/usr/local/bin"
+    monkeypatch.setenv("PATH", original_path)
+
+    def fake_run(cmd, **kwargs):
+        return _mock_run(json.dumps({"cmd": ["agent"], "cwd": "/w"}))
+
+    def fake_popen(cmd, **kwargs):
+        popen_captured["env"] = kwargs.get("env")
+        return MagicMock(pid=1)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    rt = WrapperRuntime(_make_spec(), session_dir=str(tmp_path))
+    rt.spawn(
+        agent_id="a1",
+        working_dir="/w",
+        agent_workspace_dir=str(tmp_path / "workspace"),
+        role_prompt="",
+        memory_prompt="",
+        skills_dirs=[str(skills_dir)],
+        roles_dirs=[],
+        files_dirs=[],
+        task="test",
+        env={},
+    )
+
+    path = popen_captured["env"]["PATH"]
+    assert path.startswith(str(skills_dir / "mytool"))
+    assert original_path in path

--- a/cli/tests/test_delegation_cache.py
+++ b/cli/tests/test_delegation_cache.py
@@ -1,0 +1,288 @@
+"""Tests for per-session delegation cache."""
+
+import hashlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from denden.gen import denden_pb2
+from strawpot.config import StrawPotConfig
+from strawpot.delegation import DelegateResult
+from strawpot.session import Session
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides):
+    overrides.setdefault("memory", "")
+    return StrawPotConfig(**overrides)
+
+
+def _make_session(tmp_path, **overrides):
+    """Create a minimal Session for cache testing."""
+    import os
+    import tempfile
+
+    from strawpot.isolation.protocol import IsolatedEnv
+
+    role_dir = os.path.join(str(tmp_path), "roles", "test")
+    os.makedirs(role_dir, exist_ok=True)
+    with open(os.path.join(role_dir, "ROLE.md"), "w") as f:
+        f.write("---\nname: test\ndescription: test\n---\nBody\n")
+
+    resolved = {
+        "slug": "test",
+        "kind": "role",
+        "version": "1.0",
+        "path": role_dir,
+        "source": "local",
+        "dependencies": [],
+    }
+
+    wrapper = MagicMock()
+    wrapper.name = "mock_wrapper"
+    runtime = MagicMock()
+    runtime.name = "mock_runtime"
+    isolator = MagicMock()
+    isolator.create.return_value = IsolatedEnv(path=tempfile.gettempdir())
+
+    defaults = {
+        "config": _make_config(),
+        "wrapper": wrapper,
+        "runtime": runtime,
+        "isolator": isolator,
+        "resolve_role": lambda slug, kind="role": resolved,
+        "resolve_role_dirs": lambda s: None,
+    }
+    defaults.update(overrides)
+    return Session(**defaults)
+
+
+def _make_delegate_request(
+    role="worker",
+    task="Do something",
+    return_format=denden_pb2.TEXT,
+    agent_id="agent_abc",
+    run_id="run_123",
+):
+    """Build a denden DenDenRequest with a delegate payload."""
+    req = denden_pb2.DenDenRequest()
+    req.request_id = "req_001"
+    req.delegate.delegate_to = role
+    req.delegate.task.text = task
+    req.delegate.task.return_format = return_format
+    req.trace.agent_instance_id = agent_id
+    req.trace.run_id = run_id
+    return req
+
+
+# ---------------------------------------------------------------------------
+# Cache key
+# ---------------------------------------------------------------------------
+
+
+class TestDelegationCacheKey:
+    def test_deterministic(self):
+        k1 = Session._delegation_cache_key("role", "task", "TEXT")
+        k2 = Session._delegation_cache_key("role", "task", "TEXT")
+        assert k1 == k2
+
+    def test_different_role(self):
+        k1 = Session._delegation_cache_key("role_a", "task", "TEXT")
+        k2 = Session._delegation_cache_key("role_b", "task", "TEXT")
+        assert k1 != k2
+
+    def test_different_task(self):
+        k1 = Session._delegation_cache_key("role", "task_a", "TEXT")
+        k2 = Session._delegation_cache_key("role", "task_b", "TEXT")
+        assert k1 != k2
+
+    def test_different_format(self):
+        k1 = Session._delegation_cache_key("role", "task", "TEXT")
+        k2 = Session._delegation_cache_key("role", "task", "JSON")
+        assert k1 != k2
+
+    def test_sha256_hex(self):
+        key = Session._delegation_cache_key("r", "t", "TEXT")
+        assert len(key) == 64  # sha256 hex digest
+
+
+# ---------------------------------------------------------------------------
+# Build delegate result
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDelegateResult:
+    def test_text_output(self):
+        res = Session._build_delegate_result("hello", "TEXT")
+        assert res.text == "hello"
+
+    def test_json_output(self):
+        res = Session._build_delegate_result('{"key": "val"}', "JSON")
+        assert res.json["key"] == "val"
+
+    def test_json_non_dict_falls_back_to_text(self):
+        res = Session._build_delegate_result("[1,2,3]", "JSON")
+        assert res.text == "[1,2,3]"
+
+    def test_empty_output(self):
+        res = Session._build_delegate_result("", "TEXT")
+        assert res.text == ""
+
+
+# ---------------------------------------------------------------------------
+# Cache integration via _handle_delegate
+# ---------------------------------------------------------------------------
+
+
+class TestDelegationCacheIntegration:
+    """Test cache check and store via _handle_delegate."""
+
+    def _setup_session(self, tmp_path, cache_delegations=True):
+        config = _make_config(cache_delegations=cache_delegations)
+        session = _make_session(tmp_path, config=config)
+        # Set up minimal internal state that _handle_delegate expects
+        session._tracer = MagicMock()
+        session._tracer.delegate_start.return_value = "span_001"
+        session._session_span_id = "session_span"
+        session._agent_info = {
+            "agent_abc": {"role": "parent_role", "parent": None}
+        }
+        session._agent_spans = {"agent_abc": "span_parent"}
+        session._env = MagicMock()
+        session._env.path = str(tmp_path)
+        session._working_dir = str(tmp_path)
+        session._run_id = "run_123"
+        session._denden_addr = "127.0.0.1:9700"
+        session._memory_provider = None
+        session._files_dirs = []
+        # Ensure session_dir exists for handle_delegate
+        import os
+        session_dir = os.path.join(str(tmp_path), ".strawpot", "sessions", "run_123")
+        os.makedirs(session_dir, exist_ok=True)
+        return session
+
+    @patch("strawpot.session.handle_delegate")
+    def test_cache_hit_skips_handle_delegate(self, mock_hd, tmp_path):
+        session = self._setup_session(tmp_path)
+        mock_hd.return_value = DelegateResult(output="result text", exit_code=0)
+
+        req = _make_delegate_request()
+
+        # First call — cache miss, calls handle_delegate
+        resp1 = session._handle_delegate(req)
+        assert mock_hd.call_count == 1
+        assert resp1.status == denden_pb2.OK
+
+        # Second call — cache hit, does NOT call handle_delegate
+        resp2 = session._handle_delegate(req)
+        assert mock_hd.call_count == 1  # still 1
+        assert resp2.status == denden_pb2.OK
+        assert resp2.delegate_result.text == "result text"
+
+    @patch("strawpot.session.handle_delegate")
+    def test_cache_miss_on_different_role(self, mock_hd, tmp_path):
+        session = self._setup_session(tmp_path)
+        mock_hd.return_value = DelegateResult(output="ok", exit_code=0)
+
+        req1 = _make_delegate_request(role="worker_a")
+        req2 = _make_delegate_request(role="worker_b")
+
+        session._handle_delegate(req1)
+        session._handle_delegate(req2)
+        assert mock_hd.call_count == 2
+
+    @patch("strawpot.session.handle_delegate")
+    def test_cache_miss_on_different_task(self, mock_hd, tmp_path):
+        session = self._setup_session(tmp_path)
+        mock_hd.return_value = DelegateResult(output="ok", exit_code=0)
+
+        req1 = _make_delegate_request(task="task A")
+        req2 = _make_delegate_request(task="task B")
+
+        session._handle_delegate(req1)
+        session._handle_delegate(req2)
+        assert mock_hd.call_count == 2
+
+    @patch("strawpot.session.handle_delegate")
+    def test_failed_result_not_cached(self, mock_hd, tmp_path):
+        session = self._setup_session(tmp_path)
+        mock_hd.return_value = DelegateResult(output="error", exit_code=1)
+
+        req = _make_delegate_request()
+
+        session._handle_delegate(req)
+        session._handle_delegate(req)
+        # Both calls go through handle_delegate (failure not cached)
+        assert mock_hd.call_count == 2
+
+    @patch("strawpot.session.handle_delegate")
+    def test_empty_output_not_cached(self, mock_hd, tmp_path):
+        session = self._setup_session(tmp_path)
+        mock_hd.return_value = DelegateResult(output="", exit_code=0)
+
+        req = _make_delegate_request()
+
+        session._handle_delegate(req)
+        session._handle_delegate(req)
+        # Empty output is not worth caching
+        assert mock_hd.call_count == 2
+
+    @patch("strawpot.session.handle_delegate")
+    def test_cache_disabled_skips_caching(self, mock_hd, tmp_path):
+        session = self._setup_session(tmp_path, cache_delegations=False)
+        mock_hd.return_value = DelegateResult(output="ok", exit_code=0)
+
+        req = _make_delegate_request()
+
+        session._handle_delegate(req)
+        session._handle_delegate(req)
+        assert mock_hd.call_count == 2
+
+    @patch("strawpot.session.handle_delegate")
+    def test_cache_hit_emits_trace_events(self, mock_hd, tmp_path):
+        session = self._setup_session(tmp_path)
+        mock_hd.return_value = DelegateResult(output="ok", exit_code=0)
+
+        req = _make_delegate_request()
+
+        # First call — normal delegation
+        session._handle_delegate(req)
+        # Reset tracer mock to only track cache-hit events
+        session._tracer.delegate_start.reset_mock()
+        session._tracer.delegate_end.reset_mock()
+
+        # Second call — cache hit
+        session._handle_delegate(req)
+
+        # Verify trace events emitted with cache_hit=True
+        session._tracer.delegate_start.assert_called_once()
+        start_kwargs = session._tracer.delegate_start.call_args.kwargs
+        assert start_kwargs["cache_hit"] is True
+        assert start_kwargs["role"] == "worker"
+
+        session._tracer.delegate_end.assert_called_once()
+        end_kwargs = session._tracer.delegate_end.call_args.kwargs
+        assert end_kwargs["cache_hit"] is True
+        assert end_kwargs["duration_ms"] == 0
+        assert end_kwargs["output"] == "ok"
+
+    @patch("strawpot.session.handle_delegate")
+    def test_cache_hit_json_format(self, mock_hd, tmp_path):
+        session = self._setup_session(tmp_path)
+        mock_hd.return_value = DelegateResult(
+            output='{"key": "value"}', exit_code=0
+        )
+
+        req = _make_delegate_request(return_format=denden_pb2.JSON)
+
+        # First call
+        session._handle_delegate(req)
+        # Second call — cache hit
+        resp = session._handle_delegate(req)
+
+        assert resp.delegate_result.json["key"] == "value"
+        assert mock_hd.call_count == 1

--- a/gui/frontend/src/components/ConfigForm.tsx
+++ b/gui/frontend/src/components/ConfigForm.tsx
@@ -31,6 +31,7 @@ interface FlatState {
   policy_max_depth: string;
   policy_agent_timeout: string;
   policy_max_delegate_retries: string;
+  policy_cache_delegations: string;
   session_merge_strategy: string;
   session_pull_before_session: string;
   session_pr_command: string;
@@ -51,6 +52,7 @@ function toFlat(v: Record<string, unknown>): FlatState {
     policy_max_depth: str(policy.max_depth),
     policy_agent_timeout: str(policy.agent_timeout),
     policy_max_delegate_retries: str(policy.max_delegate_retries),
+    policy_cache_delegations: str(policy.cache_delegations),
     session_merge_strategy: str(session.merge_strategy),
     session_pull_before_session: str(session.pull_before_session),
     session_pr_command: str(session.pr_command),
@@ -83,6 +85,8 @@ function toNested(flat: FlatState): Record<string, unknown> {
     policy.agent_timeout = Number(flat.policy_agent_timeout);
   if (flat.policy_max_delegate_retries)
     policy.max_delegate_retries = Number(flat.policy_max_delegate_retries);
+  if (flat.policy_cache_delegations)
+    policy.cache_delegations = flat.policy_cache_delegations === "true";
   if (Object.keys(policy).length > 0) result.policy = policy;
 
   const session: Record<string, unknown> = {};
@@ -246,6 +250,20 @@ export default function ConfigForm({
               placeholder={ph?.policy_max_delegate_retries || "0"}
               className="h-8 text-xs"
             />
+          </Field>
+          <Field label="Cache Delegations">
+            <label className="flex items-center gap-2 text-xs">
+              <input
+                type="checkbox"
+                checked={state.policy_cache_delegations === "true"}
+                onChange={(e) =>
+                  set("policy_cache_delegations")(
+                    e.target.checked ? "true" : ""
+                  )
+                }
+              />
+              Reuse results for identical delegation requests within a session
+            </label>
           </Field>
         </div>
       </section>

--- a/gui/frontend/src/components/LaunchDialog.tsx
+++ b/gui/frontend/src/components/LaunchDialog.tsx
@@ -53,7 +53,7 @@ export default function LaunchDialog({
   const projectFiles = useProjectFiles(projectId);
   const launchSession = useLaunchSession();
   const defaults = config.data?.merged as
-    | { orchestrator_role?: string; runtime?: string; isolation?: string; merge_strategy?: string }
+    | { orchestrator_role?: string; runtime?: string; isolation?: string; merge_strategy?: string; cache_delegations?: boolean }
     | undefined;
 
   const [task, setTask] = useState("");
@@ -61,6 +61,7 @@ export default function LaunchDialog({
   const [runtime, setRuntime] = useState("");
   const [isolation, setIsolation] = useState("");
   const [mergeStrategy, setMergeStrategy] = useState("");
+  const [cacheDelegations, setCacheDelegations] = useState(true);
   const [systemPrompt, setSystemPrompt] = useState("");
   const [interactive, setInteractive] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
@@ -72,6 +73,7 @@ export default function LaunchDialog({
     setRuntime("");
     setIsolation("");
     setMergeStrategy("");
+    setCacheDelegations(true);
     setSystemPrompt("");
     setInteractive(false);
     setSelectedFiles([]);
@@ -90,7 +92,7 @@ export default function LaunchDialog({
         project_id: number;
         task: string;
         role?: string;
-        overrides?: Record<string, string>;
+        overrides?: Record<string, unknown>;
         context_files?: string[];
         system_prompt?: string;
         interactive?: boolean;
@@ -100,10 +102,11 @@ export default function LaunchDialog({
       };
       if (role.trim()) body.role = role.trim();
 
-      const overrides: Record<string, string> = {};
+      const overrides: Record<string, unknown> = {};
       if (runtime.trim()) overrides.runtime = runtime.trim();
       if (isolation.trim()) overrides.isolation = isolation.trim();
       if (mergeStrategy.trim()) overrides.merge_strategy = mergeStrategy.trim();
+      if (!cacheDelegations) overrides.cache_delegations = false;
       if (Object.keys(overrides).length > 0) body.overrides = overrides;
       if (selectedFiles.length > 0) body.context_files = selectedFiles;
       if (systemPrompt.trim()) body.system_prompt = systemPrompt.trim();
@@ -313,6 +316,20 @@ export default function LaunchDialog({
                   rows={3}
                 />
               </div>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={cacheDelegations}
+                  onChange={(e) => setCacheDelegations(e.target.checked)}
+                  className="rounded border-input"
+                />
+                <span className="text-sm">
+                  Cache delegations
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  Reuse results for identical delegation requests within this session
+                </span>
+              </label>
               <label className="flex items-center gap-2 cursor-pointer">
                 <input
                   type="checkbox"

--- a/gui/frontend/src/hooks/mutations/use-sessions.ts
+++ b/gui/frontend/src/hooks/mutations/use-sessions.ts
@@ -6,7 +6,7 @@ interface LaunchSessionBody {
   project_id: number;
   task: string;
   role?: string;
-  overrides?: Record<string, string>;
+  overrides?: Record<string, unknown>;
   context_files?: string[];
   system_prompt?: string;
   interactive?: boolean;

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -114,6 +114,7 @@ class SessionOverrides(BaseModel):
     runtime: str | None = None
     isolation: str | None = None
     merge_strategy: str | None = None
+    cache_delegations: bool | None = None
 
 
 class SessionLaunch(BaseModel):
@@ -144,6 +145,7 @@ def launch_session_subprocess(
     isolation_override: str | None = None,
     merge_strategy_override: str | None = None,
     context_files: list[str] | None = None,
+    cache_delegations: bool | None = None,
     schedule_id: int | None = None,
     interactive: bool = False,
 ) -> str:
@@ -242,6 +244,8 @@ def launch_session_subprocess(
         cmd.extend(["--merge-strategy", merge_strategy_override])
     if system_prompt:
         cmd.extend(["--system-prompt", system_prompt])
+    if cache_delegations is False:
+        cmd.append("--no-cache-delegations")
 
     # Ensure subprocess can find user-installed tools (claude, etc.)
     # even when the server was started from a limited-PATH context.
@@ -298,6 +302,7 @@ def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
             runtime_override=body.overrides.runtime if body.overrides else None,
             isolation_override=body.overrides.isolation if body.overrides else None,
             merge_strategy_override=body.overrides.merge_strategy if body.overrides else None,
+            cache_delegations=body.overrides.cache_delegations if body.overrides else None,
             context_files=body.context_files,
             interactive=body.interactive,
         )


### PR DESCRIPTION
## Summary
- **Per-session delegation cache**: In-memory cache keyed by SHA-256 of `(role, task, return_format)`. Only caches successful non-empty results. Avoids redundant sub-agent spawns for identical delegations within a session.
- **Skill PATH fix**: Prepends skill subdirectories to agent PATH in `wrapper.spawn()` so agents find managed binaries (e.g. `denden`) before any stale global installs in `~/.local/bin` or `/usr/local/bin`.
- **CLI flag**: `--no-cache-delegations` to disable caching per session.
- **GUI toggles**: Cache delegations checkbox in both ConfigForm (policy) and LaunchDialog (per-session override).

## Test plan
- [x] 17 new delegation cache tests pass (`cli/tests/test_delegation_cache.py`)
- [x] 3 new wrapper PATH tests pass (`cli/tests/test_agents_wrapper.py`)
- [x] All 530+ existing tests pass
- [ ] Run a GUI session and confirm `delegateResult` contains text (not `{}`)
- [ ] Verify cache hit logging appears for repeated identical delegations

🤖 Generated with [Claude Code](https://claude.com/claude-code)