### PR TITLE
Add validation for datalist-backed config fields

### DIFF
--- a/gui/frontend/src/components/ConfigForm.tsx
+++ b/gui/frontend/src/components/ConfigForm.tsx
@@ -156,6 +156,20 @@ export default function ConfigForm({
   memoryNames.add("none");
   const memoryOptions = [...memoryNames].sort();
 
+  const runtimeError =
+    state.runtime && agentNames.length > 0 && !agentNames.includes(state.runtime)
+      ? "Runtime not found in installed agents"
+      : "";
+  const roleError =
+    state.orchestrator_role && roleNames.length > 0 && !roleNames.includes(state.orchestrator_role)
+      ? "Role not found in installed roles"
+      : "";
+  const memoryError =
+    state.memory && !memoryOptions.includes(state.memory)
+      ? "Memory not found in installed providers"
+      : "";
+  const hasValidationError = !!runtimeError || !!roleError || !!memoryError;
+
   return (
     <div className="flex flex-col gap-6">
       {/* General */}
@@ -177,6 +191,9 @@ export default function ConfigForm({
                   <option key={n} value={n} />
                 ))}
               </datalist>
+            )}
+            {runtimeError && (
+              <p className="text-xs text-destructive">{runtimeError}</p>
             )}
           </Field>
           <Field label="Isolation">
@@ -201,6 +218,9 @@ export default function ConfigForm({
                 <option key={n} value={n} />
               ))}
             </datalist>
+            {memoryError && (
+              <p className="text-xs text-destructive">{memoryError}</p>
+            )}
           </Field>
         </div>
       </section>
@@ -224,6 +244,9 @@ export default function ConfigForm({
                   <option key={n} value={n} />
                 ))}
               </datalist>
+            )}
+            {roleError && (
+              <p className="text-xs text-destructive">{roleError}</p>
             )}
           </Field>
           <Field label="Permission Mode">
@@ -361,7 +384,7 @@ export default function ConfigForm({
       <Button
         size="sm"
         onClick={handleSave}
-        disabled={saving}
+        disabled={saving || hasValidationError}
         className="self-start"
       >
         <Save className="mr-2 h-3.5 w-3.5" />

--- a/gui/frontend/src/components/LaunchDialog.tsx
+++ b/gui/frontend/src/components/LaunchDialog.tsx
@@ -174,7 +174,11 @@ export default function LaunchDialog({
     runtime.trim() && agentNames.length > 0 && !agentNames.includes(runtime.trim())
       ? "Runtime not found in installed agents"
       : "";
-  const hasValidationError = !!roleError || !!runtimeError;
+  const memoryError =
+    memory.trim() && !memoryOptions.includes(memory.trim())
+      ? "Memory not found in installed providers"
+      : "";
+  const hasValidationError = !!roleError || !!runtimeError || !!memoryError;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -341,6 +345,9 @@ export default function LaunchDialog({
                       <option key={n} value={n} />
                     ))}
                   </datalist>
+                  {memoryError && (
+                    <p className="text-xs text-destructive">{memoryError}</p>
+                  )}
                 </div>
               </div>
               <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary

- Validate **Runtime**, **Memory**, and **Role** inputs in **ConfigForm** (Settings page) against installed options — show inline error and disable Save button
- Add **Memory** validation in **LaunchDialog** (Role and Runtime already had it) — show inline error and disable Launch button

## Test plan

- [ ] Settings page: type an invalid runtime/role/memory name → error appears, Save disabled
- [ ] Settings page: select a valid value from datalist → error clears, Save enabled
- [ ] Launch dialog: type an invalid memory name → error appears, Launch disabled
- [ ] Verify existing Role and Runtime validation in Launch dialog still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)