### PR TITLE
Fix GUI server hanging indefinitely on shutdown

### DIFF
--- a/gui/src/strawpot_gui/event_bus.py
+++ b/gui/src/strawpot_gui/event_bus.py
@@ -30,14 +30,21 @@ class EventBus:
             except asyncio.QueueFull:
                 pass  # drop if subscriber is too slow
 
-    async def subscribe(self) -> AsyncIterator[SessionEvent]:
-        """Yield events as they arrive. Clean up on generator close."""
+    async def subscribe(self, poll_interval: float = 5.0) -> AsyncIterator[SessionEvent | None]:
+        """Yield events as they arrive. Clean up on generator close.
+
+        Yields ``None`` every *poll_interval* seconds when no event arrives,
+        giving callers a chance to check for client disconnection.
+        """
         q: asyncio.Queue[SessionEvent] = asyncio.Queue(maxsize=100)
         self._subscribers.append(q)
         try:
             while True:
-                event = await q.get()
-                yield event
+                try:
+                    event = await asyncio.wait_for(q.get(), timeout=poll_interval)
+                    yield event
+                except asyncio.TimeoutError:
+                    yield None
         finally:
             self._subscribers.remove(q)
 

--- a/gui/src/strawpot_gui/routers/sse.py
+++ b/gui/src/strawpot_gui/routers/sse.py
@@ -334,6 +334,8 @@ async def global_events_sse(request: Request):
         async for session_event in bus.subscribe():
             if await request.is_disconnected():
                 return
+            if session_event is None:
+                continue
             event_id += 1
             yield format_sse_typed(event_id, session_event.kind, {
                 "run_id": session_event.run_id,

--- a/gui/src/strawpot_gui/server.py
+++ b/gui/src/strawpot_gui/server.py
@@ -57,4 +57,4 @@ def main(port: int = DEFAULT_PORT, host: str = DEFAULT_HOST) -> None:
     from strawpot_gui.app import create_app
 
     app = create_app()
-    uvicorn.run(app, host=host, port=port, log_level="info")
+    uvicorn.run(app, host=host, port=port, log_level="info", timeout_graceful_shutdown=5)


### PR DESCRIPTION
## Summary
- The global `/api/events` SSE endpoint blocked forever on `q.get()` with no timeout, and uvicorn had no `timeout_graceful_shutdown`, so the server could wait indefinitely for SSE connections to close on shutdown.
- Add `timeout_graceful_shutdown=5` to `uvicorn.run()` as a hard backstop.
- Add periodic 5s timeout to `EventBus.subscribe()` so the global SSE endpoint can cooperatively detect disconnection and exit.

## Test plan
- [ ] Start GUI, open a page that subscribes to `/api/events`, then Ctrl-C the server — verify it exits within ~5s
- [ ] Verify SSE streams still work normally (events delivered, no spurious disconnects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)