### PR TITLE
Change inherit_global_skills default from true to false

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1663,8 +1663,8 @@ alive.
     `~/.strawpot/skills/`, stage alongside dependency-resolved skills,
     add "Available Skills" summary section to prompt (slug + description;
     agents read `skills/<name>/SKILL.md` for full body). Respect
-    `metadata.strawpot.inherit_global_skills` in ROLE.md (default `true`)
-    to allow roles to opt out of global skills.
+    `metadata.strawpot.inherit_global_skills` in ROLE.md (default `false`)
+    to allow roles to opt in to global skills.
 
 ### Phase 5 — Web GUI (complete)
 
@@ -1933,13 +1933,14 @@ global skill's slug and one-line description. This appears after the role
 body and before the Delegation section. Agents can read
 `skills/<name>/SKILL.md` for the full body when they need details.
 
-### Opt-Out via `inherit_global_skills`
+### Opt-In via `inherit_global_skills`
 
-Roles can opt out of receiving global skills by setting
-`metadata.strawpot.inherit_global_skills: false` in their ROLE.md
-frontmatter. When omitted, the default is `true` (global skills are
-inherited). This allows specialized roles to keep a minimal, controlled
-skill set.
+Roles can opt in to receiving global skills by setting
+`metadata.strawpot.inherit_global_skills: true` in their ROLE.md
+frontmatter. When omitted, the default is `false` (global skills are
+not inherited). This keeps roles minimal by default while allowing
+roles that need broader capabilities to inherit all globally installed
+skills.
 
 ### Denden Communication
 

--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -177,16 +177,16 @@ def _check_inherit_global_skills(role_path: str) -> bool:
     """Check if a role inherits global skills.
 
     Reads ``metadata.strawpot.inherit_global_skills`` from ROLE.md frontmatter.
-    Defaults to ``True`` if the field is not present.
+    Defaults to ``False`` if the field is not present.
     """
     role_md = Path(role_path) / "ROLE.md"
     if not role_md.exists():
-        return True
+        return False
     text = role_md.read_text(encoding="utf-8")
     parsed = parse_frontmatter(text)
     fm = parsed.get("frontmatter", {})
     return fm.get("metadata", {}).get("strawpot", {}).get(
-        "inherit_global_skills", True
+        "inherit_global_skills", False
     )
 
 

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -1775,10 +1775,10 @@ class TestMemoryIntegration:
 
 
 class TestCheckInheritGlobalSkills:
-    def test_default_true(self, tmp_path):
-        """Default is True when field is not present."""
+    def test_default_false(self, tmp_path):
+        """Default is False when field is not present."""
         d = _write_role(str(tmp_path), "basic")
-        assert _check_inherit_global_skills(d) is True
+        assert _check_inherit_global_skills(d) is False
 
     def test_explicit_true(self, tmp_path):
         """Explicit True is respected."""
@@ -1791,10 +1791,10 @@ class TestCheckInheritGlobalSkills:
         assert _check_inherit_global_skills(d) is False
 
     def test_missing_role_md(self, tmp_path):
-        """Missing ROLE.md defaults to True."""
+        """Missing ROLE.md defaults to False."""
         d = str(tmp_path / "roles" / "missing")
         os.makedirs(d, exist_ok=True)
-        assert _check_inherit_global_skills(d) is True
+        assert _check_inherit_global_skills(d) is False
 
 
 # ---------------------------------------------------------------------------
@@ -1815,13 +1815,28 @@ def _write_global_skill(global_dir, slug, version, description="test"):
 
 
 class TestDiscoverGlobalSkills:
+    def test_default_no_global_skills(self, tmp_path, monkeypatch):
+        """Roles without inherit_global_skills do not get global skills."""
+        global_dir = str(tmp_path / "global")
+        monkeypatch.setenv("STRAWPOT_HOME", global_dir)
+        _write_global_skill(global_dir, "linter", "1.0.0")
+
+        role_path = _write_role(str(tmp_path), "worker")
+        resolved = {
+            "slug": "worker", "kind": "role", "version": "1.0.0",
+            "path": role_path, "source": "local", "dependencies": [],
+        }
+
+        assert discover_global_skills(resolved) == []
+
     def test_discovers_global_skills(self, tmp_path, monkeypatch):
         """Finds skills in ~/.strawpot/skills/."""
         global_dir = str(tmp_path / "global")
         monkeypatch.setenv("STRAWPOT_HOME", global_dir)
         _write_global_skill(global_dir, "linter", "1.0.0", "Checks code quality")
 
-        role_path = _write_role(str(tmp_path), "worker")
+        role_path = _write_role(str(tmp_path), "worker",
+                               inherit_global_skills=True)
         resolved = {
             "slug": "worker", "kind": "role", "version": "1.0.0",
             "path": role_path, "source": "local", "dependencies": [],
@@ -1839,7 +1854,8 @@ class TestDiscoverGlobalSkills:
         _write_global_skill(global_dir, "linter", "1.0.0")
         _write_global_skill(global_dir, "formatter", "1.0.0", "Formats code")
 
-        role_path = _write_role(str(tmp_path), "worker")
+        role_path = _write_role(str(tmp_path), "worker",
+                               inherit_global_skills=True)
         resolved = {
             "slug": "worker", "kind": "role", "version": "1.0.0",
             "path": role_path, "source": "local",
@@ -1862,7 +1878,8 @@ class TestDiscoverGlobalSkills:
         with open(os.path.join(d, "SKILL.md"), "w") as f:
             f.write("---\nname: denden\ndescription: Agent comms\n---\n# denden\n")
 
-        role_path = _write_role(str(tmp_path), "worker")
+        role_path = _write_role(str(tmp_path), "worker",
+                               inherit_global_skills=True)
         resolved = {
             "slug": "worker", "kind": "role", "version": "1.0.0",
             "path": role_path, "source": "local", "dependencies": [],
@@ -1876,7 +1893,8 @@ class TestDiscoverGlobalSkills:
     def test_empty_when_no_dir(self, tmp_path, monkeypatch):
         """Returns empty when ~/.strawpot/skills/ doesn't exist."""
         monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "nonexistent"))
-        role_path = _write_role(str(tmp_path), "worker")
+        role_path = _write_role(str(tmp_path), "worker",
+                               inherit_global_skills=True)
         resolved = {
             "slug": "worker", "kind": "role", "version": "1.0.0",
             "path": role_path, "source": "local", "dependencies": [],
@@ -1914,7 +1932,8 @@ class TestDiscoverGlobalSkills:
         # Valid name
         _write_global_skill(global_dir, "linter", "1.0.0", "Checks code")
 
-        role_path = _write_role(str(tmp_path), "worker")
+        role_path = _write_role(str(tmp_path), "worker",
+                               inherit_global_skills=True)
         resolved = {
             "slug": "worker", "kind": "role", "version": "1.0.0",
             "path": role_path, "source": "local", "dependencies": [],
@@ -1931,7 +1950,8 @@ class TestDiscoverGlobalSkills:
         _write_global_skill(global_dir, "z-tool", "1.0.0", "Z tool")
         _write_global_skill(global_dir, "a-tool", "1.0.0", "A tool")
 
-        role_path = _write_role(str(tmp_path), "worker")
+        role_path = _write_role(str(tmp_path), "worker",
+                               inherit_global_skills=True)
         resolved = {
             "slug": "worker", "kind": "role", "version": "1.0.0",
             "path": role_path, "source": "local", "dependencies": [],
@@ -1953,7 +1973,8 @@ class TestDiscoverGlobalSkills:
         with open(os.path.join(d, "SKILL.md"), "w") as f:
             f.write("---\nname: wrong-name\ndescription: test\n---\nBody.\n")
 
-        role_path = _write_role(str(tmp_path), "worker")
+        role_path = _write_role(str(tmp_path), "worker",
+                               inherit_global_skills=True)
         resolved = {
             "slug": "worker", "kind": "role", "version": "1.0.0",
             "path": role_path, "source": "local", "dependencies": [],

--- a/docs/concepts/delegation.mdx
+++ b/docs/concepts/delegation.mdx
@@ -104,7 +104,7 @@ The resolved directory structure looks like:
 
 ## Global Skills
 
-Roles can opt into loading global skills from `~/.strawpot/skills/`. These are automatically included alongside the role's declared dependencies, giving agents access to user-wide skill configurations.
+Roles can opt in to loading global skills from `~/.strawpot/skills/` by setting `metadata.strawpot.inherit_global_skills: true` in their ROLE.md frontmatter. By default, global skills are **not** inherited. When enabled, they are included alongside the role's declared dependencies, giving agents access to user-wide skill configurations.
 
 ## Memory Context
 


### PR DESCRIPTION
## Summary
- Change `inherit_global_skills` default from `true` to `false` so delegated agents don't receive global skills unless explicitly opted in
- Roles that need global skills must set `metadata.strawpot.inherit_global_skills: true` in ROLE.md frontmatter
- Update DESIGN.md and docs to reflect opt-in semantics

## Test plan
- [x] `TestCheckInheritGlobalSkills` — default and missing ROLE.md now return `False`
- [x] `TestDiscoverGlobalSkills` — new `test_default_no_global_skills` verifies default behavior; existing tests explicitly opt in
- [x] Full CLI test suite passes (539 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)