### PR TITLE
Move isolation and merge strategy to project creation

### DIFF
--- a/gui/frontend/src/components/LaunchDialog.tsx
+++ b/gui/frontend/src/components/LaunchDialog.tsx
@@ -58,9 +58,7 @@ export default function LaunchDialog({
     | {
         orchestrator_role?: string;
         runtime?: string;
-        isolation?: string;
         memory?: string;
-        merge_strategy?: string;
         cache_delegations?: boolean;
         cache_max_entries?: number;
         cache_ttl_seconds?: number;
@@ -74,9 +72,7 @@ export default function LaunchDialog({
   const [task, setTask] = useState("");
   const [role, setRole] = useState("");
   const [runtime, setRuntime] = useState("");
-  const [isolation, setIsolation] = useState("");
   const [memory, setMemory] = useState("");
-  const [mergeStrategy, setMergeStrategy] = useState("");
   const [cacheDelegations, setCacheDelegations] = useState("");
   const [cacheMaxEntries, setCacheMaxEntries] = useState("");
   const [cacheTtlSeconds, setCacheTtlSeconds] = useState("");
@@ -90,9 +86,7 @@ export default function LaunchDialog({
     setTask("");
     setRole("");
     setRuntime("");
-    setIsolation("");
     setMemory("");
-    setMergeStrategy("");
     setCacheDelegations("");
     setCacheMaxEntries("");
     setCacheTtlSeconds("");
@@ -127,9 +121,7 @@ export default function LaunchDialog({
 
       const overrides: Record<string, unknown> = {};
       if (runtime.trim()) overrides.runtime = runtime.trim();
-      if (isolation) overrides.isolation = isolation;
       if (memory.trim()) overrides.memory = memory.trim();
-      if (mergeStrategy) overrides.merge_strategy = mergeStrategy;
       if (cacheDelegations) overrides.cache_delegations = cacheDelegations === "true";
       if (cacheMaxEntries.trim()) overrides.cache_max_entries = Number(cacheMaxEntries.trim());
       if (cacheTtlSeconds.trim()) overrides.cache_ttl_seconds = Number(cacheTtlSeconds.trim());
@@ -352,49 +344,6 @@ export default function LaunchDialog({
                   {memoryError && (
                     <p className="text-xs text-destructive">{memoryError}</p>
                   )}
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="isolation">Isolation</Label>
-                  <Select
-                    value={isolation || EMPTY}
-                    onValueChange={(v) => setIsolation(v === EMPTY ? "" : v)}
-                  >
-                    <SelectTrigger id="isolation">
-                      <SelectValue
-                        placeholder={defaults?.isolation ?? "none"}
-                      />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={EMPTY} className="text-muted-foreground">
-                        Default ({defaults?.isolation ?? "none"})
-                      </SelectItem>
-                      <SelectItem value="none">none</SelectItem>
-                      <SelectItem value="worktree">worktree</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="merge-strategy">Merge Strategy</Label>
-                  <Select
-                    value={mergeStrategy || EMPTY}
-                    onValueChange={(v) => setMergeStrategy(v === EMPTY ? "" : v)}
-                  >
-                    <SelectTrigger id="merge-strategy">
-                      <SelectValue
-                        placeholder={defaults?.merge_strategy ?? "auto"}
-                      />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={EMPTY} className="text-muted-foreground">
-                        Default ({defaults?.merge_strategy ?? "auto"})
-                      </SelectItem>
-                      <SelectItem value="auto">auto</SelectItem>
-                      <SelectItem value="local">local</SelectItem>
-                      <SelectItem value="pr">pr</SelectItem>
-                    </SelectContent>
-                  </Select>
                 </div>
               </div>
               <div className="space-y-2">

--- a/gui/frontend/src/pages/ProjectList.tsx
+++ b/gui/frontend/src/pages/ProjectList.tsx
@@ -1,13 +1,22 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useProjects } from "@/hooks/queries/use-projects";
+import { useGlobalConfig } from "@/hooks/queries/use-config";
 import { useCreateProject, useDeleteProject } from "@/hooks/mutations/use-projects";
+import { useSaveProjectConfig } from "@/hooks/mutations/use-config";
 import DirBrowser from "@/components/DirBrowser";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Table,
@@ -133,15 +142,35 @@ function RegisterForm({
 }) {
   const [displayName, setDisplayName] = useState("");
   const [workingDir, setWorkingDir] = useState("");
+  const [isolation, setIsolation] = useState("");
+  const [mergeStrategy, setMergeStrategy] = useState("");
   const [showBrowser, setShowBrowser] = useState(false);
   const createProject = useCreateProject();
+  const saveConfig = useSaveProjectConfig();
+  const globalConfig = useGlobalConfig();
+
+  const globalDefaults = globalConfig.data?.defaults as
+    | { isolation?: string; session?: { merge_strategy?: string } }
+    | undefined;
+  const defaultIsolation = globalDefaults?.isolation ?? "none";
+  const defaultMergeStrategy = globalDefaults?.session?.merge_strategy ?? "auto";
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await createProject.mutateAsync({
+      const project = await createProject.mutateAsync({
         display_name: displayName.trim(),
         working_dir: workingDir.trim(),
+      });
+      // Write initial project config with isolation and merge strategy
+      const configData: Record<string, unknown> = {};
+      const selectedIsolation = isolation || defaultIsolation;
+      const selectedMergeStrategy = mergeStrategy || defaultMergeStrategy;
+      configData.isolation = selectedIsolation;
+      configData.session = { merge_strategy: selectedMergeStrategy };
+      await saveConfig.mutateAsync({
+        projectId: (project as { id: number }).id,
+        data: configData,
       });
       onDone();
     } catch {
@@ -195,14 +224,47 @@ function RegisterForm({
               onCancel={() => setShowBrowser(false)}
             />
           )}
-          {createProject.error && (
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="isolation">Isolation</Label>
+              <Select
+                value={isolation || defaultIsolation}
+                onValueChange={setIsolation}
+              >
+                <SelectTrigger id="isolation">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">none</SelectItem>
+                  <SelectItem value="worktree">worktree</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="merge-strategy">Merge Strategy</Label>
+              <Select
+                value={mergeStrategy || defaultMergeStrategy}
+                onValueChange={setMergeStrategy}
+              >
+                <SelectTrigger id="merge-strategy">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="auto">auto</SelectItem>
+                  <SelectItem value="local">local</SelectItem>
+                  <SelectItem value="pr">pr</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          {(createProject.error || saveConfig.error) && (
             <p className="text-sm text-destructive">
-              {createProject.error.message}
+              {(createProject.error || saveConfig.error)?.message}
             </p>
           )}
           <div className="flex gap-2">
-            <Button type="submit" disabled={createProject.isPending}>
-              {createProject.isPending ? "Adding..." : "Add"}
+            <Button type="submit" disabled={createProject.isPending || saveConfig.isPending}>
+              {createProject.isPending || saveConfig.isPending ? "Adding..." : "Add"}
             </Button>
             <Button type="button" variant="outline" onClick={onCancel}>
               Cancel

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -112,8 +112,6 @@ def _refresh_session_status(conn, run_id: str) -> None:
 
 class SessionOverrides(BaseModel):
     runtime: str | None = None
-    isolation: str | None = None
-    merge_strategy: str | None = None
     memory: str | None = None
     cache_delegations: bool | None = None
     cache_max_entries: int | None = None
@@ -146,8 +144,6 @@ def launch_session_subprocess(
     role: str | None = None,
     system_prompt: str | None = None,
     runtime_override: str | None = None,
-    isolation_override: str | None = None,
-    merge_strategy_override: str | None = None,
     context_files: list[str] | None = None,
     memory_override: str | None = None,
     cache_delegations: bool | None = None,
@@ -176,7 +172,7 @@ def launch_session_subprocess(
     # Load project config for defaults
     config = load_config(Path(working_dir))
     resolved_role = role or config.orchestrator_role
-    isolation = isolation_override or config.isolation
+    isolation = config.isolation
 
     # Resolve runtime: explicit override > role default_agent > config default
     runtime = runtime_override
@@ -246,10 +242,6 @@ def launch_session_subprocess(
         cmd.extend(["--role", role])
     if runtime_override:
         cmd.extend(["--runtime", runtime_override])
-    if isolation_override:
-        cmd.extend(["--isolation", isolation_override])
-    if merge_strategy_override:
-        cmd.extend(["--merge-strategy", merge_strategy_override])
     if memory_override:
         cmd.extend(["--memory", memory_override])
     if system_prompt:
@@ -316,8 +308,6 @@ def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
             role=body.role,
             system_prompt=body.system_prompt,
             runtime_override=body.overrides.runtime if body.overrides else None,
-            isolation_override=body.overrides.isolation if body.overrides else None,
-            merge_strategy_override=body.overrides.merge_strategy if body.overrides else None,
             memory_override=body.overrides.memory if body.overrides else None,
             cache_delegations=body.overrides.cache_delegations if body.overrides else None,
             cache_max_entries=body.overrides.cache_max_entries if body.overrides else None,

--- a/gui/tests/test_session_launch.py
+++ b/gui/tests/test_session_launch.py
@@ -58,7 +58,7 @@ class TestLaunchSession:
         resp, mock_popen = self._launch(
             client, pid,
             role="deployer",
-            overrides={"runtime": "gemini", "isolation": "worktree"},
+            overrides={"runtime": "gemini"},
         )
 
         assert resp.status_code == 201
@@ -67,8 +67,6 @@ class TestLaunchSession:
         assert "deployer" in cmd
         assert "--runtime" in cmd
         assert "gemini" in cmd
-        assert "--isolation" in cmd
-        assert "worktree" in cmd
 
     def test_launch_inserts_db_row(self, client, tmp_path):
         """A DB row with status 'starting' is inserted."""


### PR DESCRIPTION
## Summary
- Remove isolation and merge strategy from the Launch Session dialog — these are project-level infrastructure concerns, not per-session overrides
- Remove `isolation` and `merge_strategy` from `SessionOverrides` model and `launch_session_subprocess()` params
- Add isolation and merge strategy selects to the project creation form (RegisterForm), defaulting to global config values
- On project creation, write initial `strawpot.toml` with the selected values

## Test plan
- [x] GUI tests pass (146 tests)
- [x] CLI tests pass (539 tests)
- [ ] Manual: Create a new project → verify isolation/merge_strategy selects appear with global defaults
- [ ] Manual: Launch a session → verify isolation/merge_strategy are no longer in the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)