### PR TITLE
Fix session status not updating in project session list

### DIFF
--- a/gui/src/strawpot_gui/routers/logs.py
+++ b/gui/src/strawpot_gui/routers/logs.py
@@ -82,7 +82,7 @@ async def agent_log_sse(run_id: str, agent_id: str, request: Request):
     - ``event: done``     — session reached terminal state, stream closes
     """
     db_path = request.app.state.db_path
-    session_dir, status = resolve_session_dir(db_path, run_id)
+    session_dir, status, _ = resolve_session_dir(db_path, run_id)
 
     if session_dir is None:
         async def not_found():
@@ -136,7 +136,7 @@ async def agent_log_sse(run_id: str, agent_id: str, request: Request):
 
                 if not changed_files:
                     # Timeout — check DB status
-                    _, current_status = resolve_session_dir(db_path, run_id)
+                    _, current_status, _ = resolve_session_dir(db_path, run_id)
                     if current_status in _TERMINAL_STATUSES:
                         # Final read
                         new_lines, offset = _read_log_delta(log_path, offset)
@@ -182,7 +182,7 @@ async def agent_log_sse(run_id: str, agent_id: str, request: Request):
 async def agent_log_full(run_id: str, agent_id: str, request: Request):
     """Return the complete log file as plain text."""
     db_path = request.app.state.db_path
-    session_dir, _ = resolve_session_dir(db_path, run_id)
+    session_dir, _, _ = resolve_session_dir(db_path, run_id)
 
     if session_dir is None:
         return PlainTextResponse("Session not found", status_code=404)

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -475,7 +475,7 @@ def get_session(project_id: int, run_id: str, conn=Depends(get_db_conn)):
 def stop_session(run_id: str, conn=Depends(get_db_conn)):
     """Stop a running session by sending SIGTERM to the orchestrator PID."""
     row = conn.execute(
-        "SELECT run_id, status, session_dir FROM sessions WHERE run_id = ?",
+        "SELECT run_id, status, session_dir, project_id FROM sessions WHERE run_id = ?",
         (run_id,),
     ).fetchone()
     if not row:
@@ -485,6 +485,8 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
         raise HTTPException(
             409, f"Session is not running (status: {row['status']})"
         )
+
+    project_id = row["project_id"]
 
     # Read PID from session.json
     session_dir = Path(row["session_dir"])
@@ -497,7 +499,7 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
             "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
             (run_id,),
         )
-        event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id))
+        event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
         return {"run_id": run_id, "status": "stopped"}
 
     pid = data.get("pid")
@@ -507,7 +509,7 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
             "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
             (run_id,),
         )
-        event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id))
+        event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
         return {"run_id": run_id, "status": "stopped"}
 
     # Check liveness and send SIGTERM
@@ -519,7 +521,7 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
             "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
             (run_id,),
         )
-        event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id))
+        event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
         return {"run_id": run_id, "status": "stopped"}
 
     try:
@@ -530,14 +532,14 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
             "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
             (run_id,),
         )
-        event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id))
+        event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
         return {"run_id": run_id, "status": "stopped"}
 
     conn.execute(
         "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
         (run_id,),
     )
-    event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id))
+    event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
     return {"run_id": run_id, "status": "stopped"}
 
 

--- a/gui/src/strawpot_gui/routers/sse.py
+++ b/gui/src/strawpot_gui/routers/sse.py
@@ -66,11 +66,11 @@ def _build_full_state(session_dir: str) -> tuple[TreeState, int]:
     return state, offset
 
 
-def _publish_terminal(run_id: str, status: str) -> None:
+def _publish_terminal(run_id: str, status: str, project_id: int | None = None) -> None:
     """Publish a lifecycle event when a session reaches terminal state."""
     kind = f"session_{status}" if status in ("completed", "failed", "stopped") else None
     if kind:
-        event_bus.publish(SessionEvent(kind=kind, run_id=run_id))
+        event_bus.publish(SessionEvent(kind=kind, run_id=run_id, project_id=project_id))
 
 
 # ---------------------------------------------------------------------------
@@ -82,7 +82,7 @@ def _publish_terminal(run_id: str, status: str) -> None:
 async def session_tree_sse(run_id: str, request: Request):
     """SSE endpoint for real-time agent tree updates."""
     db_path = request.app.state.db_path
-    session_dir, status = resolve_session_dir(db_path, run_id)
+    session_dir, status, project_id = resolve_session_dir(db_path, run_id)
 
     if session_dir is None:
         async def not_found():
@@ -139,7 +139,7 @@ async def session_tree_sse(run_id: str, request: Request):
 
                 if not changed_files:
                     # Timeout — no file changes; check DB status only
-                    _, current_status = resolve_session_dir(db_path, run_id)
+                    _, current_status, _ = resolve_session_dir(db_path, run_id)
                     if current_status in ("completed", "failed", "stopped"):
                         # Final read before closing
                         new_events, trace_offset = _read_trace_lines(
@@ -150,7 +150,7 @@ async def session_tree_sse(run_id: str, request: Request):
                         if new_events:
                             event_id += 1
                             yield format_sse(event_id, state.to_dict())
-                        _publish_terminal(run_id, current_status)
+                        _publish_terminal(run_id, current_status, project_id)
                         return
                     continue
 
@@ -197,7 +197,7 @@ async def session_tree_sse(run_id: str, request: Request):
                     yield format_sse(event_id, state.to_dict())
 
                 if state.is_terminal:
-                    _publish_terminal(run_id, "completed")
+                    _publish_terminal(run_id, "completed", project_id)
                     return
         finally:
             stop.set()
@@ -227,7 +227,7 @@ async def session_events_sse(run_id: str, request: Request):
     - Subsequent updates: sends ``event: delta`` with only new events
     """
     db_path = request.app.state.db_path
-    session_dir, status = resolve_session_dir(db_path, run_id)
+    session_dir, status, _ = resolve_session_dir(db_path, run_id)
 
     if session_dir is None:
         async def not_found():
@@ -272,7 +272,7 @@ async def session_events_sse(run_id: str, request: Request):
 
                 if not changed_files:
                     # Timeout — check DB status
-                    _, current_status = resolve_session_dir(db_path, run_id)
+                    _, current_status, _ = resolve_session_dir(db_path, run_id)
                     if current_status in ("completed", "failed", "stopped"):
                         new_events, trace_offset = _read_trace_lines(
                             trace_path, trace_offset

--- a/gui/src/strawpot_gui/sse.py
+++ b/gui/src/strawpot_gui/sse.py
@@ -58,16 +58,18 @@ async def watch_dir(
         return
 
 
-def resolve_session_dir(db_path: str, run_id: str) -> tuple[str | None, str | None]:
-    """Look up session_dir and status from the database."""
+def resolve_session_dir(
+    db_path: str, run_id: str,
+) -> tuple[str | None, str | None, int | None]:
+    """Look up session_dir, status, and project_id from the database."""
     with get_db(db_path) as conn:
         row = conn.execute(
-            "SELECT session_dir, status FROM sessions WHERE run_id = ?",
+            "SELECT session_dir, status, project_id FROM sessions WHERE run_id = ?",
             (run_id,),
         ).fetchone()
     if not row:
-        return None, None
-    return row["session_dir"], row["status"]
+        return None, None, None
+    return row["session_dir"], row["status"], row["project_id"]
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Terminal SSE events (`session_completed`, `session_failed`, `session_stopped`) were published without `project_id`, so the frontend's `useGlobalSSE` hook could not invalidate the project-specific session query cache (`["projects", id, "sessions"]`)
- Added `project_id` to `resolve_session_dir` return value, `_publish_terminal` helper, and all `SessionEvent` publishes in the `stop_session` endpoint
- Updated all call sites in `logs.py`, `sse.py`, and `sessions.py` routers to unpack the new 3-tuple

## Test plan
- [ ] Launch a session from a project, wait for it to complete — verify the project session list updates status without manual refresh
- [ ] Stop a running session — verify the project session list reflects "stopped" status
- [ ] Check the Dashboard (global session list) still updates correctly
- [ ] Verify SSE events in browser devtools include `project_id` for all lifecycle events

🤖 Generated with [Claude Code](https://claude.com/claude-code)