### PR TITLE
Fix artifact content overflow in session detail

### DIFF
--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -580,7 +580,7 @@ function ArtifactContent({ runId, hash }: { runId: string; hash: string }) {
     );
   }
   return (
-    <ScrollArea className="max-h-[300px]">
+    <ScrollArea className="max-h-[300px] overflow-hidden">
       <pre className="whitespace-pre-wrap break-words rounded-b-md bg-muted/30 px-3 py-2 font-mono text-xs leading-relaxed">
         {content}
       </pre>


### PR DESCRIPTION
## Summary
- Add `overflow-hidden` to `ScrollArea` in `ArtifactContent` so `max-h-[300px]` properly clips content within the Radix UI viewport, preventing expanded artifact text from overlapping the next artifact header

## Test plan
- [ ] Open a session with multiple artifacts
- [ ] Expand an artifact with long content
- [ ] Verify content scrolls within its 300px container and does not overlap the next artifact header

🤖 Generated with [Claude Code](https://claude.com/claude-code)