### PR TITLE
Update docs for isolation options and current GUI fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ User task → StrawPot → Role (ai-ceo)
 
 When you run `strawpot start`:
 
-1. Creates an isolated git worktree
+1. Creates an isolated environment (worktree, or uses project dir directly)
 2. Starts the Denden gRPC server for agent communication
 3. Retrieves memory context from past sessions
 4. Launches the orchestrator agent (e.g. ai-ceo)
@@ -154,7 +154,7 @@ Project: `strawpot.toml` (project root)
 
 ```toml
 runtime = "strawpot-claude-code"       # strawpot-claude-code | codex | gemini
-isolation = "worktree"        # worktree | docker
+isolation = "none"            # none | worktree | docker
 
 [denden]
 addr = "127.0.0.1:9700"
@@ -164,6 +164,7 @@ role = "ai-ceo"
 
 [policy]
 max_depth = 3
+max_num_delegations = 0       # 0 = unlimited
 
 [memory]
 provider = "dial"             # default; "" to disable

--- a/docs/gui/quickstart.mdx
+++ b/docs/gui/quickstart.mdx
@@ -25,8 +25,12 @@ strawpot gui --port 9000
 
 1. Go to **Projects** in the sidebar
 2. Click **Add Project**
-3. Enter the path to a git repository on your machine
+3. Browse to a directory on your machine
 4. The project name is auto-detected from the directory name
+5. Choose an **Isolation** strategy (`none` or `worktree`) and **Merge Strategy** (`auto`, `local`, or `pr`) — these default to your global config values
+6. Click **Create**
+
+If you select `worktree` isolation and the directory is not a git repository, you'll be prompted to initialize one with `git init`.
 
 The dashboard scans the project's `.strawpot/sessions/` directory to import any existing session history.
 
@@ -36,11 +40,16 @@ The dashboard scans the project's `.strawpot/sessions/` directory to import any 
 2. Click **Launch Session**
 3. Fill in the launch dialog:
    - **Task** — what the agent should do (required)
-   - **Role** — orchestrator role (defaults to project config)
-   - **Runtime** — agent runtime override
-   - **System Prompt** — additional instructions appended to the role prompt
    - **Context Files** — attach project files for the agent to reference
-4. Click **Launch**
+   - **Role** — orchestrator role (defaults to project config)
+4. Expand **Advanced Options** for more controls:
+   - **Interactive mode** — allow the agent to ask you questions via a chat panel
+   - **Runtime** — agent runtime override
+   - **Memory** — memory provider override
+   - **System Prompt** — additional instructions appended to the role prompt
+   - **Max Delegations** — cap delegation calls per session
+   - **Cache** settings — delegation cache controls
+5. Click **Launch**
 
 The session runs as a headless subprocess. You can monitor progress from the
 session detail page, which shows the agent delegation tree, trace events, and

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -14,11 +14,11 @@ strawpot start --role team-lead
 
 ## How It Works
 
-1. Creates a git worktree for the session
+1. Creates an isolated environment (worktree or project dir)
 2. Starts a Denden gRPC server
 3. Retrieves memory context from the configured provider
 4. Spawns an orchestrator agent (Claude Code, Codex, or OpenHands)
-5. Agents delegate sub-tasks via Denden — StrawPot resolves the role + skills from StrawHub, retrieves memory, and spawns sub-agents in the same worktree
+5. Agents delegate sub-tasks via Denden — StrawPot resolves the role + skills from StrawHub, retrieves memory, and spawns sub-agents in the same directory
 6. On exit, records results to memory and cleans up everything automatically
 
 ## Key Features
@@ -31,7 +31,7 @@ strawpot start --role team-lead
     Works with Claude Code, Codex, OpenHands, or any agent that implements the wrapper protocol. No agent-specific code in the core.
   </Card>
   <Card title="Session Isolation" icon="shield">
-    Each session gets its own git worktree. All agents share the same working directory. Changes are merged back via local patch or PR.
+    Sessions can run in a git worktree or directly in the project directory. All agents share the same working directory. Worktree changes are merged back via local patch or PR.
   </Card>
   <Card title="Skill & Role Registry" icon="book">
     Agents load reusable skills and roles from StrawHub with automatic dependency resolution and version management.


### PR DESCRIPTION
## Summary
- **README.md**: Fix config example to show `none` as default isolation (was `worktree`), add `max_num_delegations` to policy section, update "How It Works" step 1 to not assume worktree isolation
- **docs/index.mdx**: Update "How It Works" and Session Isolation card to describe both isolation modes instead of only worktree
- **docs/gui/quickstart.mdx**: Update "Register a Project" with new isolation/merge strategy fields and git init prompt; update "Launch a Session" with current dialog fields including Advanced Options (interactive mode, memory, max delegations, cache settings)

## Test plan
- [ ] Verify README config example matches actual defaults
- [ ] Verify GUI quickstart matches current RegisterForm and LaunchDialog fields
- [ ] Verify docs site renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)