### PR TITLE
Add thread-safe locking to delegation cache

### DIFF
--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -8,6 +8,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import threading
 import time
 import uuid
 from collections import OrderedDict
@@ -319,6 +320,8 @@ class Session:
         self._orchestrator_role_prompt: str = ""
         self._files_dirs: list[str] = []
         self._delegation_cache: OrderedDict[str, tuple[str, "denden_pb2.DelegateResult", float]] = OrderedDict()
+        self._delegation_lock = threading.RLock()
+        self._delegation_key_locks: dict[str, threading.RLock] = {}
         self._delegation_count: int = 0
         self._shutting_down: bool = False
         self._interrupted: bool = False
@@ -774,10 +777,51 @@ class Session:
     # Denden handlers
     # ------------------------------------------------------------------
 
+    def _get_key_lock(self, cache_key: str) -> threading.RLock:
+        """Return (or create) a per-cache-key RLock."""
+        with self._delegation_lock:
+            lock = self._delegation_key_locks.get(cache_key)
+            if lock is None:
+                lock = threading.RLock()
+                self._delegation_key_locks[cache_key] = lock
+            return lock
+
+    def _cache_lookup(self, cache_key: str) -> tuple[str, "denden_pb2.DelegateResult"] | None:
+        """Check cache under *_delegation_lock*; evict if TTL expired."""
+        with self._delegation_lock:
+            cached = self._delegation_cache.get(cache_key)
+            if cached is None:
+                return None
+            cached_output, cached_delegate_res, cached_at = cached
+            ttl = self.config.cache_ttl_seconds
+            if ttl > 0 and (time.monotonic() - cached_at) > ttl:
+                del self._delegation_cache[cache_key]
+                return None
+            return cached_output, cached_delegate_res
+
+    def _cache_store(self, cache_key: str, output: str, delegate_res: "denden_pb2.DelegateResult") -> None:
+        """Store a result in the cache under *_delegation_lock*."""
+        with self._delegation_lock:
+            max_entries = self.config.cache_max_entries
+            if max_entries > 0 and len(self._delegation_cache) >= max_entries:
+                self._delegation_cache.popitem(last=False)
+            self._delegation_cache[cache_key] = (
+                output,
+                delegate_res,
+                time.monotonic(),
+            )
+
     def _handle_delegate(
         self, request: denden_pb2.DenDenRequest
     ) -> denden_pb2.DenDenResponse:
-        """Handle a delegate request from a sub-agent."""
+        """Handle a delegate request from a sub-agent.
+
+        Thread-safe: a class-level ``_delegation_lock`` guards shared
+        cache / counter state, and a per-cache-key ``RLock`` ensures
+        that parallel identical requests are deduplicated — only the
+        first thread executes the delegation while the others wait and
+        then return the cached result.
+        """
         payload = request.delegate
         trace = request.trace
 
@@ -799,41 +843,37 @@ class Session:
         )
 
         # --- Max delegations check (before cache — cache hits count too) ---
-        max_del = self.config.max_num_delegations
-        if max_del > 0 and self._delegation_count >= max_del:
-            reason = "DENY_DELEGATIONS_LIMIT"
-            if self._tracer is not None:
-                self._tracer.delegate_denied(
-                    role=delegate_req.role_slug,
-                    parent_span=requester_span,
-                    reason=reason,
-                    depth=delegate_req.depth,
+        with self._delegation_lock:
+            max_del = self.config.max_num_delegations
+            if max_del > 0 and self._delegation_count >= max_del:
+                reason = "DENY_DELEGATIONS_LIMIT"
+                if self._tracer is not None:
+                    self._tracer.delegate_denied(
+                        role=delegate_req.role_slug,
+                        parent_span=requester_span,
+                        reason=reason,
+                        depth=delegate_req.depth,
+                    )
+                return denied_response(
+                    request.request_id,
+                    reason,
+                    f"Session delegation limit reached ({max_del})",
                 )
-            return denied_response(
-                request.request_id,
-                reason,
-                f"Session delegation limit reached ({max_del})",
-            )
-        self._delegation_count += 1
+            self._delegation_count += 1
 
-        # --- Cache check ---
+        # --- Cache check (fast path) ---
         cache_key: str | None = None
+        key_lock: threading.RLock | None = None
         if self.config.cache_delegations:
             cache_key = self._delegation_cache_key(
                 delegate_req.role_slug,
                 delegate_req.task_text,
                 return_format,
             )
-            cached = self._delegation_cache.get(cache_key)
-            if cached is not None:
-                cached_output, cached_delegate_res, cached_at = cached
-                # TTL eviction
-                ttl = self.config.cache_ttl_seconds
-                if ttl > 0 and (time.monotonic() - cached_at) > ttl:
-                    del self._delegation_cache[cache_key]
-                    cached = None
-            if cached is not None:
-                cached_output, cached_delegate_res, _ = cached
+            # Quick cache check before acquiring the per-key lock
+            hit = self._cache_lookup(cache_key)
+            if hit is not None:
+                cached_output, cached_delegate_res = hit
                 logger.info(
                     "Delegation cache hit for role=%s, output_len=%d, format=%s",
                     delegate_req.role_slug,
@@ -862,7 +902,48 @@ class Session:
                     delegate_result=cached_delegate_res,
                 )
 
+            # Acquire a per-key lock so parallel identical requests
+            # are serialised: the first thread delegates, the rest wait
+            # and pick up the cached result.
+            key_lock = self._get_key_lock(cache_key)
+
+        # If caching is enabled, hold the per-key lock for the
+        # delegation so duplicate requests block here.
+        if key_lock is not None:
+            key_lock.acquire()
         try:
+            # Re-check cache after acquiring per-key lock (another
+            # thread may have populated it while we were waiting).
+            if cache_key is not None:
+                hit = self._cache_lookup(cache_key)
+                if hit is not None:
+                    cached_output, cached_delegate_res = hit
+                    logger.info(
+                        "Delegation cache hit (after wait) for role=%s",
+                        delegate_req.role_slug,
+                    )
+                    if self._tracer is not None:
+                        span = self._tracer.delegate_start(
+                            role=delegate_req.role_slug,
+                            parent_span=requester_span,
+                            context=delegate_req.task_text,
+                            depth=delegate_req.depth,
+                            parent_agent_id=delegate_req.parent_agent_id,
+                            cache_hit=True,
+                        )
+                        self._tracer.delegate_end(
+                            span_id=span,
+                            exit_code=0,
+                            duration_ms=0,
+                            output=cached_output,
+                            role=delegate_req.role_slug,
+                            cache_hit=True,
+                        )
+                    return ok_response(
+                        request.request_id,
+                        delegate_result=cached_delegate_res,
+                    )
+
             result = handle_delegate(
                 request=delegate_req,
                 config=self.config,
@@ -895,14 +976,7 @@ class Session:
             )
             # Cache successful results with non-empty output
             if cache_key is not None and result.output:
-                max_entries = self.config.cache_max_entries
-                if max_entries > 0 and len(self._delegation_cache) >= max_entries:
-                    self._delegation_cache.popitem(last=False)
-                self._delegation_cache[cache_key] = (
-                    result.output,
-                    delegate_res,
-                    time.monotonic(),
-                )
+                self._cache_store(cache_key, result.output, delegate_res)
             return ok_response(
                 request.request_id,
                 delegate_result=delegate_res,
@@ -925,6 +999,9 @@ class Session:
                 "ERR_SUBAGENT_FAILURE",
                 str(exc),
             )
+        finally:
+            if key_lock is not None:
+                key_lock.release()
 
     def _handle_ask_user(
         self, request: denden_pb2.DenDenRequest

--- a/cli/tests/test_delegation_cache.py
+++ b/cli/tests/test_delegation_cache.py
@@ -1,6 +1,7 @@
 """Tests for per-session delegation cache."""
 
 import hashlib
+import threading
 import time
 from unittest.mock import MagicMock, patch
 
@@ -399,3 +400,142 @@ class TestDelegationCacheEviction:
         monkeypatch.setattr(time, "monotonic", lambda: fake_time)
         session._handle_delegate(req)
         assert mock_hd.call_count == 1  # cache hit
+
+
+# ---------------------------------------------------------------------------
+# Thread-safety
+# ---------------------------------------------------------------------------
+
+
+class TestDelegationCacheThreadSafety:
+    """Verify locking around cache and delegation count."""
+
+    def _setup_session(self, tmp_path, **config_overrides):
+        config_overrides.setdefault("cache_delegations", True)
+        config = _make_config(**config_overrides)
+        session = _make_session(tmp_path, config=config)
+        session._tracer = MagicMock()
+        session._tracer.delegate_start.return_value = "span_001"
+        session._session_span_id = "session_span"
+        session._agent_info = {
+            "agent_abc": {"role": "parent_role", "parent": None}
+        }
+        session._agent_spans = {"agent_abc": "span_parent"}
+        session._env = MagicMock()
+        session._env.path = str(tmp_path)
+        session._working_dir = str(tmp_path)
+        session._run_id = "run_123"
+        session._denden_addr = "127.0.0.1:9700"
+        session._memory_provider = None
+        session._files_dirs = []
+        import os
+        session_dir = os.path.join(str(tmp_path), ".strawpot", "sessions", "run_123")
+        os.makedirs(session_dir, exist_ok=True)
+        return session
+
+    @patch("strawpot.session.handle_delegate")
+    def test_parallel_same_request_deduplicates(self, mock_hd, tmp_path):
+        """Parallel identical requests should only trigger one delegation."""
+        gate = threading.Event()
+
+        def slow_delegate(**kwargs):
+            gate.wait(timeout=5)
+            return DelegateResult(output="result", exit_code=0)
+
+        mock_hd.side_effect = slow_delegate
+        session = self._setup_session(tmp_path)
+
+        req = _make_delegate_request()
+        results: list[denden_pb2.DenDenResponse] = [None, None]
+        errors: list[Exception | None] = [None, None]
+
+        def call(idx):
+            try:
+                results[idx] = session._handle_delegate(req)
+            except Exception as exc:
+                errors[idx] = exc
+
+        t1 = threading.Thread(target=call, args=(0,))
+        t2 = threading.Thread(target=call, args=(1,))
+        t1.start()
+        t2.start()
+
+        # Let the delegation complete
+        gate.set()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        assert errors == [None, None]
+        # Only one actual delegation should have happened
+        assert mock_hd.call_count == 1
+        # Both threads get OK responses
+        assert results[0].status == denden_pb2.OK
+        assert results[1].status == denden_pb2.OK
+
+    @patch("strawpot.session.handle_delegate")
+    def test_parallel_different_requests_both_execute(self, mock_hd, tmp_path):
+        """Parallel requests with different cache keys should both execute."""
+        mock_hd.return_value = DelegateResult(output="ok", exit_code=0)
+        session = self._setup_session(tmp_path)
+        # Pre-create running symlink to avoid TOCTOU race in _session_dir
+        import os
+        running_dir = os.path.join(str(tmp_path), ".strawpot", "running")
+        os.makedirs(running_dir, exist_ok=True)
+        running_link = os.path.join(running_dir, "run_123")
+        session_target = os.path.join("..", "sessions", "run_123")
+        if not os.path.islink(running_link):
+            os.symlink(session_target, running_link)
+
+        req_a = _make_delegate_request(task="task_a")
+        req_b = _make_delegate_request(task="task_b")
+        results = [None, None]
+
+        def call(idx, req):
+            results[idx] = session._handle_delegate(req)
+
+        t1 = threading.Thread(target=call, args=(0, req_a))
+        t2 = threading.Thread(target=call, args=(1, req_b))
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        assert mock_hd.call_count == 2
+        assert results[0].status == denden_pb2.OK
+        assert results[1].status == denden_pb2.OK
+
+    @patch("strawpot.session.handle_delegate")
+    def test_delegation_count_thread_safe(self, mock_hd, tmp_path):
+        """Delegation count increments correctly under contention."""
+        mock_hd.return_value = DelegateResult(output="ok", exit_code=0)
+        session = self._setup_session(tmp_path, cache_delegations=False)
+
+        n_threads = 20
+        barrier = threading.Barrier(n_threads)
+
+        def call(i):
+            barrier.wait(timeout=5)
+            req = _make_delegate_request(task=f"task_{i}")
+            session._handle_delegate(req)
+
+        threads = [threading.Thread(target=call, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert session._delegation_count == n_threads
+
+    @patch("strawpot.session.handle_delegate")
+    def test_per_key_lock_created_per_cache_key(self, mock_hd, tmp_path):
+        """Each unique cache key gets its own RLock."""
+        mock_hd.return_value = DelegateResult(output="ok", exit_code=0)
+        session = self._setup_session(tmp_path)
+
+        req_a = _make_delegate_request(task="task_a")
+        req_b = _make_delegate_request(task="task_b")
+
+        session._handle_delegate(req_a)
+        session._handle_delegate(req_b)
+
+        assert len(session._delegation_key_locks) == 2


### PR DESCRIPTION
## Summary

- Guard `_delegation_cache`, `_delegation_key_locks`, and `_delegation_count` with a class-level `RLock` (`_delegation_lock`)
- Add per-cache-key `RLock` so parallel identical delegation requests are deduplicated — only the first thread executes the actual delegation while others block and return the cached result
- Extract `_cache_lookup()`, `_cache_store()`, and `_get_key_lock()` helper methods that hold the lock internally
- Double-checked locking pattern: fast-path cache check before key lock, re-check after acquiring it

## Test plan

- [x] 4 new thread-safety tests in `TestDelegationCacheThreadSafety`
  - `test_parallel_same_request_deduplicates` — 2 threads, 1 delegation
  - `test_parallel_different_requests_both_execute` — different keys run concurrently
  - `test_delegation_count_thread_safe` — 20 threads incrementing count correctly
  - `test_per_key_lock_created_per_cache_key` — verifies per-key lock creation
- [x] All 21 existing cache tests still pass
- [x] Full CLI test suite passes (545 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)