### PR TITLE
Persist chat message history for interactive sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,8 @@ Global: `$STRAWPOT_HOME/strawpot.toml` (default `~/.strawpot/strawpot.toml`)
 Project: `strawpot.toml` (project root)
 
 ```toml
-runtime = "strawpot-claude-code"       # strawpot-claude-code | codex | gemini
+runtime = "strawpot-claude-code"       # strawpot-claude-code | strawpot-codex | strawpot-gemini
 isolation = "none"                     # none | worktree | docker
-
-[denden]
-addr = "127.0.0.1:9700"
 
 [orchestrator]
 role = "ai-ceo"

--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -60,6 +60,13 @@ export interface AskUserPending {
   timestamp: number;
 }
 
+export interface ChatMessage {
+  id: string;
+  role: "agent" | "user";
+  text: string;
+  timestamp: number;
+}
+
 export interface TreeNode {
   agent_id: string;
   role: string;

--- a/gui/frontend/src/components/ChatPanel.tsx
+++ b/gui/frontend/src/components/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import type { AskUserPending } from "@/api/types";
+import type { AskUserPending, ChatMessage } from "@/api/types";
 import { useRespondToAskUser } from "@/hooks/mutations/use-ask-user";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -9,31 +9,46 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { MessageSquare, Send } from "lucide-react";
 
-interface ChatMessage {
-  id: string;
-  role: "agent" | "user";
-  text: string;
-  timestamp: number;
-}
-
 export default function ChatPanel({
   runId,
   pendingAskUser,
+  initialMessages,
 }: {
   runId: string;
   pendingAskUser: AskUserPending | null;
+  initialMessages?: ChatMessage[];
 }) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const respond = useRespondToAskUser(runId);
   const scrollRef = useRef<HTMLDivElement>(null);
   const lastPendingIdRef = useRef<string | null>(null);
+  const seenIdsRef = useRef<Set<string>>(new Set());
+
+  // Seed from persisted history when it arrives
+  useEffect(() => {
+    if (!initialMessages || initialMessages.length === 0) return;
+    setMessages((prev) => {
+      // Merge persisted history with any messages already in state
+      const existingIds = new Set(prev.map((m) => m.id));
+      const fromHistory = initialMessages.filter((m) => !existingIds.has(m.id));
+      if (fromHistory.length === 0) return prev;
+      const merged = [...fromHistory, ...prev];
+      merged.sort((a, b) => a.timestamp - b.timestamp);
+      for (const m of merged) seenIdsRef.current.add(m.id);
+      return merged;
+    });
+  }, [initialMessages]);
 
   // When a new pending question arrives, add it to the chat
   useEffect(() => {
     if (!pendingAskUser) return;
     if (lastPendingIdRef.current === pendingAskUser.request_id) return;
     lastPendingIdRef.current = pendingAskUser.request_id;
+
+    // Skip if already loaded from history
+    if (seenIdsRef.current.has(pendingAskUser.request_id)) return;
+    seenIdsRef.current.add(pendingAskUser.request_id);
 
     setMessages((prev) => [
       ...prev,
@@ -54,15 +69,20 @@ export default function ChatPanel({
   const handleSend = async (text: string) => {
     if (!text.trim() || !pendingAskUser) return;
 
-    setMessages((prev) => [
-      ...prev,
-      {
-        id: `user-${Date.now()}`,
-        role: "user",
-        text: text.trim(),
-        timestamp: Date.now() / 1000,
-      },
-    ]);
+    const msgId = `user-${pendingAskUser.request_id}`;
+    // Skip if already in history
+    if (!seenIdsRef.current.has(msgId)) {
+      seenIdsRef.current.add(msgId);
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: msgId,
+          role: "user",
+          text: text.trim(),
+          timestamp: Date.now() / 1000,
+        },
+      ]);
+    }
     setInput("");
 
     try {

--- a/gui/frontend/src/hooks/useAskUserSSE.ts
+++ b/gui/frontend/src/hooks/useAskUserSSE.ts
@@ -1,17 +1,19 @@
 import { useEffect, useRef, useState } from "react";
-import type { AskUserPending } from "@/api/types";
+import type { AskUserPending, ChatMessage } from "@/api/types";
 
 /**
- * Listens to the session tree SSE for `ask_user` and `ask_user_resolved` events.
- * Returns the current pending question (if any).
+ * Listens to the session tree SSE for `ask_user`, `ask_user_resolved`,
+ * and `chat_history` events. Returns the current pending question and
+ * any persisted chat messages from previous connections.
  */
 export function useAskUserSSE(
   runId: string,
   active: boolean,
-): { pendingAskUser: AskUserPending | null } {
+): { pendingAskUser: AskUserPending | null; chatMessages: ChatMessage[] } {
   const [pendingAskUser, setPendingAskUser] = useState<AskUserPending | null>(
     null,
   );
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
   const esRef = useRef<EventSource | null>(null);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
@@ -21,6 +23,7 @@ export function useAskUserSSE(
   useEffect(() => {
     if (!active) {
       setPendingAskUser(null);
+      setChatMessages([]);
       return;
     }
 
@@ -31,6 +34,17 @@ export function useAskUserSSE(
       es.onopen = () => {
         backoffMs.current = 1000;
       };
+
+      es.addEventListener("chat_history", (msg) => {
+        try {
+          const data = JSON.parse(msg.data) as { messages: ChatMessage[] };
+          if (data.messages) {
+            setChatMessages(data.messages);
+          }
+        } catch {
+          /* ignore */
+        }
+      });
 
       es.addEventListener("ask_user", (msg) => {
         try {
@@ -64,5 +78,5 @@ export function useAskUserSSE(
     };
   }, [runId, active]);
 
-  return { pendingAskUser };
+  return { pendingAskUser, chatMessages };
 }

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -70,7 +70,7 @@ export default function SessionDetail() {
 
   // SSE for interactive ask_user events
   const isInteractive = !!sessionData?.interactive;
-  const { pendingAskUser } = useAskUserSSE(
+  const { pendingAskUser, chatMessages } = useAskUserSSE(
     runId ?? "",
     active && isInteractive,
   );
@@ -206,6 +206,7 @@ export default function SessionDetail() {
             <ChatPanel
               runId={sessionData.run_id}
               pendingAskUser={pendingAskUser}
+              initialMessages={chatMessages}
             />
           </TabsContent>
         )}

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -6,6 +6,7 @@ import re
 import signal
 import shutil
 import subprocess
+import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -631,6 +632,17 @@ def respond_to_ask_user(
     with open(tmp_path, "w", encoding="utf-8") as f:
         json.dump(resp_data, f, indent=2)
     os.replace(tmp_path, str(response_path))
+
+    # Persist the user message to chat history
+    chat_path = session_dir / "chat_messages.jsonl"
+    entry = json.dumps({
+        "id": f"user-{body.request_id}",
+        "role": "user",
+        "text": body.text,
+        "timestamp": time.time(),
+    })
+    with open(chat_path, "a", encoding="utf-8") as f:
+        f.write(entry + "\n")
 
     return {"ok": True}
 

--- a/gui/src/strawpot_gui/routers/sse.py
+++ b/gui/src/strawpot_gui/routers/sse.py
@@ -50,6 +50,37 @@ def _read_trace_lines(trace_path: str, offset: int) -> tuple[list[dict], int]:
     return events, new_offset
 
 
+def _append_chat_message(
+    session_dir: str, role: str, text: str, msg_id: str, timestamp: float
+) -> None:
+    """Append a chat message to the session's chat_messages.jsonl."""
+    path = os.path.join(session_dir, "chat_messages.jsonl")
+    entry = json.dumps(
+        {"id": msg_id, "role": role, "text": text, "timestamp": timestamp}
+    )
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(entry + "\n")
+
+
+def _read_chat_messages(session_dir: str) -> list[dict]:
+    """Read all chat messages from chat_messages.jsonl."""
+    path = os.path.join(session_dir, "chat_messages.jsonl")
+    messages: list[dict] = []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    messages.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        pass
+    return messages
+
+
 def _build_full_state(session_dir: str) -> tuple[TreeState, int]:
     """Build complete TreeState from disk."""
     state = TreeState()
@@ -107,12 +138,28 @@ async def session_tree_sse(run_id: str, request: Request):
         event_id += 1
         yield format_sse(event_id, state.to_dict())
 
+        # Send chat history on initial connect
+        chat_messages = _read_chat_messages(session_dir)
+        if chat_messages:
+            event_id += 1
+            yield format_sse_typed(event_id, "chat_history", {"messages": chat_messages})
+
+        # Track which ask_user IDs have already been persisted
+        persisted_ask_ids: set[str] = {m["id"] for m in chat_messages if m.get("role") == "agent"}
+
         # Check for pending ask_user on initial connect
         ask_user_path = os.path.join(session_dir, "ask_user_pending.json")
         if os.path.isfile(ask_user_path):
             try:
                 with open(ask_user_path, encoding="utf-8") as f:
                     ask_data = json.load(f)
+                req_id = ask_data.get("request_id", "")
+                if req_id and req_id not in persisted_ask_ids:
+                    _append_chat_message(
+                        session_dir, "agent", ask_data.get("question", ""),
+                        req_id, ask_data.get("timestamp", 0),
+                    )
+                    persisted_ask_ids.add(req_id)
                 event_id += 1
                 yield format_sse_typed(event_id, "ask_user", ask_data)
             except (OSError, json.JSONDecodeError):
@@ -181,6 +228,14 @@ async def session_tree_sse(run_id: str, request: Request):
                         try:
                             with open(pending, encoding="utf-8") as f:
                                 ask_data = json.load(f)
+                            req_id = ask_data.get("request_id", "")
+                            if req_id and req_id not in persisted_ask_ids:
+                                _append_chat_message(
+                                    session_dir, "agent",
+                                    ask_data.get("question", ""),
+                                    req_id, ask_data.get("timestamp", 0),
+                                )
+                                persisted_ask_ids.add(req_id)
                             event_id += 1
                             yield format_sse_typed(event_id, "ask_user", ask_data)
                         except (OSError, json.JSONDecodeError):


### PR DESCRIPTION
## Summary
- Store agent questions and user responses in `chat_messages.jsonl` (same pattern as `trace.jsonl`) so chat history survives page navigation and SSE reconnections
- Emit `chat_history` SSE event on connect with persisted messages; deduplicate on both server and client side
- Fix runtime names in README config example and remove stale `[denden]` section

## Test plan
- [ ] Launch interactive session, exchange messages, navigate away and return — messages restored
- [ ] Refresh browser mid-conversation — messages restored
- [ ] Verify `chat_messages.jsonl` created in session directory with correct entries
- [ ] Run `cd gui && pytest tests/ -v` — all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)