### PR TITLE
Add ask_user trace events

### DIFF
--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -1040,7 +1040,6 @@ class Session:
                 agent_id=agent_id,
                 role=role,
                 session_id=self._run_id,
-                parent_agent_id=agent_id,
             )
         t0 = time.monotonic()
 
@@ -1057,7 +1056,6 @@ class Session:
                     agent_id=agent_id,
                     role=role,
                     session_id=self._run_id,
-                    parent_agent_id=agent_id,
                 )
             logger.exception("ask_user handler failed")
             return error_response(
@@ -1076,7 +1074,6 @@ class Session:
                 agent_id=agent_id,
                 role=role,
                 session_id=self._run_id,
-                parent_agent_id=agent_id,
             )
 
         result = denden_pb2.AskUserResult(text=resp.text)

--- a/cli/src/strawpot/trace.py
+++ b/cli/src/strawpot/trace.py
@@ -336,7 +336,6 @@ class Tracer:
         agent_id: str = "",
         role: str = "",
         session_id: str = "",
-        parent_agent_id: str | None = None,
     ) -> str:
         """Emit ``ask_user_start``.  Stores question as artifact.  Returns new span_id."""
         span_id = self._new_span_id()
@@ -350,7 +349,6 @@ class Tracer:
             agent_id=agent_id,
             role=role,
             session_id=session_id,
-            parent_agent_id=parent_agent_id,
         )
         return span_id
 
@@ -364,7 +362,6 @@ class Tracer:
         agent_id: str = "",
         role: str = "",
         session_id: str = "",
-        parent_agent_id: str | None = None,
     ) -> None:
         """Emit ``ask_user_end``.  Stores answer as artifact."""
         answer_ref = self.store_artifact(answer)
@@ -377,5 +374,4 @@ class Tracer:
             agent_id=agent_id,
             role=role,
             session_id=session_id,
-            parent_agent_id=parent_agent_id,
         )

--- a/cli/tests/test_trace.py
+++ b/cli/tests/test_trace.py
@@ -446,7 +446,6 @@ class TestAskUserEvents:
             agent_id="agent_123",
             role="implementer",
             session_id="run_abc",
-            parent_agent_id="agent_000",
         )
         events = _read_events(session_dir)
         assert len(events) == 1
@@ -458,7 +457,6 @@ class TestAskUserEvents:
         assert data["agent_id"] == "agent_123"
         assert data["role"] == "implementer"
         assert data["session_id"] == "run_abc"
-        assert data["parent_agent_id"] == "agent_000"
         # Verify artifact content
         artifact_path = os.path.join(session_dir, "artifacts", data["question_ref"])
         with open(artifact_path, encoding="utf-8") as f:
@@ -474,7 +472,6 @@ class TestAskUserEvents:
             agent_id="agent_123",
             role="implementer",
             session_id="run_abc",
-            parent_agent_id="agent_000",
         )
         events = _read_events(session_dir)
         assert len(events) == 1
@@ -487,7 +484,6 @@ class TestAskUserEvents:
         assert data["agent_id"] == "agent_123"
         assert data["role"] == "implementer"
         assert data["session_id"] == "run_abc"
-        assert data["parent_agent_id"] == "agent_000"
         artifact_path = os.path.join(session_dir, "artifacts", data["answer_ref"])
         with open(artifact_path, encoding="utf-8") as f:
             assert f.read() == "yes"


### PR DESCRIPTION
## Summary
- Add `ask_user_start` and `ask_user_end` trace events to make agent-user interactions visible in the GUI Trace tab
- Question content stored as `question_ref` artifact, user response as `answer_ref` artifact (rendered as clickable buttons in the timeline)
- Empty lines separate Question, Choices, and Why sections in the question artifact for readability

## Test plan
- [x] `test_ask_user_start_returns_span_id` — verifies span ID generation
- [x] `test_ask_user_start_stores_question_artifact` — verifies question artifact storage and all fields
- [x] `test_ask_user_end_stores_answer_artifact` — verifies answer artifact storage and all fields
- [x] Full CLI test suite (548 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)