### PR TITLE
Add parallel-safe ask_user bridge with reliable chat persistence

### DIFF
--- a/cli/src/strawpot/ask_user_bridge.py
+++ b/cli/src/strawpot/ask_user_bridge.py
@@ -8,6 +8,7 @@ for a response file written by the GUI.
 import json
 import logging
 import os
+import threading
 import time
 import uuid
 
@@ -18,6 +19,23 @@ logger = logging.getLogger(__name__)
 POLL_INTERVAL_S = 0.5
 DEFAULT_TIMEOUT_S = 300  # 5 minutes
 
+# Lock shared across all handler calls within a process for
+# thread-safe appends to chat_messages.jsonl.
+_chat_lock = threading.Lock()
+
+
+def _append_chat_message(
+    session_dir: str, role: str, text: str, msg_id: str, timestamp: float
+) -> None:
+    """Append a chat message to chat_messages.jsonl, thread-safe."""
+    path = os.path.join(session_dir, "chat_messages.jsonl")
+    entry = json.dumps(
+        {"id": msg_id, "role": role, "text": text, "timestamp": timestamp}
+    )
+    with _chat_lock:
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(entry + "\n")
+
 
 def make_file_bridge_handler(
     session_dir: str,
@@ -27,18 +45,24 @@ def make_file_bridge_handler(
     """Return an ask_user handler that bridges via filesystem.
 
     The returned callable:
-    1. Writes ``ask_user_pending.json`` with the question
-    2. Polls for ``ask_user_response.json``
-    3. Reads the response, cleans up both files
-    4. Returns :class:`AskUserResponse`
-    5. On timeout falls back to *default_value* or a generic message
+    1. Writes ``ask_user_pending_<request_id>.json`` with the question
+    2. Persists the agent question to ``chat_messages.jsonl``
+    3. Polls for ``ask_user_response_<request_id>.json``
+    4. Reads the response, persists it, cleans up both files
+    5. Returns :class:`AskUserResponse`
+    6. On timeout falls back to *default_value* or a generic message
     """
 
     def handler(req: AskUserRequest) -> AskUserResponse:
         request_id = uuid.uuid4().hex[:12]
-        pending_path = os.path.join(session_dir, "ask_user_pending.json")
-        response_path = os.path.join(session_dir, "ask_user_response.json")
+        pending_path = os.path.join(
+            session_dir, f"ask_user_pending_{request_id}.json"
+        )
+        response_path = os.path.join(
+            session_dir, f"ask_user_response_{request_id}.json"
+        )
 
+        ts = time.time()
         pending_data = {
             "request_id": request_id,
             "question": req.question,
@@ -46,7 +70,7 @@ def make_file_bridge_handler(
             "default_value": req.default_value,
             "why": req.why,
             "response_format": req.response_format,
-            "timestamp": time.time(),
+            "timestamp": ts,
         }
 
         # Atomic write: tmp → rename
@@ -54,6 +78,9 @@ def make_file_bridge_handler(
         with open(tmp_path, "w", encoding="utf-8") as f:
             json.dump(pending_data, f, indent=2)
         os.replace(tmp_path, pending_path)
+
+        # Persist agent question to chat history
+        _append_chat_message(session_dir, "agent", req.question, request_id, ts)
 
         logger.info("ask_user bridge: wrote pending request %s", request_id)
 
@@ -68,16 +95,19 @@ def make_file_bridge_handler(
                     time.sleep(POLL_INTERVAL_S)
                     continue
 
-                if resp_data.get("request_id") != request_id:
-                    time.sleep(POLL_INTERVAL_S)
-                    continue
+                # Persist user answer to chat history
+                resp_text = resp_data.get("text", "")
+                _append_chat_message(
+                    session_dir, "user", resp_text,
+                    f"user-{request_id}", time.time(),
+                )
 
                 _safe_remove(pending_path)
                 _safe_remove(response_path)
 
                 logger.info("ask_user bridge: got response for %s", request_id)
                 return AskUserResponse(
-                    text=resp_data.get("text", ""),
+                    text=resp_text,
                     json=resp_data.get("json", ""),
                 )
 
@@ -85,10 +115,13 @@ def make_file_bridge_handler(
 
         # Timeout — clean up and fall back
         _safe_remove(pending_path)
+        fallback_text = req.default_value or "Proceed with your best judgment."
+        _append_chat_message(
+            session_dir, "user", f"[timeout] {fallback_text}",
+            f"user-{request_id}", time.time(),
+        )
         logger.warning("ask_user bridge: timeout for %s, using default", request_id)
-        if req.default_value:
-            return AskUserResponse(text=req.default_value)
-        return AskUserResponse(text="Proceed with your best judgment.")
+        return AskUserResponse(text=fallback_text)
 
     return handler
 

--- a/cli/tests/test_ask_user_bridge.py
+++ b/cli/tests/test_ask_user_bridge.py
@@ -1,5 +1,6 @@
 """Tests for file-based ask_user bridge."""
 
+import glob
 import json
 import os
 import threading
@@ -21,6 +22,16 @@ def _make_request(**overrides):
     return AskUserRequest(**defaults)
 
 
+def _find_pending(tmp_path):
+    """Find the ask_user_pending_*.json file and return (path, data)."""
+    pattern = str(tmp_path / "ask_user_pending_*.json")
+    files = glob.glob(pattern)
+    assert len(files) == 1, f"Expected 1 pending file, found {len(files)}"
+    path = files[0]
+    data = json.loads(open(path, encoding="utf-8").read())
+    return path, data
+
+
 class TestFileBridgeHandler:
     def test_writes_pending_file(self, tmp_path):
         handler = make_file_bridge_handler(str(tmp_path), timeout=1)
@@ -31,12 +42,12 @@ class TestFileBridgeHandler:
         t.start()
         time.sleep(0.3)
 
-        pending = tmp_path / "ask_user_pending.json"
-        assert pending.is_file()
-        data = json.loads(pending.read_text())
+        path, data = _find_pending(tmp_path)
         assert data["question"] == "What is your name?"
         assert data["why"] == "Need to greet you"
         assert "request_id" in data
+        # Filename should contain request_id
+        assert data["request_id"] in os.path.basename(path)
 
         t.join(timeout=5)
 
@@ -46,10 +57,11 @@ class TestFileBridgeHandler:
 
         def write_response():
             time.sleep(0.3)
-            pending = tmp_path / "ask_user_pending.json"
-            data = json.loads(pending.read_text())
-            resp = {"request_id": data["request_id"], "text": "Alice"}
-            (tmp_path / "ask_user_response.json").write_text(json.dumps(resp))
+            _, data = _find_pending(tmp_path)
+            req_id = data["request_id"]
+            resp = {"request_id": req_id, "text": "Alice"}
+            resp_path = tmp_path / f"ask_user_response_{req_id}.json"
+            resp_path.write_text(json.dumps(resp))
 
         t = threading.Thread(target=write_response)
         t.start()
@@ -59,8 +71,8 @@ class TestFileBridgeHandler:
 
         assert result.text == "Alice"
         # Both files should be cleaned up
-        assert not (tmp_path / "ask_user_pending.json").exists()
-        assert not (tmp_path / "ask_user_response.json").exists()
+        assert len(glob.glob(str(tmp_path / "ask_user_pending_*.json"))) == 0
+        assert len(glob.glob(str(tmp_path / "ask_user_response_*.json"))) == 0
 
     def test_timeout_with_default_value(self, tmp_path):
         handler = make_file_bridge_handler(str(tmp_path), timeout=1)
@@ -69,7 +81,7 @@ class TestFileBridgeHandler:
         result = handler(req)
         assert result.text == "Bob"
         # Pending file should be cleaned up
-        assert not (tmp_path / "ask_user_pending.json").exists()
+        assert len(glob.glob(str(tmp_path / "ask_user_pending_*.json"))) == 0
 
     def test_timeout_without_default(self, tmp_path):
         handler = make_file_bridge_handler(str(tmp_path), timeout=1)
@@ -78,33 +90,6 @@ class TestFileBridgeHandler:
         result = handler(req)
         assert result.text == "Proceed with your best judgment."
 
-    def test_ignores_wrong_request_id(self, tmp_path):
-        handler = make_file_bridge_handler(str(tmp_path), timeout=2)
-        req = _make_request(default_value="fallback")
-
-        def write_bad_then_good():
-            time.sleep(0.3)
-            # Write response with wrong request_id
-            (tmp_path / "ask_user_response.json").write_text(
-                json.dumps({"request_id": "wrong", "text": "Bad"})
-            )
-            time.sleep(0.8)
-            # Now write correct one
-            pending = tmp_path / "ask_user_pending.json"
-            if pending.is_file():
-                data = json.loads(pending.read_text())
-                (tmp_path / "ask_user_response.json").write_text(
-                    json.dumps({"request_id": data["request_id"], "text": "Good"})
-                )
-
-        t = threading.Thread(target=write_bad_then_good)
-        t.start()
-
-        result = handler(req)
-        t.join()
-
-        assert result.text == "Good"
-
     def test_choices_passed_through(self, tmp_path):
         handler = make_file_bridge_handler(str(tmp_path), timeout=1)
         req = _make_request(choices=["A", "B", "C"])
@@ -112,8 +97,7 @@ class TestFileBridgeHandler:
         # Let it timeout — just verify the pending file has choices
         def check_pending():
             time.sleep(0.3)
-            pending = tmp_path / "ask_user_pending.json"
-            data = json.loads(pending.read_text())
+            _, data = _find_pending(tmp_path)
             assert data["choices"] == ["A", "B", "C"]
 
         t = threading.Thread(target=check_pending)
@@ -121,3 +105,55 @@ class TestFileBridgeHandler:
 
         handler(req)
         t.join()
+
+    def test_chat_messages_persisted(self, tmp_path):
+        """Agent question and user answer are persisted to chat_messages.jsonl."""
+        handler = make_file_bridge_handler(str(tmp_path), timeout=10)
+        req = _make_request(question="Pick a color")
+
+        def write_response():
+            time.sleep(0.3)
+            _, data = _find_pending(tmp_path)
+            req_id = data["request_id"]
+            resp = {"request_id": req_id, "text": "Blue"}
+            resp_path = tmp_path / f"ask_user_response_{req_id}.json"
+            resp_path.write_text(json.dumps(resp))
+
+        t = threading.Thread(target=write_response)
+        t.start()
+
+        result = handler(req)
+        t.join()
+
+        assert result.text == "Blue"
+
+        # Verify chat_messages.jsonl has both entries
+        chat_path = tmp_path / "chat_messages.jsonl"
+        assert chat_path.is_file()
+        messages = [
+            json.loads(line)
+            for line in chat_path.read_text().strip().split("\n")
+        ]
+        assert len(messages) == 2
+        assert messages[0]["role"] == "agent"
+        assert messages[0]["text"] == "Pick a color"
+        assert messages[1]["role"] == "user"
+        assert messages[1]["text"] == "Blue"
+
+    def test_timeout_persists_fallback(self, tmp_path):
+        """Timeout fallback is persisted to chat_messages.jsonl."""
+        handler = make_file_bridge_handler(str(tmp_path), timeout=1)
+        req = _make_request(default_value="skip")
+
+        handler(req)
+
+        chat_path = tmp_path / "chat_messages.jsonl"
+        assert chat_path.is_file()
+        messages = [
+            json.loads(line)
+            for line in chat_path.read_text().strip().split("\n")
+        ]
+        assert len(messages) == 2
+        assert messages[0]["role"] == "agent"
+        assert messages[1]["role"] == "user"
+        assert "[timeout]" in messages[1]["text"]

--- a/gui/frontend/src/components/ChatPanel.tsx
+++ b/gui/frontend/src/components/ChatPanel.tsx
@@ -11,18 +11,17 @@ import { MessageSquare, Send } from "lucide-react";
 
 export default function ChatPanel({
   runId,
-  pendingAskUser,
+  pendingAskUsers,
   initialMessages,
 }: {
   runId: string;
-  pendingAskUser: AskUserPending | null;
+  pendingAskUsers: AskUserPending[];
   initialMessages?: ChatMessage[];
 }) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const respond = useRespondToAskUser(runId);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const lastPendingIdRef = useRef<string | null>(null);
   const seenIdsRef = useRef<Set<string>>(new Set());
 
   // Seed from persisted history when it arrives
@@ -40,36 +39,36 @@ export default function ChatPanel({
     });
   }, [initialMessages]);
 
-  // When a new pending question arrives, add it to the chat
+  // When new pending questions arrive, add them to the chat
   useEffect(() => {
-    if (!pendingAskUser) return;
-    if (lastPendingIdRef.current === pendingAskUser.request_id) return;
-    lastPendingIdRef.current = pendingAskUser.request_id;
+    if (pendingAskUsers.length === 0) return;
 
-    // Skip if already loaded from history
-    if (seenIdsRef.current.has(pendingAskUser.request_id)) return;
-    seenIdsRef.current.add(pendingAskUser.request_id);
-
-    setMessages((prev) => [
-      ...prev,
-      {
-        id: pendingAskUser.request_id,
+    const newMessages: ChatMessage[] = [];
+    for (const pending of pendingAskUsers) {
+      if (seenIdsRef.current.has(pending.request_id)) continue;
+      seenIdsRef.current.add(pending.request_id);
+      newMessages.push({
+        id: pending.request_id,
         role: "agent",
-        text: pendingAskUser.question,
-        timestamp: pendingAskUser.timestamp,
-      },
-    ]);
-  }, [pendingAskUser]);
+        text: pending.question,
+        timestamp: pending.timestamp,
+      });
+    }
+
+    if (newMessages.length > 0) {
+      setMessages((prev) => [...prev, ...newMessages]);
+    }
+  }, [pendingAskUsers]);
 
   // Auto-scroll on new messages
   useEffect(() => {
     scrollRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  const handleSend = async (text: string) => {
-    if (!text.trim() || !pendingAskUser) return;
+  const handleSend = async (text: string, target: AskUserPending) => {
+    if (!text.trim()) return;
 
-    const msgId = `user-${pendingAskUser.request_id}`;
+    const msgId = `user-${target.request_id}`;
     // Skip if already in history
     if (!seenIdsRef.current.has(msgId)) {
       seenIdsRef.current.add(msgId);
@@ -87,7 +86,7 @@ export default function ChatPanel({
 
     try {
       await respond.mutateAsync({
-        request_id: pendingAskUser.request_id,
+        request_id: target.request_id,
         text: text.trim(),
       });
     } catch {
@@ -95,9 +94,8 @@ export default function ChatPanel({
     }
   };
 
-  const handleChoiceClick = (choice: string) => {
-    handleSend(choice);
-  };
+  // The oldest pending question receives free-text input
+  const activePending = pendingAskUsers.length > 0 ? pendingAskUsers[0] : null;
 
   return (
     <Card className="flex h-[500px] flex-col">
@@ -113,58 +111,65 @@ export default function ChatPanel({
                 </p>
               </div>
             )}
-            {messages.map((msg) => (
-              <div
-                key={msg.id}
-                className={cn(
-                  "flex",
-                  msg.role === "user" ? "justify-end" : "justify-start",
-                )}
-              >
-                <div
-                  className={cn(
-                    "max-w-[80%] rounded-lg px-3 py-2 text-sm",
-                    msg.role === "user"
-                      ? "bg-primary text-primary-foreground"
-                      : "bg-muted",
+            {messages.map((msg) => {
+              const pending =
+                msg.role === "agent"
+                  ? pendingAskUsers.find((p) => p.request_id === msg.id)
+                  : undefined;
+              return (
+                <div key={msg.id}>
+                  <div
+                    className={cn(
+                      "flex",
+                      msg.role === "user" ? "justify-end" : "justify-start",
+                    )}
+                  >
+                    <div
+                      className={cn(
+                        "max-w-[80%] rounded-lg px-3 py-2 text-sm",
+                        msg.role === "user"
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-muted",
+                      )}
+                    >
+                      <p className="whitespace-pre-wrap">{msg.text}</p>
+                    </div>
+                  </div>
+                  {/* Inline choice buttons for pending questions */}
+                  {pending?.choices && pending.choices.length > 0 && (
+                    <div className="ml-3 mt-1 flex flex-wrap gap-1.5">
+                      {pending.choices.map((choice) => (
+                        <Button
+                          key={choice}
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleSend(choice, pending)}
+                          disabled={respond.isPending}
+                        >
+                          {choice}
+                        </Button>
+                      ))}
+                    </div>
                   )}
-                >
-                  <p className="whitespace-pre-wrap">{msg.text}</p>
                 </div>
-              </div>
-            ))}
+              );
+            })}
             <div ref={scrollRef} />
           </div>
         </ScrollArea>
 
-        {/* Pending indicator + choice buttons */}
-        {pendingAskUser && (
-          <div className="space-y-2">
-            <div className="flex items-center gap-2">
-              <Badge
-                variant="outline"
-                className="border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-400"
-              >
-                <span className="mr-1.5 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-amber-500" />
-                Waiting for response
-              </Badge>
-            </div>
-            {pendingAskUser.choices &&
-              pendingAskUser.choices.length > 0 && (
-                <div className="flex flex-wrap gap-1.5">
-                  {pendingAskUser.choices.map((choice) => (
-                    <Button
-                      key={choice}
-                      variant="outline"
-                      size="sm"
-                      onClick={() => handleChoiceClick(choice)}
-                      disabled={respond.isPending}
-                    >
-                      {choice}
-                    </Button>
-                  ))}
-                </div>
-              )}
+        {/* Pending indicator */}
+        {pendingAskUsers.length > 0 && (
+          <div className="flex items-center gap-2">
+            <Badge
+              variant="outline"
+              className="border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-400"
+            >
+              <span className="mr-1.5 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-amber-500" />
+              {pendingAskUsers.length === 1
+                ? "Waiting for response"
+                : `${pendingAskUsers.length} questions waiting`}
+            </Badge>
           </div>
         )}
 
@@ -173,23 +178,23 @@ export default function ChatPanel({
           className="flex gap-2"
           onSubmit={(e) => {
             e.preventDefault();
-            handleSend(input);
+            if (activePending) handleSend(input, activePending);
           }}
         >
           <Input
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder={
-              pendingAskUser
+              activePending
                 ? "Type your response..."
                 : "Waiting for agent question..."
             }
-            disabled={!pendingAskUser || respond.isPending}
+            disabled={!activePending || respond.isPending}
           />
           <Button
             type="submit"
             size="icon"
-            disabled={!pendingAskUser || !input.trim() || respond.isPending}
+            disabled={!activePending || !input.trim() || respond.isPending}
           >
             <Send className="h-4 w-4" />
           </Button>

--- a/gui/frontend/src/hooks/useAskUserSSE.ts
+++ b/gui/frontend/src/hooks/useAskUserSSE.ts
@@ -3,31 +3,38 @@ import type { AskUserPending, ChatMessage } from "@/api/types";
 
 /**
  * Listens to the session tree SSE for `ask_user`, `ask_user_resolved`,
- * and `chat_history` events. Returns the current pending question and
- * any persisted chat messages from previous connections.
+ * `chat_history`, and `stream_complete` events. Returns current pending
+ * questions and any persisted chat messages from previous connections.
+ *
+ * Connects for all interactive sessions (including completed ones) so
+ * that chat history is always available.
  */
 export function useAskUserSSE(
   runId: string,
   active: boolean,
-): { pendingAskUser: AskUserPending | null; chatMessages: ChatMessage[] } {
-  const [pendingAskUser, setPendingAskUser] = useState<AskUserPending | null>(
-    null,
-  );
+): { pendingAskUsers: AskUserPending[]; chatMessages: ChatMessage[] } {
+  const [pendingAskUsers, setPendingAskUsers] = useState<AskUserPending[]>([]);
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
   const esRef = useRef<EventSource | null>(null);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
   const backoffMs = useRef(1000);
+  // When true, the server signaled the stream is done (terminal session).
+  // Prevents reconnection loops for completed sessions.
+  const streamDoneRef = useRef(false);
 
   useEffect(() => {
     if (!active) {
-      setPendingAskUser(null);
+      setPendingAskUsers([]);
       setChatMessages([]);
+      streamDoneRef.current = false;
       return;
     }
 
     function connect() {
+      if (streamDoneRef.current) return;
+
       const es = new EventSource(`/api/sessions/${runId}/tree`);
       esRef.current = es;
 
@@ -49,19 +56,40 @@ export function useAskUserSSE(
       es.addEventListener("ask_user", (msg) => {
         try {
           const data = JSON.parse(msg.data) as AskUserPending;
-          setPendingAskUser(data);
+          setPendingAskUsers((prev) => {
+            if (prev.some((p) => p.request_id === data.request_id)) return prev;
+            return [...prev, data];
+          });
         } catch {
           /* ignore */
         }
       });
 
-      es.addEventListener("ask_user_resolved", () => {
-        setPendingAskUser(null);
+      es.addEventListener("ask_user_resolved", (msg) => {
+        try {
+          const data = JSON.parse(msg.data) as { request_id?: string };
+          if (data.request_id) {
+            setPendingAskUsers((prev) =>
+              prev.filter((p) => p.request_id !== data.request_id),
+            );
+          } else {
+            setPendingAskUsers([]);
+          }
+        } catch {
+          setPendingAskUsers([]);
+        }
+      });
+
+      es.addEventListener("stream_complete", () => {
+        streamDoneRef.current = true;
+        es.close();
+        esRef.current = null;
       });
 
       es.onerror = () => {
         es.close();
         esRef.current = null;
+        if (streamDoneRef.current) return;
         reconnectTimer.current = setTimeout(() => {
           backoffMs.current = Math.min(backoffMs.current * 2, 15000);
           connect();
@@ -78,5 +106,5 @@ export function useAskUserSSE(
     };
   }, [runId, active]);
 
-  return { pendingAskUser, chatMessages };
+  return { pendingAskUsers, chatMessages };
 }

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -70,17 +70,17 @@ export default function SessionDetail() {
 
   // SSE for interactive ask_user events
   const isInteractive = !!sessionData?.interactive;
-  const { pendingAskUser, chatMessages } = useAskUserSSE(
+  const { pendingAskUsers, chatMessages } = useAskUserSSE(
     runId ?? "",
-    active && isInteractive,
+    isInteractive,
   );
 
   // Auto-switch to Chat tab when a question arrives
   const [activeTab, setActiveTab] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    if (pendingAskUser) setActiveTab("chat");
-  }, [pendingAskUser]);
+    if (pendingAskUsers.length > 0) setActiveTab("chat");
+  }, [pendingAskUsers]);
 
   if (session.isLoading) {
     return <SessionDetailSkeleton />;
@@ -105,7 +105,7 @@ export default function SessionDetail() {
   const artifacts = extractArtifacts(displayEvents);
   const outputRef = extractOutputRef(displayEvents);
   const defaultTab =
-    searchParams.get("tab") ?? (active ? "agent-tree" : "overview");
+    searchParams.get("tab") ?? (!active ? "overview" : isInteractive ? "chat" : "agent-tree");
 
   return (
     <div className="space-y-6">
@@ -127,7 +127,7 @@ export default function SessionDetail() {
           {isInteractive && (
             <TabsTrigger value="chat" className="relative">
               Chat
-              {pendingAskUser && (
+              {pendingAskUsers.length > 0 && (
                 <span className="ml-1.5 inline-block h-2 w-2 animate-pulse rounded-full bg-amber-500" />
               )}
             </TabsTrigger>
@@ -187,7 +187,7 @@ export default function SessionDetail() {
           <TabsContent value="chat">
             <ChatPanel
               runId={sessionData.run_id}
-              pendingAskUser={pendingAskUser}
+              pendingAskUsers={pendingAskUsers}
               initialMessages={chatMessages}
             />
           </TabsContent>

--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -271,12 +271,15 @@ def _upsert_session(
         else:
             status = "stale"
 
+    # Detect interactive sessions by presence of chat_messages.jsonl
+    interactive = os.path.isfile(os.path.join(session_dir, "chat_messages.jsonl"))
+
     conn.execute(
         """INSERT OR REPLACE INTO sessions
            (run_id, project_id, role, runtime, isolation, status,
             started_at, ended_at, duration_ms, exit_code, session_dir,
-            task)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            task, interactive)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             run_id,
             project_id,
@@ -290,5 +293,6 @@ def _upsert_session(
             trace_info.get("exit_code"),
             session_dir,
             data.get("task"),
+            1 if interactive else 0,
         ),
     )

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -6,7 +6,7 @@ import re
 import signal
 import shutil
 import subprocess
-import time
+
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -609,20 +609,12 @@ def respond_to_ask_user(
         raise HTTPException(409, f"Session is not active (status: {row['status']})")
 
     session_dir = Path(row["session_dir"])
-    pending_path = session_dir / "ask_user_pending.json"
+    pending_path = session_dir / f"ask_user_pending_{body.request_id}.json"
 
     if not pending_path.is_file():
-        raise HTTPException(404, "No pending ask_user request")
+        raise HTTPException(404, "No pending ask_user request for this request_id")
 
-    try:
-        pending = json.loads(pending_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        raise HTTPException(500, "Failed to read pending request")
-
-    if pending.get("request_id") != body.request_id:
-        raise HTTPException(409, "request_id does not match pending request")
-
-    response_path = session_dir / "ask_user_response.json"
+    response_path = session_dir / f"ask_user_response_{body.request_id}.json"
     resp_data = {
         "request_id": body.request_id,
         "text": body.text,
@@ -632,17 +624,6 @@ def respond_to_ask_user(
     with open(tmp_path, "w", encoding="utf-8") as f:
         json.dump(resp_data, f, indent=2)
     os.replace(tmp_path, str(response_path))
-
-    # Persist the user message to chat history
-    chat_path = session_dir / "chat_messages.jsonl"
-    entry = json.dumps({
-        "id": f"user-{body.request_id}",
-        "role": "user",
-        "text": body.text,
-        "timestamp": time.time(),
-    })
-    with open(chat_path, "a", encoding="utf-8") as f:
-        f.write(entry + "\n")
 
     return {"ok": True}
 

--- a/gui/src/strawpot_gui/routers/sse.py
+++ b/gui/src/strawpot_gui/routers/sse.py
@@ -1,6 +1,7 @@
 """SSE streaming endpoints for real-time session monitoring."""
 
 import asyncio
+import glob
 import json
 import os
 
@@ -50,16 +51,20 @@ def _read_trace_lines(trace_path: str, offset: int) -> tuple[list[dict], int]:
     return events, new_offset
 
 
-def _append_chat_message(
-    session_dir: str, role: str, text: str, msg_id: str, timestamp: float
-) -> None:
-    """Append a chat message to the session's chat_messages.jsonl."""
-    path = os.path.join(session_dir, "chat_messages.jsonl")
-    entry = json.dumps(
-        {"id": msg_id, "role": role, "text": text, "timestamp": timestamp}
-    )
-    with open(path, "a", encoding="utf-8") as f:
-        f.write(entry + "\n")
+def _scan_pending_ask_users(session_dir: str) -> dict[str, dict]:
+    """Scan for all ask_user_pending_*.json files, return {request_id: data}."""
+    result: dict[str, dict] = {}
+    pattern = os.path.join(session_dir, "ask_user_pending_*.json")
+    for path in glob.glob(pattern):
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            req_id = data.get("request_id", "")
+            if req_id:
+                result[req_id] = data
+        except (OSError, json.JSONDecodeError):
+            pass
+    return result
 
 
 def _read_chat_messages(session_dir: str) -> list[dict]:
@@ -144,33 +149,26 @@ async def session_tree_sse(run_id: str, request: Request):
             event_id += 1
             yield format_sse_typed(event_id, "chat_history", {"messages": chat_messages})
 
-        # Track which ask_user IDs have already been persisted
-        persisted_ask_ids: set[str] = {m["id"] for m in chat_messages if m.get("role") == "agent"}
+        # Track pending ask_user request IDs for change detection
+        known_pending_ids: set[str] = set()
 
-        # Check for pending ask_user on initial connect
-        ask_user_path = os.path.join(session_dir, "ask_user_pending.json")
-        if os.path.isfile(ask_user_path):
-            try:
-                with open(ask_user_path, encoding="utf-8") as f:
-                    ask_data = json.load(f)
-                req_id = ask_data.get("request_id", "")
-                if req_id and req_id not in persisted_ask_ids:
-                    _append_chat_message(
-                        session_dir, "agent", ask_data.get("question", ""),
-                        req_id, ask_data.get("timestamp", 0),
-                    )
-                    persisted_ask_ids.add(req_id)
-                event_id += 1
-                yield format_sse_typed(event_id, "ask_user", ask_data)
-            except (OSError, json.JSONDecodeError):
-                pass
+        # Check for pending ask_user files on initial connect
+        pending_map = _scan_pending_ask_users(session_dir)
+        for req_id, ask_data in pending_map.items():
+            known_pending_ids.add(req_id)
+            event_id += 1
+            yield format_sse_typed(event_id, "ask_user", ask_data)
 
         # Terminal sessions: send final state and close
         if status in ("completed", "failed", "stopped"):
+            event_id += 1
+            yield format_sse_typed(event_id, "stream_complete", {})
             return
 
         # Trace already has session_end even though DB says running
         if state.is_terminal:
+            event_id += 1
+            yield format_sse_typed(event_id, "stream_complete", {})
             return
 
         # Active sessions: watch for file changes
@@ -219,32 +217,37 @@ async def session_tree_sse(run_id: str, request: Request):
 
                 # Detect ask_user bridge files
                 if any(
-                    f.endswith("ask_user_pending.json")
-                    or f.endswith("ask_user_response.json")
+                    "ask_user_pending_" in f or "ask_user_response_" in f
                     for f in changed_files
                 ):
-                    pending = os.path.join(session_dir, "ask_user_pending.json")
-                    if os.path.isfile(pending):
-                        try:
-                            with open(pending, encoding="utf-8") as f:
-                                ask_data = json.load(f)
-                            req_id = ask_data.get("request_id", "")
-                            if req_id and req_id not in persisted_ask_ids:
-                                _append_chat_message(
-                                    session_dir, "agent",
-                                    ask_data.get("question", ""),
-                                    req_id, ask_data.get("timestamp", 0),
-                                )
-                                persisted_ask_ids.add(req_id)
-                            event_id += 1
-                            yield format_sse_typed(event_id, "ask_user", ask_data)
-                        except (OSError, json.JSONDecodeError):
-                            pass
-                    else:
-                        # Pending file removed → question resolved
+                    current_pending = _scan_pending_ask_users(session_dir)
+                    current_ids = set(current_pending.keys())
+
+                    # New pending questions
+                    for req_id in current_ids - known_pending_ids:
                         event_id += 1
                         yield format_sse_typed(
-                            event_id, "ask_user_resolved", {}
+                            event_id, "ask_user", current_pending[req_id]
+                        )
+
+                    # Resolved questions
+                    for req_id in known_pending_ids - current_ids:
+                        event_id += 1
+                        yield format_sse_typed(
+                            event_id, "ask_user_resolved",
+                            {"request_id": req_id},
+                        )
+
+                    known_pending_ids = current_ids
+
+                # Re-send chat history when chat_messages.jsonl changes
+                if any(f.endswith("chat_messages.jsonl") for f in changed_files):
+                    updated_chat = _read_chat_messages(session_dir)
+                    if updated_chat:
+                        event_id += 1
+                        yield format_sse_typed(
+                            event_id, "chat_history",
+                            {"messages": updated_chat},
                         )
 
                 if changed:

--- a/gui/tests/test_ask_user_respond.py
+++ b/gui/tests/test_ask_user_respond.py
@@ -25,8 +25,8 @@ def _make_active_session(client, tmp_path, run_id="run_interactive"):
 
 
 def _write_pending(session_dir, request_id="abc123"):
-    """Write an ask_user_pending.json file."""
-    path = os.path.join(session_dir, "ask_user_pending.json")
+    """Write an ask_user_pending_<request_id>.json file."""
+    path = os.path.join(session_dir, f"ask_user_pending_{request_id}.json")
     with open(path, "w", encoding="utf-8") as f:
         json.dump({"request_id": request_id, "question": "Pick a color?"}, f)
     return path
@@ -63,7 +63,7 @@ class TestRespondToAskUser:
         assert resp.status_code == 404
 
     def test_request_id_mismatch(self, client, tmp_path):
-        """409 when request_id doesn't match pending."""
+        """404 when request_id doesn't match any pending file."""
         _, session_dir = _make_active_session(client, tmp_path, "run_mismatch")
         _write_pending(session_dir, request_id="correct_id")
 
@@ -71,7 +71,7 @@ class TestRespondToAskUser:
             "/api/sessions/run_mismatch/respond",
             json={"request_id": "wrong_id", "text": "hi"},
         )
-        assert resp.status_code == 409
+        assert resp.status_code == 404
 
     def test_successful_respond(self, client, tmp_path):
         """Successful response writes ask_user_response.json."""
@@ -86,7 +86,7 @@ class TestRespondToAskUser:
         assert resp.json() == {"ok": True}
 
         # Verify response file was written
-        response_path = os.path.join(session_dir, "ask_user_response.json")
+        response_path = os.path.join(session_dir, "ask_user_response_req123.json")
         assert os.path.isfile(response_path)
         with open(response_path, encoding="utf-8") as f:
             data = json.load(f)


### PR DESCRIPTION
## Summary
- **Per-request file naming**: `ask_user_pending_{id}.json` / `ask_user_response_{id}.json` to support concurrent ask_user requests from parallel sub-agents
- **CLI-side chat persistence**: Thread-safe `chat_messages.jsonl` writes in the bridge (agent questions, user answers, timeout fallbacks), removing dependency on SSE client being connected
- **SSE improvements**: Glob-based multi-file pending detection, live `chat_history` re-sends on file changes (fixes tab-switch wipe), `stream_complete` event to prevent reconnection loops for completed sessions
- **Frontend multi-question support**: Array-based `pendingAskUsers`, inline choice buttons per pending question, free-text input targets oldest pending
- **Interactive flag survives GUI restart**: `sync_sessions` detects interactive sessions by `chat_messages.jsonl` presence
- **Tab defaults**: Chat tab for active interactive sessions, Overview for completed sessions

## Test plan
- [x] All 549 CLI tests pass
- [x] All 233 GUI tests pass
- [ ] Launch interactive session, verify chat messages persist across tab switches
- [ ] Verify chat messages persist across page navigation (session list → session detail)
- [ ] Verify chat history survives GUI restart
- [ ] Test completed interactive session shows Chat tab with full history

🤖 Generated with [Claude Code](https://claude.com/claude-code)