### PR TITLE
Update docs to reflect interactive mode implementation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -61,10 +61,11 @@ src/strawpot/
     worktree.py            # WorktreeIsolator
   memory/
     registry.py            # Memory provider discovery and resolution
+  ask_user_bridge.py       # File-based ask_user bridge for GUI interactive sessions
   trace.py                 # Session tracing — JSONL events + content-addressed artifacts
 ```
 
-16 source files. No agent-specific code in the core — agents are installed
+17 source files. No agent-specific code in the core — agents are installed
 via StrawHub (e.g. `strawhub install agent strawpot_claude_code --global`).
 
 ---
@@ -791,12 +792,17 @@ provider is configured, returns an error response.
 
 | Mode | Handler | Wired in |
 |------|---------|----------|
-| All CLI modes | `_default_ask_user_handler` — returns `default_value` or auto-responds | `session.py` (default) |
+| Autonomous (default) | `_default_ask_user_handler` — returns `default_value` or auto-responds | `session.py` (default) |
+| Interactive (`STRAWPOT_ASK_USER_BRIDGE=file`) | `make_file_bridge_handler` — writes pending file, polls for response file | `ask_user_bridge.py` |
 
-All CLI modes (headless, task, interactive) use the default auto-respond
-handler. The orchestrator is an AI agent that can make decisions on
-behalf of the user. Interactive session support (GUI chat panel,
-ask_user bridge) is planned — see `gui/DESIGN.md`.
+Autonomous mode (headless, task, interactive terminal) uses the default
+auto-respond handler. When `STRAWPOT_ASK_USER_BRIDGE=file` is set (by
+the GUI for interactive sessions), `Session.start()` swaps in the file
+bridge handler which writes `ask_user_pending_{request_id}.json` to the
+session directory and polls for `ask_user_response_{request_id}.json`.
+Per-request file naming supports parallel sub-agents. Chat history is
+persisted to `chat_messages.jsonl` by the bridge (thread-safe). See
+`gui/DESIGN.md` for the GUI-side protocol.
 
 ### Headless Mode
 

--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -62,6 +62,7 @@ src/strawpot/
     worktree.py            # Git worktree isolator
   memory/
     registry.py            # Memory provider resolution
+  ask_user_bridge.py       # File-based ask_user bridge for GUI interactive sessions
 # Protocol types live in the external strawpot-memory package
 ```
 

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -74,6 +74,19 @@ as a subprocess.
 
 Headless mode requires `--task` (there is no interactive prompt).
 
+## Interactive Mode
+
+Sessions launched from the [web dashboard](/gui/index) can optionally enable
+**interactive mode**, which allows agents to ask the user questions via a chat
+panel. When enabled, `STRAWPOT_ASK_USER_BRIDGE=file` is set and the CLI writes
+`ask_user_pending_{id}.json` files to the session directory. The GUI detects
+these via SSE, displays the question in a chat panel, and writes back
+`ask_user_response_{id}.json`. Per-request file naming supports parallel
+sub-agents asking questions concurrently.
+
+Chat history is persisted to `chat_messages.jsonl` by the CLI bridge
+(thread-safe), surviving tab switches, page reloads, and GUI restarts.
+
 ## Crash Recovery
 
 If StrawPot crashes or is interrupted, sessions may be left in a stale state. On the next `strawpot start`, StrawPot automatically:

--- a/docs/gui/index.mdx
+++ b/docs/gui/index.mdx
@@ -23,7 +23,7 @@ Opens [http://localhost:8741](http://localhost:8741) in your browser.
     Register projects, upload context files, install resources, and launch sessions from a single page.
   </Card>
   <Card title="Session Detail" icon="list-tree">
-    View agent delegation trees, trace events, and live log output for any session.
+    View agent delegation trees, trace events, and live log output for any session. Interactive sessions include a chat panel for agent questions.
   </Card>
   <Card title="Scheduled Tasks" icon="clock">
     Create cron-based schedules that automatically launch sessions on a recurring basis.


### PR DESCRIPTION
## Summary

- Add `ask_user_bridge.py` to package structure in root `DESIGN.md` and `docs/concepts/architecture.mdx`
- Update handlers-by-mode table in `DESIGN.md` from "planned" to dual-mode (Autonomous / Interactive) with implementation details
- Add "Interactive Mode" section to `docs/concepts/sessions.mdx` documenting the file bridge protocol and chat persistence
- Update Session Detail card in `docs/gui/index.mdx` to mention the chat panel

## Test plan

- [ ] Verify Mintlify docs render correctly with the new sections
- [ ] Confirm no broken links in the new interactive mode references

🤖 Generated with [Claude Code](https://claude.com/claude-code)