### PR TITLE
Add chat-mode conversations (item 12)

### DIFF
--- a/gui/frontend/src/App.tsx
+++ b/gui/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Dashboard from "./pages/Dashboard";
 import ProjectList from "./pages/ProjectList";
 import ProjectDetail from "./pages/ProjectDetail";
 import SessionDetail from "./pages/SessionDetail";
+import ConversationView from "./pages/ConversationView";
 import ResourceBrowser from "./pages/ResourceBrowser";
 import ScheduledTasks from "./pages/ScheduledTasks";
 import Settings from "./pages/Settings";
@@ -22,6 +23,10 @@ export default function App() {
         <Route
           path="projects/:projectId/sessions/:runId"
           element={<SessionDetail />}
+        />
+        <Route
+          path="projects/:projectId/conversations/:conversationId"
+          element={<ConversationView />}
         />
         <Route path="schedules" element={<ScheduledTasks />} />
         <Route

--- a/gui/frontend/src/api/client.ts
+++ b/gui/frontend/src/api/client.ts
@@ -32,6 +32,9 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     const body = await res.json().catch(() => null);
     throw new ApiError(res.status, res.statusText, body);
   }
+  if (res.status === 204 || res.headers.get("content-length") === "0") {
+    return undefined as T;
+  }
   return res.json() as Promise<T>;
 }
 

--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -18,6 +18,8 @@ export interface Session {
   duration_ms: number | null;
   exit_code: number | null;
   task: string | null;
+  summary: string | null;
+  conversation_id: number | null;
 }
 
 export interface SessionList {
@@ -171,6 +173,44 @@ export interface ProjectStats {
   success_rate: number;
   avg_duration_ms: number | null;
   daily: DailyStats[];
+}
+
+export interface ConversationSession {
+  run_id: string;
+  task: string | null;
+  summary: string | null;
+  status: string;
+  exit_code: number | null;
+  started_at: string;
+  ended_at: string | null;
+  duration_ms: number | null;
+  role: string;
+}
+
+export interface Conversation {
+  id: number;
+  project_id: number;
+  title: string | null;
+  created_at: string;
+  updated_at: string | null;
+  sessions: ConversationSession[];
+}
+
+export interface ConversationListItem {
+  id: number;
+  project_id: number;
+  title: string | null;
+  created_at: string;
+  updated_at: string | null;
+  session_count: number;
+  last_activity: string | null;
+}
+
+export interface ConversationList {
+  items: ConversationListItem[];
+  total: number;
+  page: number;
+  per_page: number;
 }
 
 export interface Schedule {

--- a/gui/frontend/src/hooks/mutations/use-conversations.ts
+++ b/gui/frontend/src/hooks/mutations/use-conversations.ts
@@ -1,0 +1,90 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import { queryKeys } from "@/lib/query-keys";
+import type { Conversation, ConversationList } from "@/api/types";
+
+interface CreateConversationBody {
+  project_id: number;
+  title?: string;
+}
+
+interface SubmitTaskBody {
+  task: string;
+  role?: string;
+  context_files?: string[];
+  interactive?: boolean;
+  system_prompt?: string;
+  runtime?: string;
+  memory?: string;
+  max_num_delegations?: number;
+  cache_delegations?: boolean;
+  cache_max_entries?: number;
+  cache_ttl_seconds?: number;
+}
+
+export function useCreateConversation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateConversationBody) =>
+      api.post<Conversation>("/conversations", body),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({
+        queryKey: queryKeys.conversations.all(variables.project_id),
+      });
+    },
+  });
+}
+
+export function useSubmitConversationTask(conversationId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: SubmitTaskBody) =>
+      api.post<{ run_id: string; conversation_id: number }>(
+        `/conversations/${conversationId}/tasks`,
+        body,
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: queryKeys.conversations.detail(conversationId),
+      });
+      qc.invalidateQueries({ queryKey: ["sessions"] });
+    },
+  });
+}
+
+export function useRenameConversation(projectId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ conversationId, title }: { conversationId: number; title: string | null }) =>
+      api.patch<Conversation>(`/conversations/${conversationId}`, { title }),
+    onSuccess: (_data, { conversationId }) => {
+      qc.invalidateQueries({ queryKey: queryKeys.conversations.all(projectId) });
+      qc.invalidateQueries({ queryKey: queryKeys.conversations.detail(conversationId) });
+    },
+  });
+}
+
+export function useDeleteConversation(projectId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (conversationId: number) =>
+      api.delete(`/conversations/${conversationId}`),
+    onMutate: async (conversationId: number) => {
+      await qc.cancelQueries({ queryKey: queryKeys.conversations.all(projectId) });
+      const previous = qc.getQueryData<ConversationList>(queryKeys.conversations.all(projectId));
+      qc.setQueryData<ConversationList>(queryKeys.conversations.all(projectId), (old) => {
+        if (!old) return old;
+        return { ...old, items: old.items.filter((c) => c.id !== conversationId), total: old.total - 1 };
+      });
+      return { previous };
+    },
+    onError: (_err, _id, context) => {
+      if (context?.previous) {
+        qc.setQueryData(queryKeys.conversations.all(projectId), context.previous);
+      }
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.conversations.all(projectId) });
+    },
+  });
+}

--- a/gui/frontend/src/hooks/queries/use-conversations.ts
+++ b/gui/frontend/src/hooks/queries/use-conversations.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import { queryKeys } from "@/lib/query-keys";
+import type { Conversation, ConversationList } from "@/api/types";
+
+export function useConversation(
+  id: number,
+  options?: { refetchInterval?: number | false },
+) {
+  return useQuery({
+    queryKey: queryKeys.conversations.detail(id),
+    queryFn: () => api.get<Conversation>(`/conversations/${id}`),
+    ...options,
+  });
+}
+
+export function useProjectConversations(
+  projectId: number,
+  page = 1,
+  perPage = 20,
+) {
+  return useQuery({
+    queryKey: [...queryKeys.conversations.all(projectId), page, perPage],
+    queryFn: () =>
+      api.get<ConversationList>(
+        `/projects/${projectId}/conversations?page=${page}&per_page=${perPage}`,
+      ),
+    enabled: projectId > 0,
+  });
+}

--- a/gui/frontend/src/hooks/useGlobalSSE.ts
+++ b/gui/frontend/src/hooks/useGlobalSSE.ts
@@ -63,12 +63,17 @@ export function useGlobalSSE(): void {
 
           // Invalidate all session list queries
           qc.invalidateQueries({ queryKey: ["sessions"] });
-          // Invalidate specific project sessions if project_id present
+          // Invalidate specific project sessions and conversations if project_id present
           if (data.project_id) {
             qc.invalidateQueries({
               queryKey: queryKeys.projects.sessions(data.project_id),
             });
+            qc.invalidateQueries({
+              queryKey: queryKeys.conversations.all(data.project_id),
+            });
           }
+          // Invalidate active conversation detail views
+          qc.invalidateQueries({ queryKey: ["conversations", "detail"] });
         } catch {
           /* ignore */
         }

--- a/gui/frontend/src/layouts/AppLayout.tsx
+++ b/gui/frontend/src/layouts/AppLayout.tsx
@@ -1,9 +1,12 @@
-import { useState } from "react";
-import { Link, NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
+import { useRef, useState } from "react";
+import { Link, NavLink, Outlet, useLocation, useMatch, useNavigate } from "react-router-dom";
 import { useTheme } from "next-themes";
-import { LayoutDashboard, FolderKanban, Clock, Users, Wrench, Bot, Brain, Settings, Sun, Moon, Check, ChevronsUpDown } from "lucide-react";
+import { ArrowLeft, LayoutDashboard, FolderKanban, Clock, Users, Wrench, Bot, Brain, Pencil, Plus, Settings, Sun, Moon, Check, ChevronsUpDown, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useProject, useProjects } from "@/hooks/queries/use-projects";
+import { useProjectConversations } from "@/hooks/queries/use-conversations";
+import { useCreateConversation, useRenameConversation, useDeleteConversation } from "@/hooks/mutations/use-conversations";
+import { Input } from "@/components/ui/input";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import CommandPalette from "@/components/CommandPalette";
 import KeyboardShortcutsDialog from "@/components/KeyboardShortcutsDialog";
@@ -38,6 +41,171 @@ const resourceItems = [
   { to: "/resources/memories", label: "Memory", icon: Brain },
 ];
 
+interface ConvItem {
+  id: number;
+  title: string | null;
+  session_count?: number;
+}
+
+function ConversationSidebarItem({
+  conv,
+  projectId,
+  isActive,
+  navigate,
+}: {
+  conv: ConvItem;
+  projectId: number;
+  isActive: boolean;
+  navigate: ReturnType<typeof useNavigate>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const rename = useRenameConversation(projectId);
+  const del = useDeleteConversation(projectId);
+
+  const startEdit = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setDraft(conv.title ?? "");
+    setEditing(true);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  };
+
+  const save = () => {
+    const trimmed = draft.trim();
+    rename.mutate({ conversationId: conv.id, title: trimmed || null });
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <div className="px-1">
+        <Input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={save}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") { e.preventDefault(); save(); }
+            if (e.key === "Escape") { e.stopPropagation(); setEditing(false); }
+          }}
+          onClick={(e) => e.stopPropagation()}
+          className="h-7 text-xs px-2"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      className={cn(
+        "flex items-center gap-1 rounded-md px-2 py-1.5 transition-colors",
+        isActive
+          ? "bg-accent text-accent-foreground"
+          : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground",
+      )}
+    >
+      <button
+        onClick={() => navigate(`/projects/${projectId}/conversations/${conv.id}`)}
+        className="flex-1 min-w-0 text-left text-sm"
+      >
+        <span className="truncate block">{conv.title ?? `Conversation #${conv.id}`}</span>
+      </button>
+      {confirming ? (
+        <div className="flex items-center gap-1 shrink-0">
+          <button
+            onClick={(e) => { e.stopPropagation(); del.mutate(conv.id); setConfirming(false); }}
+            className="text-xs text-destructive hover:text-destructive/80 font-medium"
+            disabled={del.isPending}
+          >
+            Delete
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); setConfirming(false); }}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            No
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-0.5 shrink-0" style={{ opacity: hovered ? 1 : 0 }}>
+          <button
+            onClick={startEdit}
+            className="p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
+            title="Rename"
+          >
+            <Pencil className="h-3 w-3" />
+          </button>
+          {!isActive && (
+            <button
+              onClick={(e) => { e.stopPropagation(); setConfirming(true); }}
+              className="p-0.5 rounded text-muted-foreground hover:text-destructive transition-colors"
+              title="Delete"
+            >
+              <Trash2 className="h-3 w-3" />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConversationSidebar({ projectId, conversationId }: { projectId: number; conversationId: number }) {
+  const navigate = useNavigate();
+  const conversations = useProjectConversations(projectId, 1, 50);
+  const createConversation = useCreateConversation();
+  const project = useProject(projectId);
+
+  return (
+    <aside className="flex w-56 flex-col border-r border-border bg-card">
+      <div className="flex h-14 items-center border-b border-border px-4">
+        <Link to="/" className="text-lg font-bold tracking-tight hover:text-foreground/80">StrawPot</Link>
+      </div>
+      <div className="flex flex-col gap-1 p-3 flex-1 min-h-0">
+        <button
+          onClick={() => navigate(`/projects/${projectId}`)}
+          className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4 shrink-0" />
+          <span className="truncate">{project.data?.display_name ?? "Back to Project"}</span>
+        </button>
+
+        <div className="flex items-center justify-between px-3 pt-2 pb-1">
+          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">Conversations</span>
+          <button
+            onClick={() => createConversation.mutate(
+              { project_id: projectId },
+              { onSuccess: (conv) => navigate(`/projects/${projectId}/conversations/${conv.id}`) }
+            )}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+            title="New conversation"
+          >
+            <Plus className="h-3.5 w-3.5" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto space-y-0.5">
+          {(conversations.data?.items ?? []).map((conv) => (
+            <ConversationSidebarItem
+              key={conv.id}
+              conv={conv}
+              projectId={projectId}
+              isActive={conv.id === conversationId}
+              navigate={navigate}
+            />
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
 function useBreadcrumbs() {
   const location = useLocation();
   const segments = location.pathname.split("/").filter(Boolean);
@@ -59,6 +227,8 @@ function useBreadcrumbs() {
 
       if (segments[2] === "sessions" && segments[3]) {
         crumbs.push({ label: `Session ${segments[3].slice(0, 8)}…` });
+      } else if (segments[2] === "conversations" && segments[3]) {
+        crumbs.push({ label: `Conversation #${segments[3]}` });
       }
     }
   }
@@ -95,6 +265,9 @@ export default function AppLayout() {
   const { setTheme } = useTheme();
   const [cmdOpen, setCmdOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const convMatch = useMatch("/projects/:projectId/conversations/:conversationId");
+  const convProjectId = convMatch ? Number(convMatch.params.projectId) : 0;
+  const convId = convMatch ? Number(convMatch.params.conversationId) : 0;
 
   useKeyboardShortcuts({
     onCommandPalette: () => setCmdOpen(true),
@@ -102,55 +275,58 @@ export default function AppLayout() {
   });
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex h-screen">
       {/* Sidebar */}
-      <aside className="flex w-56 flex-col border-r border-border bg-card">
-        <div className="flex h-14 items-center border-b border-border px-4">
-          <Link to="/" className="text-lg font-bold tracking-tight hover:text-foreground/80">StrawPot</Link>
-        </div>
-        <nav className="flex flex-col gap-1 p-3">
-          {navItems.map(({ to, label, icon: Icon, end }) => (
-            <NavLink
-              key={to}
-              to={to}
-              end={end}
-              className={({ isActive }) =>
-                cn(
-                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                  isActive
-                    ? "bg-accent text-accent-foreground"
-                    : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground",
-                )
-              }
-            >
-              <Icon className="h-4 w-4" />
-              {label}
-            </NavLink>
-          ))}
-
-          <div className="mt-4 mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">
-            Resources
+      {convMatch ? (
+        <ConversationSidebar projectId={convProjectId} conversationId={convId} />
+      ) : (
+        <aside className="flex w-56 flex-col border-r border-border bg-card">
+          <div className="flex h-14 items-center border-b border-border px-4">
+            <Link to="/" className="text-lg font-bold tracking-tight hover:text-foreground/80">StrawPot</Link>
           </div>
-          {resourceItems.map(({ to, label, icon: Icon }) => (
-            <NavLink
-              key={to}
-              to={to}
-              className={({ isActive }) =>
-                cn(
-                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                  isActive
-                    ? "bg-accent text-accent-foreground"
-                    : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground",
-                )
-              }
-            >
-              <Icon className="h-4 w-4" />
-              {label}
-            </NavLink>
-          ))}
-        </nav>
+          <nav className="flex flex-col gap-1 p-3">
+            {navItems.map(({ to, label, icon: Icon, end }) => (
+              <NavLink
+                key={to}
+                to={to}
+                end={end}
+                className={({ isActive }) =>
+                  cn(
+                    "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    isActive
+                      ? "bg-accent text-accent-foreground"
+                      : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground",
+                  )
+                }
+              >
+                <Icon className="h-4 w-4" />
+                {label}
+              </NavLink>
+            ))}
 
-      </aside>
+            <div className="mt-4 mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">
+              Resources
+            </div>
+            {resourceItems.map(({ to, label, icon: Icon }) => (
+              <NavLink
+                key={to}
+                to={to}
+                className={({ isActive }) =>
+                  cn(
+                    "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    isActive
+                      ? "bg-accent text-accent-foreground"
+                      : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground",
+                  )
+                }
+              >
+                <Icon className="h-4 w-4" />
+                {label}
+              </NavLink>
+            ))}
+          </nav>
+        </aside>
+      )}
 
       {/* Main content */}
       <div className="flex flex-1 flex-col">

--- a/gui/frontend/src/lib/query-keys.ts
+++ b/gui/frontend/src/lib/query-keys.ts
@@ -37,4 +37,8 @@ export const queryKeys = {
     detail: (id: number) => ["schedules", id] as const,
     history: (id: number) => ["schedules", id, "history"] as const,
   },
+  conversations: {
+    all: (projectId: number) => ["conversations", projectId] as const,
+    detail: (id: number) => ["conversations", "detail", id] as const,
+  },
 };

--- a/gui/frontend/src/pages/ConversationView.tsx
+++ b/gui/frontend/src/pages/ConversationView.tsx
@@ -1,0 +1,502 @@
+import { useEffect, useRef, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useConversation } from "@/hooks/queries/use-conversations";
+import { useSubmitConversationTask, useRenameConversation } from "@/hooks/mutations/use-conversations";
+import { useStopSession } from "@/hooks/mutations/use-sessions";
+import { useRoles } from "@/hooks/queries/use-roles";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useResources } from "@/hooks/queries/use-registry";
+import { useProjectConfig } from "@/hooks/queries/use-projects";
+import { AlertCircle, CheckCircle2, CornerDownLeft, ExternalLink, Loader2, Settings, Square, XCircle } from "lucide-react";
+import type { ConversationSession } from "@/api/types";
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return "";
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return rem > 0 ? `${m}m ${rem}s` : `${m}m`;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === "running" || status === "starting") {
+    return (
+      <Badge variant="outline" className="gap-1 border-blue-200 text-blue-700 dark:border-blue-800 dark:text-blue-400">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        {status === "starting" ? "Starting" : "Running"}
+      </Badge>
+    );
+  }
+  if (status === "completed") {
+    return (
+      <Badge variant="outline" className="gap-1 border-green-200 text-green-700 dark:border-green-800 dark:text-green-400">
+        <CheckCircle2 className="h-3 w-3" />
+        Completed
+      </Badge>
+    );
+  }
+  if (status === "failed") {
+    return (
+      <Badge variant="outline" className="gap-1 border-red-200 text-red-700 dark:border-red-800 dark:text-red-400">
+        <XCircle className="h-3 w-3" />
+        Failed
+      </Badge>
+    );
+  }
+  return <Badge variant="outline">{status}</Badge>;
+}
+
+function AgentMessage({
+  session,
+  projectId,
+}: {
+  session: ConversationSession;
+  projectId: number;
+}) {
+  const isActive = session.status === "running" || session.status === "starting";
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium text-muted-foreground">Agent</span>
+        <StatusBadge status={session.status} />
+        {session.duration_ms !== null && (
+          <span className="text-xs text-muted-foreground">
+            {formatDuration(session.duration_ms)}
+          </span>
+        )}
+        <span className="text-xs text-muted-foreground">{session.role}</span>
+      </div>
+      <div className="rounded-lg border border-border bg-muted/30 p-3 text-sm">
+        {isActive ? (
+          <span className="flex items-center gap-2 text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Working…
+          </span>
+        ) : session.summary ? (
+          <p className="whitespace-pre-wrap text-foreground">{session.summary}</p>
+        ) : (
+          <span className="text-muted-foreground italic">
+            {session.status === "failed" ? "Session failed without output." : session.status === "stopped" ? "Interrupted." : "No summary available."}
+          </span>
+        )}
+      </div>
+      <Link
+        to={`/projects/${projectId}/sessions/${session.run_id}`}
+        className="flex w-fit items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+      >
+        <ExternalLink className="h-3 w-3" />
+        View session
+      </Link>
+    </div>
+  );
+}
+
+function UserMessage({ task }: { task: string }) {
+  return (
+    <div className="flex flex-col gap-1.5 items-end">
+      <span className="text-xs font-medium text-muted-foreground">You</span>
+      <div className="max-w-[80%] rounded-lg bg-primary px-3 py-2 text-sm text-primary-foreground">
+        <p className="whitespace-pre-wrap">{task}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function ConversationView() {
+  const { projectId, conversationId } = useParams();
+  const pid = Number(projectId);
+  const cid = Number(conversationId);
+  const [task, setTask] = useState("");
+  const [role, setRole] = useState("");
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState("");
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  // Advanced settings (persist across submissions)
+  const [advRuntime, setAdvRuntime] = useState("");
+  const [advMemory, setAdvMemory] = useState("");
+  const [advSystemPrompt, setAdvSystemPrompt] = useState("");
+  const [advMaxDelegations, setAdvMaxDelegations] = useState("");
+  const [advCacheDelegations, setAdvCacheDelegations] = useState("");
+  const [advCacheMaxEntries, setAdvCacheMaxEntries] = useState("");
+  const [advCacheTtl, setAdvCacheTtl] = useState("");
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const titleInputRef = useRef<HTMLInputElement>(null);
+
+  const roles = useRoles();
+  const { data: agents } = useResources("agents");
+  const { data: memories } = useResources("memories");
+  const config = useProjectConfig(pid);
+  const defaults = config.data?.merged as {
+    runtime?: string; memory?: string;
+    cache_delegations?: boolean; cache_max_entries?: number;
+    cache_ttl_seconds?: number; max_num_delegations?: number;
+  } | undefined;
+
+  // Initial load — no polling yet
+  const { data: conversation, error } = useConversation(cid);
+
+  // Poll while any session is active
+  const hasActiveSession = conversation?.sessions.some(
+    (s) => s.status === "running" || s.status === "starting",
+  ) ?? false;
+  useConversation(cid, { refetchInterval: hasActiveSession ? 2000 : false });
+
+  const submit = useSubmitConversationTask(cid);
+  const stop = useStopSession();
+  const rename = useRenameConversation(pid);
+
+  const roleError =
+    role.trim() && !(roles.data ?? []).includes(role.trim())
+      ? "Role not found in installed roles"
+      : "";
+
+  const lastSession = conversation?.sessions[conversation.sessions.length - 1];
+  const isActive =
+    lastSession?.status === "running" || lastSession?.status === "starting";
+
+  // Auto-scroll when a new session is added or the last session's content changes
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [conversation?.sessions.length, lastSession?.summary, lastSession?.status]);
+
+  const agentNames = (agents ?? []).map((a: { name: string }) => a.name);
+  const memoryNames = [...new Set((memories ?? []).map((m: { name: string }) => m.name)), "none"].sort();
+
+  const advRuntimeError = advRuntime.trim() && agentNames.length > 0 && !agentNames.includes(advRuntime.trim())
+    ? "Runtime not found in installed agents" : "";
+  const advMemoryError = advMemory.trim() && memoryNames.length > 0 && !memoryNames.includes(advMemory.trim())
+    ? "Memory not found in installed providers" : "";
+  const hasAdvError = !!advRuntimeError || !!advMemoryError;
+
+  // Count active advanced settings for badge indicator
+  const advCount = [advRuntime, advMemory, advSystemPrompt, advMaxDelegations, advCacheDelegations, advCacheMaxEntries, advCacheTtl]
+    .filter(v => v.trim()).length;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = task.trim();
+    if (!trimmed || isActive || !!roleError || hasAdvError) return;
+    const body: Parameters<typeof submit.mutate>[0] = {
+      task: trimmed,
+      role: role.trim() || undefined,
+      system_prompt: advSystemPrompt.trim() || undefined,
+      runtime: advRuntime.trim() || undefined,
+      memory: advMemory.trim() || undefined,
+      max_num_delegations: advMaxDelegations.trim() ? Number(advMaxDelegations) : undefined,
+      cache_delegations: advCacheDelegations ? advCacheDelegations === "true" : undefined,
+      cache_max_entries: advCacheMaxEntries.trim() ? Number(advCacheMaxEntries) : undefined,
+      cache_ttl_seconds: advCacheTtl.trim() ? Number(advCacheTtl) : undefined,
+    };
+    submit.mutate(
+      body,
+      { onSuccess: () => setTask("") },
+    );
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e as unknown as React.FormEvent);
+    }
+  }
+
+  function startEditTitle() {
+    setTitleDraft(conversation?.title ?? "");
+    setEditingTitle(true);
+    setTimeout(() => titleInputRef.current?.select(), 0);
+  }
+
+  function commitTitle() {
+    const trimmed = titleDraft.trim();
+    rename.mutate({ conversationId: cid, title: trimmed || null });
+    setEditingTitle(false);
+  }
+
+  function handleTitleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") { e.preventDefault(); commitTitle(); }
+    if (e.key === "Escape") { setEditingTitle(false); }
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 text-destructive">
+        <AlertCircle className="h-4 w-4" />
+        <span>Error: {(error as Error).message}</span>
+      </div>
+    );
+  }
+
+  const title = conversation?.title ?? `Conversation #${cid}`;
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex flex-shrink-0 items-center justify-between border-b border-border pb-3 mb-4">
+        <div className="flex items-center gap-3">
+          {editingTitle ? (
+            <Input
+              ref={titleInputRef}
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              onBlur={commitTitle}
+              onKeyDown={handleTitleKeyDown}
+              className="h-7 text-sm font-semibold w-64"
+              placeholder={`Conversation #${cid}`}
+            />
+          ) : (
+            <h1
+              className="text-sm font-semibold cursor-pointer hover:text-muted-foreground"
+              onClick={startEditTitle}
+              title="Click to rename"
+            >
+              {title}
+            </h1>
+          )}
+        </div>
+        {conversation && (
+          <span className="text-xs text-muted-foreground">
+            {conversation.sessions.length} session{conversation.sessions.length !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+
+      {/* Message list — scrolls within this container */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto w-full max-w-2xl space-y-6 py-4">
+          {conversation?.sessions.length === 0 && (
+            <p className="text-center text-sm text-muted-foreground py-12">
+              Start the conversation by submitting a task below.
+            </p>
+          )}
+          {conversation?.sessions.map((session) => (
+            <div key={session.run_id} className="space-y-4">
+              {session.task && <UserMessage task={session.task} />}
+              <AgentMessage session={session} projectId={pid} />
+            </div>
+          ))}
+          <div ref={messagesEndRef} />
+        </div>
+      </div>
+
+      {/* Task input */}
+      <div className="flex-shrink-0 border-t border-border bg-background pt-4">
+        <form onSubmit={handleSubmit} className="mx-auto max-w-2xl space-y-2">
+          <Textarea
+            value={task}
+            onChange={(e) => setTask(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={
+              isActive
+                ? "Agent is working…"
+                : "Describe the next task… (Enter to submit, Shift+Enter for new line)"
+            }
+            disabled={isActive || submit.isPending}
+            className="h-[80px] resize-none overflow-y-auto"
+            autoFocus
+          />
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex flex-col gap-1">
+                <Input
+                  list="datalist-role"
+                  value={role}
+                  onChange={(e) => setRole(e.target.value)}
+                  placeholder="Default role"
+                  className="w-48 text-sm"
+                />
+                {roleError && (
+                  <p className="text-xs text-destructive">{roleError}</p>
+                )}
+              </div>
+              <datalist id="datalist-role">
+                {(roles.data ?? []).map((r) => (
+                  <option key={r} value={r} />
+                ))}
+              </datalist>
+              <div className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="relative h-8 w-8 text-muted-foreground hover:text-foreground"
+                  onClick={() => setSettingsOpen(true)}
+                  title="Advanced options"
+                >
+                  <Settings className="h-4 w-4" />
+                  {advCount > 0 && (
+                    <span className="absolute -right-0.5 -top-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-primary text-[9px] text-primary-foreground">
+                      {advCount}
+                    </span>
+                  )}
+                </Button>
+                {isActive ? (
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={() => lastSession && stop.mutate(lastSession.run_id)}
+                    disabled={stop.isPending}
+                  >
+                    {stop.isPending ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <Square className="mr-2 h-4 w-4 fill-current" />
+                    )}
+                    Stop
+                  </Button>
+                ) : (
+                  <Button
+                    type="submit"
+                    disabled={!task.trim() || submit.isPending || !!roleError || hasAdvError}
+                  >
+                    {submit.isPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <CornerDownLeft className="h-4 w-4" />
+                    )}
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+
+      {/* Advanced settings dialog */}
+      <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Advanced Options</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Runtime</Label>
+                <Input
+                  list="adv-datalist-runtime"
+                  value={advRuntime}
+                  onChange={(e) => setAdvRuntime(e.target.value)}
+                  placeholder={defaults?.runtime ?? "default"}
+                  className="text-sm"
+                />
+                <datalist id="adv-datalist-runtime">
+                  {agentNames.map((n) => <option key={n} value={n} />)}
+                </datalist>
+                {advRuntimeError && <p className="text-xs text-destructive">{advRuntimeError}</p>}
+              </div>
+              <div className="space-y-2">
+                <Label>Memory</Label>
+                <Input
+                  list="adv-datalist-memory"
+                  value={advMemory}
+                  onChange={(e) => setAdvMemory(e.target.value)}
+                  placeholder={defaults?.memory ?? "dial"}
+                  className="text-sm"
+                />
+                <datalist id="adv-datalist-memory">
+                  {memoryNames.map((n) => <option key={n} value={n} />)}
+                </datalist>
+                {advMemoryError && <p className="text-xs text-destructive">{advMemoryError}</p>}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>System Prompt</Label>
+              <Textarea
+                value={advSystemPrompt}
+                onChange={(e) => setAdvSystemPrompt(e.target.value)}
+                placeholder="Additional instructions appended to conversation context…"
+                rows={3}
+                className="text-sm"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Max Delegations</Label>
+                <Input
+                  type="number"
+                  min="0"
+                  value={advMaxDelegations}
+                  onChange={(e) => setAdvMaxDelegations(e.target.value)}
+                  placeholder={defaults?.max_num_delegations ? String(defaults.max_num_delegations) : "0 (unlimited)"}
+                  className="h-8 text-xs"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Cache Delegations</Label>
+                <Select
+                  value={advCacheDelegations || "__empty__"}
+                  onValueChange={(v) => setAdvCacheDelegations(v === "__empty__" ? "" : v)}
+                >
+                  <SelectTrigger className="h-8 text-xs">
+                    <SelectValue placeholder={`Default (${defaults?.cache_delegations !== false ? "true" : "false"})`} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__empty__" className="text-muted-foreground">
+                      Default ({defaults?.cache_delegations !== false ? "true" : "false"})
+                    </SelectItem>
+                    <SelectItem value="true">true</SelectItem>
+                    <SelectItem value="false">false</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Cache Max Entries</Label>
+                <Input
+                  type="number"
+                  min="0"
+                  value={advCacheMaxEntries}
+                  onChange={(e) => setAdvCacheMaxEntries(e.target.value)}
+                  placeholder={defaults?.cache_max_entries ? String(defaults.cache_max_entries) : "0 (unlimited)"}
+                  className="h-8 text-xs"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Cache TTL (seconds)</Label>
+                <Input
+                  type="number"
+                  min="0"
+                  value={advCacheTtl}
+                  onChange={(e) => setAdvCacheTtl(e.target.value)}
+                  placeholder={defaults?.cache_ttl_seconds ? String(defaults.cache_ttl_seconds) : "0 (unlimited)"}
+                  className="h-8 text-xs"
+                />
+              </div>
+            </div>
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setAdvRuntime(""); setAdvMemory(""); setAdvSystemPrompt("");
+                setAdvMaxDelegations(""); setAdvCacheDelegations("");
+                setAdvCacheMaxEntries(""); setAdvCacheTtl("");
+              }}
+            >
+              Reset
+            </Button>
+            <Button size="sm" onClick={() => setSettingsOpen(false)}>Done</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/gui/frontend/src/pages/ProjectDetail.tsx
+++ b/gui/frontend/src/pages/ProjectDetail.tsx
@@ -1,8 +1,10 @@
-import { useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { useRef, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { useProject } from "@/hooks/queries/use-projects";
 import { useProjectSessions } from "@/hooks/queries/use-sessions";
 import { useProjectResources } from "@/hooks/queries/use-project-resources";
+import { useProjectConversations } from "@/hooks/queries/use-conversations";
+import { useCreateConversation, useDeleteConversation, useRenameConversation } from "@/hooks/mutations/use-conversations";
 import Pagination from "@/components/Pagination";
 import SessionTable from "@/components/SessionTable";
 import LaunchDialog from "@/components/LaunchDialog";
@@ -12,15 +14,141 @@ import { ProjectActivityTab } from "@/components/ProjectActivityTab";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import {
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from "@/components/ui/tabs";
-import { AlertCircle, ArrowLeft, Download, Play } from "lucide-react";
+import { AlertCircle, ArrowLeft, Download, MessageSquare, Pencil, Play, Trash2 } from "lucide-react";
 import InstallDialog from "@/components/InstallDialog";
 import ProjectDetailSkeleton from "@/components/skeletons/ProjectDetailSkeleton";
+
+function EditableTitleCell({
+  projectId,
+  conversationId,
+  title,
+  fallback,
+}: {
+  projectId: number;
+  conversationId: number;
+  title: string | null;
+  fallback: string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const rename = useRenameConversation(projectId);
+
+  function start(e: React.MouseEvent) {
+    e.stopPropagation();
+    setDraft(title ?? "");
+    setEditing(true);
+    setTimeout(() => inputRef.current?.select(), 0);
+  }
+
+  function commit(e: React.SyntheticEvent) {
+    e.stopPropagation();
+    const trimmed = draft.trim();
+    rename.mutate({ conversationId, title: trimmed || null });
+    setEditing(false);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") { e.preventDefault(); commit(e); }
+    if (e.key === "Escape") { e.stopPropagation(); setEditing(false); }
+  }
+
+  if (editing) {
+    return (
+      <Input
+        ref={inputRef}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={handleKeyDown}
+        onClick={(e) => e.stopPropagation()}
+        className="h-7 text-sm font-medium w-full"
+        placeholder={fallback}
+      />
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1.5 group">
+      <span className="font-medium">{title ?? fallback}</span>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-5 w-5 text-muted-foreground hover:text-foreground"
+        onClick={start}
+        aria-label="Rename"
+      >
+        <Pencil className="h-3 w-3" />
+      </Button>
+    </div>
+  );
+}
+
+function DeleteConversationButton({
+  projectId,
+  conversationId,
+  label,
+}: {
+  projectId: number;
+  conversationId: number;
+  label: string;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const deleteConversation = useDeleteConversation(projectId);
+
+  if (confirming) {
+    return (
+      <div className="flex justify-end gap-1" onClick={(e) => e.stopPropagation()}>
+        <Button
+          size="sm"
+          variant="destructive"
+          disabled={deleteConversation.isPending}
+          onClick={(e) => {
+            e.stopPropagation();
+            deleteConversation.mutate(conversationId, {
+              onSuccess: () => setConfirming(false),
+              onError: () => setConfirming(false),
+            });
+          }}
+        >
+          Confirm
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={(e) => {
+            e.stopPropagation();
+            setConfirming(false);
+          }}
+        >
+          No
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-7 w-7 text-muted-foreground hover:text-destructive"
+      onClick={(e) => {
+        e.stopPropagation();
+        setConfirming(true);
+      }}
+      aria-label={`Delete ${label}`}
+    >
+      <Trash2 className="h-3.5 w-3.5" />
+    </Button>
+  );
+}
 
 const TYPE_LABELS: Record<string, string> = {
   roles: "Role",
@@ -32,13 +160,17 @@ const TYPE_LABELS: Record<string, string> = {
 export default function ProjectDetail() {
   const { projectId } = useParams();
   const pid = Number(projectId);
+  const navigate = useNavigate();
   const project = useProject(pid);
   const [sessionPage, setSessionPage] = useState(1);
+  const [conversationPage] = useState(1);
   const sessions = useProjectSessions(pid, sessionPage);
   const resources = useProjectResources(pid);
+  const conversations = useProjectConversations(pid, conversationPage);
+  const createConversation = useCreateConversation();
   const [launchOpen, setLaunchOpen] = useState(false);
   const [installOpen, setInstallOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState("sessions");
+  const [activeTab, setActiveTab] = useState("conversations");
 
   const loading = project.isLoading || sessions.isLoading;
   const error = project.error || sessions.error;
@@ -80,7 +212,22 @@ export default function ProjectDetail() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-tight">{p.display_name}</h1>
         <div className="flex gap-2">
-          <Button onClick={() => setLaunchOpen(true)} disabled={!p.dir_exists}>
+          <Button
+            disabled={!p.dir_exists || createConversation.isPending}
+            onClick={() => {
+              createConversation.mutate(
+                { project_id: pid },
+                {
+                  onSuccess: (conv) =>
+                    navigate(`/projects/${pid}/conversations/${conv.id}`),
+                },
+              );
+            }}
+          >
+            <MessageSquare className="mr-2 h-4 w-4" />
+            New Conversation
+          </Button>
+          <Button variant="outline" onClick={() => setLaunchOpen(true)} disabled={!p.dir_exists}>
             <Play className="mr-2 h-4 w-4" />
             Launch Session
           </Button>
@@ -161,6 +308,9 @@ export default function ProjectDetail() {
 
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList>
+          <TabsTrigger value="conversations">
+            Conversations ({conversations.data?.total ?? 0})
+          </TabsTrigger>
           <TabsTrigger value="sessions">
             Sessions ({sessionTotal})
           </TabsTrigger>
@@ -189,6 +339,64 @@ export default function ProjectDetail() {
                 onPageChange={setSessionPage}
               />
             </>
+          )}
+        </TabsContent>
+
+        <TabsContent value="conversations" className="mt-4 space-y-3">
+          {(conversations.data?.items ?? []).length === 0 ? (
+            <p className="text-sm italic text-muted-foreground">
+              No conversations yet. Click "New Conversation" to start one.
+            </p>
+          ) : (
+            <Card>
+              <CardContent className="p-0">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border text-left text-xs text-muted-foreground">
+                      <th className="px-4 py-2 font-medium">Title</th>
+                      <th className="px-4 py-2 font-medium">Sessions</th>
+                      <th className="px-4 py-2 font-medium">Last activity</th>
+                      <th className="px-4 py-2" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(conversations.data?.items ?? []).map((conv) => (
+                      <tr
+                        key={conv.id}
+                        className="cursor-pointer border-b border-border last:border-0 hover:bg-muted/50"
+                        onClick={() =>
+                          navigate(`/projects/${pid}/conversations/${conv.id}`)
+                        }
+                      >
+                        <td className="px-4 py-2">
+                          <EditableTitleCell
+                            projectId={pid}
+                            conversationId={conv.id}
+                            title={conv.title}
+                            fallback={`Conversation #${conv.id}`}
+                          />
+                        </td>
+                        <td className="px-4 py-2 text-muted-foreground">
+                          {conv.session_count}
+                        </td>
+                        <td className="px-4 py-2 text-muted-foreground">
+                          {conv.last_activity
+                            ? new Date(conv.last_activity).toLocaleString()
+                            : "—"}
+                        </td>
+                        <td className="px-4 py-2 text-right">
+                          <DeleteConversationButton
+                            projectId={pid}
+                            conversationId={conv.id}
+                            label={conv.title ?? `Conversation #${conv.id}`}
+                          />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </CardContent>
+            </Card>
           )}
         </TabsContent>
 

--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -18,7 +18,7 @@ from strawpot_gui.event_bus import event_bus
 from strawpot_gui.scheduler import Scheduler
 
 logger = logging.getLogger(__name__)
-from strawpot_gui.routers import config, files, fs, health, logs, project_resources, projects, registry, schedules, sessions, sse, stats
+from strawpot_gui.routers import config, conversations, files, fs, health, logs, project_resources, projects, registry, schedules, sessions, sse, stats
 
 
 def _auto_rebuild_frontend(dist_dir: Path) -> None:
@@ -96,6 +96,7 @@ def create_app(db_path: str | None = None) -> FastAPI:
 
     app.include_router(health.router)
     app.include_router(projects.router)
+    app.include_router(conversations.router)
     app.include_router(config.router)
     app.include_router(files.router)
     app.include_router(sessions.router)

--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -19,6 +19,16 @@ CREATE TABLE IF NOT EXISTS projects (
     created_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+CREATE TABLE IF NOT EXISTS conversations (
+    id          INTEGER PRIMARY KEY,
+    project_id  INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    title       TEXT,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_project ON conversations(project_id, created_at DESC);
+
 CREATE TABLE IF NOT EXISTS sessions (
     run_id      TEXT PRIMARY KEY,
     project_id  INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
@@ -32,7 +42,9 @@ CREATE TABLE IF NOT EXISTS sessions (
     exit_code   INTEGER,
     session_dir TEXT NOT NULL,
     task        TEXT,
-    schedule_id INTEGER REFERENCES scheduled_tasks(id) ON DELETE SET NULL
+    summary     TEXT,
+    schedule_id INTEGER REFERENCES scheduled_tasks(id) ON DELETE SET NULL,
+    conversation_id INTEGER REFERENCES conversations(id) ON DELETE SET NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id, started_at DESC);
@@ -106,6 +118,27 @@ def _migrate(conn: sqlite3.Connection) -> None:
     except sqlite3.OperationalError:
         pass  # Column already exists
 
+    # Add summary column to sessions (added 2026-03-11)
+    try:
+        conn.execute("ALTER TABLE sessions ADD COLUMN summary TEXT")
+    except sqlite3.OperationalError:
+        pass  # Column already exists
+
+    # Add conversation_id column to sessions (added 2026-03-11)
+    try:
+        conn.execute(
+            "ALTER TABLE sessions "
+            "ADD COLUMN conversation_id INTEGER REFERENCES conversations(id) ON DELETE SET NULL"
+        )
+    except sqlite3.OperationalError:
+        pass  # Column already exists
+
+    # Index on conversation sessions (added 2026-03-11, after column migration)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_conversation "
+        "ON sessions(conversation_id, started_at)"
+    )
+
 
 @contextmanager
 def get_db(db_path: str):
@@ -135,10 +168,10 @@ def get_db_conn(request: Request):
 # ---------------------------------------------------------------------------
 
 
-def _parse_trace(trace_path: str) -> dict:
+def _parse_trace(trace_path: str, session_dir: str | None = None) -> dict:
     """Extract completion fields from a trace.jsonl file.
 
-    Returns dict with keys: ended_at, duration_ms, exit_code.
+    Returns dict with keys: ended_at, duration_ms, exit_code, summary.
     Missing fields are omitted.
     """
     result: dict = {}
@@ -159,6 +192,29 @@ def _parse_trace(trace_path: str) -> dict:
                     if "duration_ms" in data:
                         result["duration_ms"] = data["duration_ms"]
                     result["exit_code"] = data.get("exit_code", 0)
+                    # session_end carries the final output ref
+                    output_ref = data.get("output_ref")
+                    if output_ref and session_dir and "summary" not in result:
+                        artifact_path = os.path.join(session_dir, "artifacts", output_ref)
+                        try:
+                            with open(artifact_path, encoding="utf-8") as af:
+                                content = af.read().strip()
+                            if content:
+                                result["summary"] = content
+                        except OSError:
+                            pass
+                elif etype == "delegate_end" and not event.get("parent_span"):
+                    # Fallback: root delegation also carries an output ref
+                    output_ref = data.get("output_ref")
+                    if output_ref and session_dir and "summary" not in result:
+                        artifact_path = os.path.join(session_dir, "artifacts", output_ref)
+                        try:
+                            with open(artifact_path, encoding="utf-8") as af:
+                                content = af.read().strip()
+                            if content:
+                                result["summary"] = content
+                        except OSError:
+                            pass
     except OSError:
         pass
     return result
@@ -252,7 +308,7 @@ def _upsert_session(
 
     # Determine status and parse trace
     trace_path = os.path.join(session_dir, "trace.jsonl")
-    trace_info = _parse_trace(trace_path)
+    trace_info = _parse_trace(trace_path, session_dir)
 
     if is_archived:
         exit_code = trace_info.get("exit_code")
@@ -275,11 +331,26 @@ def _upsert_session(
     interactive = os.path.isfile(os.path.join(session_dir, "chat_messages.jsonl"))
 
     conn.execute(
-        """INSERT OR REPLACE INTO sessions
+        """INSERT INTO sessions
            (run_id, project_id, role, runtime, isolation, status,
             started_at, ended_at, duration_ms, exit_code, session_dir,
-            task, interactive)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            task, summary, interactive)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(run_id) DO UPDATE SET
+             project_id  = excluded.project_id,
+             role        = excluded.role,
+             runtime     = excluded.runtime,
+             isolation   = excluded.isolation,
+             status      = CASE WHEN sessions.status IN ('stopped', 'completed', 'failed') THEN sessions.status ELSE excluded.status END,
+             started_at  = excluded.started_at,
+             ended_at    = excluded.ended_at,
+             duration_ms = excluded.duration_ms,
+             exit_code   = excluded.exit_code,
+             session_dir = excluded.session_dir,
+             task        = excluded.task,
+             summary     = COALESCE(excluded.summary, sessions.summary),
+             interactive = excluded.interactive
+             -- conversation_id intentionally omitted: preserve existing FK""",
         (
             run_id,
             project_id,
@@ -293,6 +364,7 @@ def _upsert_session(
             trace_info.get("exit_code"),
             session_dir,
             data.get("task"),
+            trace_info.get("summary"),
             1 if interactive else 0,
         ),
     )

--- a/gui/src/strawpot_gui/routers/conversations.py
+++ b/gui/src/strawpot_gui/routers/conversations.py
@@ -1,0 +1,268 @@
+"""Conversation endpoints — chat-mode sessions with sequential task submission."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from strawpot_gui.db import get_db_conn
+from strawpot_gui.routers.sessions import _refresh_session_status, launch_session_subprocess
+
+router = APIRouter(prefix="/api", tags=["conversations"])
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class ConversationCreate(BaseModel):
+    project_id: int
+    title: str | None = None
+
+
+class ConversationTask(BaseModel):
+    task: str
+    role: str | None = None
+    context_files: list[str] | None = None
+    interactive: bool = False
+    system_prompt: str | None = None
+    runtime: str | None = None
+    memory: str | None = None
+    max_num_delegations: int | None = None
+    cache_delegations: bool | None = None
+    cache_max_entries: int | None = None
+    cache_ttl_seconds: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Context builder
+# ---------------------------------------------------------------------------
+
+
+def _build_conversation_context(conn, conversation_id: int) -> str:
+    """Build a prior-turns summary to inject into the next session's system prompt."""
+    rows = conn.execute(
+        "SELECT task, summary, exit_code, status FROM sessions "
+        "WHERE conversation_id = ? ORDER BY started_at",
+        (conversation_id,),
+    ).fetchall()
+    if not rows:
+        return ""
+    parts = [
+        "## Prior Conversation\n",
+        "This is a continuation of a multi-turn conversation. "
+        "Here are the previous turns for context:\n",
+    ]
+    for i, row in enumerate(rows, 1):
+        parts.append(f"### Turn {i}")
+        parts.append(f"**User task:** {row['task']}")
+        if row["summary"]:
+            parts.append(f"**Result:** {row['summary']}")
+        elif row["status"] in ("completed", "failed"):
+            parts.append(f"**Result:** (exit code {row['exit_code']})")
+        else:
+            parts.append(f"**Result:** (status: {row['status']})")
+        parts.append("")
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/conversations", status_code=201)
+def create_conversation(body: ConversationCreate, conn=Depends(get_db_conn)):
+    """Create a new conversation for a project."""
+    project = conn.execute(
+        "SELECT id FROM projects WHERE id = ?", (body.project_id,)
+    ).fetchone()
+    if not project:
+        raise HTTPException(404, "Project not found")
+
+    now = datetime.now(timezone.utc).isoformat()
+    cur = conn.execute(
+        "INSERT INTO conversations (project_id, title, created_at) VALUES (?, ?, ?)",
+        (body.project_id, body.title, now),
+    )
+    conv_id = cur.lastrowid
+    row = conn.execute(
+        "SELECT id, project_id, title, created_at, updated_at FROM conversations WHERE id = ?",
+        (conv_id,),
+    ).fetchone()
+    return dict(row)
+
+
+@router.get("/conversations/{conversation_id}")
+def get_conversation(conversation_id: int, conn=Depends(get_db_conn)):
+    """Get a conversation with its ordered sessions."""
+    row = conn.execute(
+        "SELECT id, project_id, title, created_at, updated_at FROM conversations WHERE id = ?",
+        (conversation_id,),
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, "Conversation not found")
+
+    # Refresh status/summary for any active sessions before returning
+    active = conn.execute(
+        "SELECT run_id FROM sessions WHERE conversation_id = ? AND status IN ('starting', 'running')",
+        (conversation_id,),
+    ).fetchall()
+    for s in active:
+        _refresh_session_status(conn, s["run_id"])
+
+    sessions = conn.execute(
+        "SELECT run_id, task, summary, status, exit_code, started_at, ended_at, duration_ms, role "
+        "FROM sessions WHERE conversation_id = ? ORDER BY started_at",
+        (conversation_id,),
+    ).fetchall()
+
+    result = dict(row)
+    result["sessions"] = [dict(s) for s in sessions]
+    return result
+
+
+@router.get("/projects/{project_id}/conversations")
+def list_project_conversations(
+    project_id: int,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=100),
+    conn=Depends(get_db_conn),
+):
+    """List conversations for a project, most recent first."""
+    project = conn.execute(
+        "SELECT id FROM projects WHERE id = ?", (project_id,)
+    ).fetchone()
+    if not project:
+        raise HTTPException(404, "Project not found")
+
+    total = conn.execute(
+        "SELECT COUNT(*) FROM conversations WHERE project_id = ?",
+        (project_id,),
+    ).fetchone()[0]
+
+    offset = (page - 1) * per_page
+    rows = conn.execute(
+        """SELECT c.id, c.project_id, c.title, c.created_at, c.updated_at,
+                  COUNT(s.run_id) AS session_count,
+                  MAX(s.started_at) AS last_activity
+           FROM conversations c
+           LEFT JOIN sessions s ON s.conversation_id = c.id
+           WHERE c.project_id = ?
+           GROUP BY c.id
+           ORDER BY c.created_at DESC
+           LIMIT ? OFFSET ?""",
+        (project_id, per_page, offset),
+    ).fetchall()
+
+    return {
+        "items": [dict(r) for r in rows],
+        "total": total,
+        "page": page,
+        "per_page": per_page,
+    }
+
+
+@router.post("/conversations/{conversation_id}/tasks", status_code=201)
+def submit_task(
+    conversation_id: int,
+    body: ConversationTask,
+    conn=Depends(get_db_conn),
+):
+    """Submit a new task in a conversation.
+
+    Builds context from prior sessions and launches a new session with
+    the conversation history injected as the system prompt.
+    """
+    conv = conn.execute(
+        "SELECT id, project_id FROM conversations WHERE id = ?",
+        (conversation_id,),
+    ).fetchone()
+    if not conv:
+        raise HTTPException(404, "Conversation not found")
+
+    project_id = conv["project_id"]
+
+    # Build prior conversation context for the agent
+    context = _build_conversation_context(conn, conversation_id)
+
+    # Merge conversation context with any user-supplied extra system prompt
+    system_prompt_parts = [p for p in [context, body.system_prompt] if p]
+    combined_system_prompt = "\n\n".join(system_prompt_parts) or None
+
+    try:
+        run_id = launch_session_subprocess(
+            conn,
+            project_id,
+            body.task,
+            role=body.role,
+            system_prompt=combined_system_prompt,
+            context_files=body.context_files,
+            interactive=body.interactive,
+            conversation_id=conversation_id,
+            runtime_override=body.runtime,
+            memory_override=body.memory,
+            max_num_delegations=body.max_num_delegations,
+            cache_delegations=body.cache_delegations,
+            cache_max_entries=body.cache_max_entries,
+            cache_ttl_seconds=body.cache_ttl_seconds,
+        )
+    except RuntimeError as e:
+        _ERROR_STATUS = {
+            "Project not found": 404,
+            "Project working directory does not exist": 422,
+        }
+        status = _ERROR_STATUS.get(str(e), 500)
+        raise HTTPException(status, str(e))
+
+    # Touch updated_at on the conversation
+    now = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        "UPDATE conversations SET updated_at = ? WHERE id = ?",
+        (now, conversation_id),
+    )
+
+    return {"run_id": run_id, "conversation_id": conversation_id}
+
+
+class ConversationUpdate(BaseModel):
+    title: str | None = None
+
+
+@router.patch("/conversations/{conversation_id}")
+def update_conversation(
+    conversation_id: int, body: ConversationUpdate, conn=Depends(get_db_conn)
+):
+    """Update conversation metadata (e.g. title)."""
+    row = conn.execute(
+        "SELECT id FROM conversations WHERE id = ?", (conversation_id,)
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, "Conversation not found")
+
+    conn.execute(
+        "UPDATE conversations SET title = ? WHERE id = ?",
+        (body.title, conversation_id),
+    )
+    updated = conn.execute(
+        "SELECT id, project_id, title, created_at, updated_at FROM conversations WHERE id = ?",
+        (conversation_id,),
+    ).fetchone()
+    return dict(updated)
+
+
+@router.delete("/conversations/{conversation_id}", status_code=204)
+def delete_conversation(conversation_id: int, conn=Depends(get_db_conn)):
+    """Delete a conversation. Sessions are kept but lose their conversation link."""
+    row = conn.execute(
+        "SELECT id FROM conversations WHERE id = ?", (conversation_id,)
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, "Conversation not found")
+
+    conn.execute(
+        "UPDATE sessions SET conversation_id = NULL WHERE conversation_id = ?",
+        (conversation_id,),
+    )
+    conn.execute("DELETE FROM conversations WHERE id = ?", (conversation_id,))

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -66,7 +66,7 @@ def _refresh_session_status(conn, run_id: str) -> None:
 
     # Check trace for completion
     trace_path = os.path.join(session_dir, "trace.jsonl")
-    trace_info = _parse_trace(trace_path)
+    trace_info = _parse_trace(trace_path, session_dir)
 
     if trace_info.get("exit_code") is not None or "ended_at" in trace_info:
         # Session has ended
@@ -75,13 +75,14 @@ def _refresh_session_status(conn, run_id: str) -> None:
         conn.execute(
             """UPDATE sessions
                SET status = ?, ended_at = ?, duration_ms = ?,
-                   exit_code = ?
+                   exit_code = ?, summary = COALESCE(summary, ?)
                WHERE run_id = ?""",
             (
                 status,
                 trace_info.get("ended_at"),
                 trace_info.get("duration_ms"),
                 exit_code,
+                trace_info.get("summary"),
                 run_id,
             ),
         )
@@ -128,6 +129,7 @@ class SessionLaunch(BaseModel):
     context_files: list[str] | None = None
     system_prompt: str | None = None
     interactive: bool = False
+    conversation_id: int | None = None
 
     @field_validator("task")
     @classmethod
@@ -153,6 +155,7 @@ def launch_session_subprocess(
     max_num_delegations: int | None = None,
     schedule_id: int | None = None,
     interactive: bool = False,
+    conversation_id: int | None = None,
 ) -> str:
     """Launch a headless session subprocess. Returns run_id.
 
@@ -200,10 +203,10 @@ def launch_session_subprocess(
     conn.execute(
         """INSERT INTO sessions
            (run_id, project_id, role, runtime, isolation, status,
-            started_at, session_dir, task, schedule_id, interactive)
-           VALUES (?, ?, ?, ?, ?, 'starting', ?, ?, ?, ?, ?)""",
+            started_at, session_dir, task, schedule_id, interactive, conversation_id)
+           VALUES (?, ?, ?, ?, ?, 'starting', ?, ?, ?, ?, ?, ?)""",
         (run_id, project_id, resolved_role, runtime, isolation, now,
-         session_dir, task, schedule_id, 1 if interactive else 0),
+         session_dir, task, schedule_id, 1 if interactive else 0, conversation_id),
     )
 
     # Resolve context files and append to task
@@ -316,6 +319,7 @@ def launch_session(body: SessionLaunch, conn=Depends(get_db_conn)):
             max_num_delegations=body.overrides.max_num_delegations if body.overrides else None,
             context_files=body.context_files,
             interactive=body.interactive,
+            conversation_id=body.conversation_id,
         )
     except RuntimeError as e:
         status = _ERROR_STATUS.get(str(e), 500)
@@ -497,7 +501,7 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
     except (OSError, json.JSONDecodeError):
         # session.json not created yet — session never fully started
         conn.execute(
-            "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
+            "UPDATE sessions SET status = 'stopped', summary = COALESCE(summary, 'Interrupted') WHERE run_id = ?",
             (run_id,),
         )
         event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
@@ -507,7 +511,7 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
     if pid is None:
         # No PID recorded — mark as stopped
         conn.execute(
-            "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
+            "UPDATE sessions SET status = 'stopped', summary = COALESCE(summary, 'Interrupted') WHERE run_id = ?",
             (run_id,),
         )
         event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
@@ -519,7 +523,7 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
     except (ProcessLookupError, OSError):
         # Process already gone
         conn.execute(
-            "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
+            "UPDATE sessions SET status = 'stopped', summary = COALESCE(summary, 'Interrupted') WHERE run_id = ?",
             (run_id,),
         )
         event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
@@ -530,7 +534,7 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
     except (ProcessLookupError, OSError):
         # Race: died between check and kill
         conn.execute(
-            "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
+            "UPDATE sessions SET status = 'stopped', summary = COALESCE(summary, 'Interrupted') WHERE run_id = ?",
             (run_id,),
         )
         event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))


### PR DESCRIPTION
## Summary

- Introduces persistent multi-turn conversations where each user message spawns an independent strawpot session with prior conversation context automatically injected via `--system-prompt`
- New `ConversationView` page with full chat interface: message history, role selector, stop/submit toggle, inline title editing, advanced settings (runtime, memory, system prompt, delegations, cache)
- `ConversationSidebar` in `AppLayout` replaces the main nav when on a conversation route, listing all conversations with hover rename/delete
- `ProjectDetail` updated: Conversations as default tab, "New Conversation" as primary button, inline title editing and delete in the conversation list
- Backend: new `conversations` table, `sessions.conversation_id` FK, `sessions.summary` column, terminal status preservation across restarts, "Interrupted" summary on stop

## Test plan

- [ ] Navigate to a project → Conversations tab is shown by default
- [ ] Click "New Conversation" → navigates to ConversationView with conversation sidebar
- [ ] Submit a task → session launches, spinner shown, summary appears on completion
- [ ] Submit a follow-up → agent receives prior conversation context (check trace for `## Prior Conversation` in system prompt)
- [ ] Stop a running session → "Interrupted." shown; persists after server restart
- [ ] Rename a conversation from sidebar hover (pencil icon) and from chat header
- [ ] Delete a non-active conversation from sidebar (trash icon → Delete/No confirmation)
- [ ] Advanced settings gear → set runtime/memory/system prompt/delegation options, verify they persist across submissions
- [ ] Refresh page → conversation history persists
- [ ] Existing session launch (non-conversation) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)