### PR TITLE
Fix memory.dump to use memory_task and show user_task in session list

### DIFF
--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -536,7 +536,7 @@ class Session:
                         agent_id=orch_agent_id,
                         role=self.config.orchestrator_role,
                         behavior_ref=self._orchestrator_role_prompt,
-                        task=self.task,
+                        task=self.memory_task,
                         status=status,
                         output=output,
                     )
@@ -550,7 +550,7 @@ class Session:
                         agent_id=orch_agent_id,
                         role=self.config.orchestrator_role,
                         behavior_ref=self._orchestrator_role_prompt,
-                        task=self.task or "",
+                        task=self.memory_task or "",
                         status=status,
                         output=output,
                     )

--- a/gui/frontend/src/components/SessionTable.tsx
+++ b/gui/frontend/src/components/SessionTable.tsx
@@ -68,7 +68,7 @@ export default function SessionTable({
               {formatDuration(s.duration_ms)}
             </TableCell>
             <TableCell className="max-w-[300px] truncate text-sm">
-              {s.task ?? "—"}
+              {s.user_task ?? s.task ?? "—"}
             </TableCell>
             <TableCell>
               <DeleteSessionButton


### PR DESCRIPTION
## Summary

- **`cli/src/strawpot/session.py`**: Fixed `memory_provider.dump` and `tracer.memory_dump` to use `self.memory_task` (the clean original user message) instead of `self.task` (the full internally-enriched task string). Memory should store the user's original intent, not the context-augmented version.
- **`gui/frontend/src/components/SessionTable.tsx`**: Session list now shows `user_task` with fallback to `task`, so users see their original message rather than the enriched task.

## Test plan
- [ ] Run a session with a user task — session list shows user_task
- [ ] Check memory dump contains the original user message, not the enriched task
- [ ] Sessions without user_task still display task correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)