### PR TITLE
Fix memory_get tracer to use memory_task instead of task

### DIFF
--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -439,7 +439,7 @@ class Session:
                         agent_id=agent_id,
                         role=self.config.orchestrator_role,
                         behavior_ref=role_prompt,
-                        task=self.task,
+                        task=self.memory_task,
                         cards=get_result.context_cards or [],
                         card_count=len(get_result.context_cards) if get_result.context_cards else 0,
                     )


### PR DESCRIPTION
## Summary

- `tracer.memory_get()` was passing `self.task` while `memory_provider.get()` just above it used `self.memory_task`
- This caused the trace to record a different task string than what was actually passed to the memory lookup
- Same bug as was fixed for `memory.dump` in #211

## Change

```python
# before
task=self.task,
# after
task=self.memory_task,
```

One-line fix in `cli/src/strawpot/session.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)