### PR TITLE
Remove redundant 'or ""' from tracer.memory_dump task arg

### DIFF
--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -550,7 +550,7 @@ class Session:
                         agent_id=orch_agent_id,
                         role=self.config.orchestrator_role,
                         behavior_ref=self._orchestrator_role_prompt,
-                        task=self.memory_task or "",
+                        task=self.memory_task,
                         status=status,
                         output=output,
                     )


### PR DESCRIPTION
## Summary

- `self.memory_task` is already resolved as `memory_task or task` in `Session.__init__` (line 299), so the extra `or ""` in `tracer.memory_dump` was redundant
- Makes all four `memory_task` usages in `session.py` consistent: `memory_provider.get`, `tracer.memory_get`, `memory_provider.dump`, and `tracer.memory_dump` all now pass `self.memory_task` directly

Follows #213 which fixed `tracer.memory_get` to use `memory_task` instead of `task`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)