### PR TITLE
Mark orphaned running/starting sessions as stopped on server startup

### DIFF
--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -71,6 +71,8 @@ def create_app(db_path: str | None = None) -> FastAPI:
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         ensure_global_config()
         init_db(db_path)
+        from strawpot_gui.db import mark_orphaned_sessions_stopped
+        mark_orphaned_sessions_stopped(db_path)
         sync_sessions(db_path)
         from strawpot_gui.routers.sessions import launch_session_subprocess
         scheduler = Scheduler(db_path, launch_fn=launch_session_subprocess)

--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -90,6 +90,23 @@ def init_db(db_path: str) -> None:
         conn.close()
 
 
+def mark_orphaned_sessions_stopped(db_path: str) -> int:
+    """Mark sessions stuck in 'running' or 'starting' as 'stopped' on server startup.
+
+    Sessions in these states when the server starts are orphaned — their agent
+    processes died with the previous server process.  Leaving them as 'running'
+    causes WS file-watchers to hang indefinitely for every open browser tab.
+
+    Returns the number of rows updated.
+    """
+    with get_db(db_path) as conn:
+        cur = conn.execute(
+            "UPDATE sessions SET status = 'stopped'"
+            " WHERE status IN ('running', 'starting')"
+        )
+        return cur.rowcount
+
+
 def _migrate(conn: sqlite3.Connection) -> None:
     """Apply incremental schema migrations for existing databases."""
     # Add schedule_id column to sessions (added 2026-03-09)


### PR DESCRIPTION
## Summary

- On server startup, update all sessions with `status IN ('running', 'starting')` to `'stopped'`
- These sessions are orphaned — their agent processes died with the previous server process
- Fixes server hanging when browser tabs from a previous server run reconnect: orphaned sessions no longer spawn long-lived `file_watcher` tasks; their WS connections receive `stream_complete` immediately and close

## Test plan

- [ ] Start a session, kill the GUI server mid-run, restart the server — the session appears as `stopped` rather than stuck as `running`
- [ ] With open browser tabs from the previous server run, restart the server — reconnecting tabs resolve quickly without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)