### PR TITLE
Include agent tree in session REST response; fix Agent Tree for all sessions

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -51,6 +51,7 @@ export interface SessionDetail extends Session {
   interactive: boolean;
   agents: Record<string, AgentInfo>;
   events: TraceEvent[];
+  tree: TreeData;
 }
 
 export interface AskUserPending {

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -64,10 +64,11 @@ export default function SessionDetail() {
   }, [active, session]);
 
   const isInteractive = !!sessionData?.interactive;
-  const { pendingAskUsers, chatMessages, traceEvents, treeData, connected, respond } = useSessionWS(
+  const { pendingAskUsers, chatMessages, traceEvents, treeData: wsTreeData, connected, respond } = useSessionWS(
     runId ?? "",
     active || isInteractive,
   );
+  const treeData = wsTreeData ?? sessionData?.tree ?? null;
   const restEvents = sessionData?.events ?? [];
   const displayEvents = traceEvents.length > 0 ? traceEvents : restEvents;
 

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -478,6 +478,11 @@ def get_session(project_id: int, run_id: str, conn=Depends(get_db_conn)):
         pass
     result["events"] = events
 
+    # Build agent tree from session.json + trace.jsonl
+    from strawpot_gui.routers.ws import _build_full_state
+    state, _ = _build_full_state(str(session_dir))
+    result["tree"] = state.to_dict()
+
     return result
 
 


### PR DESCRIPTION
## Summary

- **Root cause**: Agent Tree in SessionDetail was only populated via WebSocket, which only connected for `active || isInteractive` sessions. Completed non-interactive sessions never got a WS connection, so their tree stayed `null` and showed "Connecting..." indefinitely. Only the first interactive/running session ever worked.
- **Backend**: `GET /projects/{id}/sessions/{run_id}` now runs `_build_full_state()` and includes `tree: { nodes, pending_delegations, denied_delegations }` in the response — same data the WS would have sent, computed once from the already-loaded `session.json` + `trace.jsonl`
- **Frontend**: `treeData = wsTreeData ?? sessionData.tree` — WS data takes precedence for live active sessions; REST tree is the fallback for completed sessions
- **WS condition**: reverted to `active || isInteractive` (removed the `!!runId` workaround)

## Test plan

- [ ] Open Agent Tree for a completed non-interactive session — tree renders correctly without needing a WS connection
- [ ] Open Agent Tree for a running session — live updates still work via WS
- [ ] Navigate between multiple sessions — each Agent Tree renders correctly
- [ ] Open Agent Tree for a completed interactive session — tree renders (from WS or REST fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)