### PR TITLE
Add memory_remember trace event

### DIFF
--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -1108,6 +1108,24 @@ class Session:
                 keywords=list(remember.keywords) or None,
                 scope=remember.scope or "project",
             )
+            if self._tracer is not None:
+                span_id = self._agent_spans.get(
+                    trace.agent_instance_id, self._session_span_id
+                )
+                if span_id:
+                    self._tracer.memory_remember(
+                        span_id=span_id,
+                        provider=self._memory_provider.name,
+                        session_id=self._run_id or trace.run_id,
+                        agent_id=trace.agent_instance_id,
+                        role=self._agent_role(trace.agent_instance_id),
+                        content=remember.content,
+                        keywords=list(remember.keywords) or None,
+                        scope=remember.scope or "project",
+                        status=result.status,
+                        entry_id=result.entry_id,
+                        parent_agent_id=None,
+                    )
             return ok_response(
                 request.request_id,
                 remember_result=denden_pb2.RememberResult(

--- a/cli/src/strawpot/trace.py
+++ b/cli/src/strawpot/trace.py
@@ -234,6 +234,38 @@ class Tracer:
             parent_agent_id=parent_agent_id,
         )
 
+    def memory_remember(
+        self,
+        *,
+        span_id: str,
+        provider: str,
+        session_id: str,
+        agent_id: str,
+        role: str,
+        content: str = "",
+        keywords: list[str] | None = None,
+        scope: str = "",
+        status: str = "",
+        entry_id: str = "",
+        parent_agent_id: str | None = None,
+    ) -> None:
+        """Emit ``memory_remember``.  Stores content as artifact."""
+        content_ref = self.store_artifact(content)
+        self.emit(
+            "memory_remember",
+            span_id,
+            provider=provider,
+            session_id=session_id,
+            agent_id=agent_id,
+            role=role,
+            content_ref=content_ref,
+            keywords=keywords or [],
+            scope=scope,
+            status=status,
+            entry_id=entry_id,
+            parent_agent_id=parent_agent_id,
+        )
+
     def memory_dump(
         self,
         *,


### PR DESCRIPTION
## Summary

- Add `Tracer.memory_remember()` to [cli/src/strawpot/trace.py](cli/src/strawpot/trace.py), following the same pattern as `memory_get` and `memory_dump`
- Emit the event from `Session._handle_remember()` after a successful `memory_provider.remember()` call
- The span is resolved via `_agent_spans` (falling back to session span), so the event is attributed to the correct agent

## Event fields

| Field | Description |
|-------|-------------|
| `provider` | Memory provider name |
| `session_id` | Run ID |
| `agent_id` | Agent that triggered the remember |
| `role` | Agent's role |
| `content_ref` | Artifact hash of the content stored |
| `keywords` | Keywords passed to the call |
| `scope` | Scope (project / session / etc.) |
| `status` | Result status from the provider |
| `entry_id` | Entry ID assigned by the provider |

## Test plan

- [ ] Run a session where an agent calls `memory.remember` — a `memory_remember` event appears in `trace.jsonl`
- [ ] Confirm fields (content_ref, status, entry_id) are populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)