### PR TITLE
Move Back button to top-left on Project and Session Detail pages

### DIFF
--- a/gui/frontend/src/pages/ProjectDetail.tsx
+++ b/gui/frontend/src/pages/ProjectDetail.tsx
@@ -210,7 +210,15 @@ export default function ProjectDetail() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight">{p.display_name}</h1>
+        <div className="flex items-center gap-3">
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/projects">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back
+            </Link>
+          </Button>
+          <h1 className="text-2xl font-bold tracking-tight">{p.display_name}</h1>
+        </div>
         <div className="flex gap-2">
           <Button
             disabled={!p.dir_exists || createConversation.isPending}
@@ -237,12 +245,6 @@ export default function ProjectDetail() {
           >
             <Download className="mr-2 h-4 w-4" />
             Install Resource
-          </Button>
-          <Button variant="outline" asChild>
-            <Link to="/projects">
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back
-            </Link>
           </Button>
         </div>
       </div>

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -284,9 +284,17 @@ function SessionHeader({
 
   return (
     <div className="flex items-center justify-between">
-      <h1 className="text-2xl font-bold tracking-tight">
-        Session {session.run_id.slice(0, 16)}
-      </h1>
+      <div className="flex items-center gap-3">
+        <Button variant="outline" size="sm" asChild>
+          <Link to={`/projects/${projectId}`}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back
+          </Link>
+        </Button>
+        <h1 className="text-2xl font-bold tracking-tight">
+          Session {session.run_id.slice(0, 16)}
+        </h1>
+      </div>
       <div className="flex gap-2">
         {active &&
           (confirming ? (
@@ -317,12 +325,6 @@ function SessionHeader({
               Stop Session
             </Button>
           ))}
-        <Button variant="outline" asChild>
-          <Link to={`/projects/${projectId}`}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back
-          </Link>
-        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Back button moved from the right-side action group to the top-left, before the page title, on both `ProjectDetail` and `SessionDetail`
- Action buttons (New Conversation, Launch Session, Install Resource, Stop Session) remain on the right

🤖 Generated with [Claude Code](https://claude.com/claude-code)