### PR TITLE
Add Bot Imu nav link (item 6)

### DIFF
--- a/gui/frontend/src/App.tsx
+++ b/gui/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import ProjectList from "./pages/ProjectList";
 import ProjectDetail from "./pages/ProjectDetail";
 import SessionDetail from "./pages/SessionDetail";
 import ConversationView from "./pages/ConversationView";
+import ImuPage from "./pages/ImuPage";
 import ResourceBrowser from "./pages/ResourceBrowser";
 import ScheduledTasks from "./pages/ScheduledTasks";
 import Settings from "./pages/Settings";
@@ -28,6 +29,8 @@ export default function App() {
           path="projects/:projectId/conversations/:conversationId"
           element={<ConversationView />}
         />
+        <Route path="imu" element={<ImuPage />} />
+        <Route path="imu/:conversationId" element={<ImuPage />} />
         <Route path="schedules" element={<ScheduledTasks />} />
         <Route
           path="resources/:resourceType"

--- a/gui/frontend/src/layouts/AppLayout.tsx
+++ b/gui/frontend/src/layouts/AppLayout.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import { Link, NavLink, Outlet, useLocation, useMatch, useNavigate } from "react-router-dom";
 import { useTheme } from "next-themes";
-import { ArrowLeft, LayoutDashboard, FolderKanban, Clock, Users, Wrench, Bot, Brain, Pencil, Plus, Settings, Sun, Moon, Check, ChevronsUpDown, Trash2 } from "lucide-react";
+import { ArrowLeft, LayoutDashboard, FolderKanban, Clock, BotMessageSquare, Users, Wrench, Bot, Brain, Pencil, Plus, Settings, Sun, Moon, Check, ChevronsUpDown, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useProject, useProjects } from "@/hooks/queries/use-projects";
 import { useProjectConversations } from "@/hooks/queries/use-conversations";
@@ -28,6 +28,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 
 const navItems = [
+  { to: "/imu", label: "Bot Imu", icon: BotMessageSquare },
   { to: "/", label: "Dashboard", icon: LayoutDashboard, end: true },
   { to: "/projects", label: "Projects", icon: FolderKanban },
   { to: "/schedules", label: "Schedules", icon: Clock },

--- a/gui/frontend/src/pages/ImuPage.tsx
+++ b/gui/frontend/src/pages/ImuPage.tsx
@@ -1,0 +1,7 @@
+export default function ImuPage() {
+  return (
+    <div className="flex h-full items-center justify-center text-muted-foreground">
+      Bot Imu — coming soon
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds **Bot Imu** as the first item in the left sidebar nav with the `BotMessageSquare` icon
- Registers `/imu` and `/imu/:conversationId` routes in the router
- Creates a minimal `ImuPage` placeholder (full page implementation in next PR)

## Test plan

- [ ] Bot Imu link appears at the top of the sidebar
- [ ] Clicking it navigates to `/imu` without 404
- [ ] Link is highlighted (active) when on `/imu` or `/imu/123`

🤖 Generated with [Claude Code](https://claude.com/claude-code)