### PR TITLE
Add Bot Imu dedicated page with conversation UI (item 7)

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -221,6 +221,14 @@ export interface ConversationList {
   per_page: number;
 }
 
+export interface ImuConversation {
+  id: number;
+  title: string | null;
+  created_at: string;
+  updated_at: string | null;
+  session_count: number;
+}
+
 export interface Schedule {
   id: number;
   name: string;

--- a/gui/frontend/src/hooks/mutations/use-conversations.ts
+++ b/gui/frontend/src/hooks/mutations/use-conversations.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { queryKeys } from "@/lib/query-keys";
-import type { Conversation, ConversationList } from "@/api/types";
+import type { Conversation, ConversationList, ImuConversation } from "@/api/types";
 
 interface CreateConversationBody {
   project_id: number;
@@ -60,6 +60,55 @@ export function useRenameConversation(projectId: number) {
     onSuccess: (_data, { conversationId }) => {
       qc.invalidateQueries({ queryKey: queryKeys.conversations.all(projectId) });
       qc.invalidateQueries({ queryKey: queryKeys.conversations.detail(conversationId) });
+    },
+  });
+}
+
+export function useCreateImuConversation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      api.post<Pick<ImuConversation, "id" | "title" | "created_at" | "updated_at">>(
+        "/imu/conversations",
+        {},
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["imu", "conversations"] });
+    },
+  });
+}
+
+export function useRenameImuConversation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ conversationId, title }: { conversationId: number; title: string | null }) =>
+      api.patch<Conversation>(`/conversations/${conversationId}`, { title }),
+    onSuccess: (_data, { conversationId }) => {
+      qc.invalidateQueries({ queryKey: ["imu", "conversations"] });
+      qc.invalidateQueries({ queryKey: queryKeys.conversations.detail(conversationId) });
+    },
+  });
+}
+
+export function useDeleteImuConversation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (conversationId: number) => api.delete(`/conversations/${conversationId}`),
+    onMutate: async (conversationId: number) => {
+      await qc.cancelQueries({ queryKey: ["imu", "conversations"] });
+      const previous = qc.getQueryData<ImuConversation[]>(["imu", "conversations"]);
+      qc.setQueryData<ImuConversation[]>(["imu", "conversations"], (old) =>
+        old ? old.filter((c) => c.id !== conversationId) : old,
+      );
+      return { previous };
+    },
+    onError: (_err, _id, context) => {
+      if (context?.previous) {
+        qc.setQueryData(["imu", "conversations"], context.previous);
+      }
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ["imu", "conversations"] });
     },
   });
 }

--- a/gui/frontend/src/hooks/queries/use-conversations.ts
+++ b/gui/frontend/src/hooks/queries/use-conversations.ts
@@ -1,7 +1,7 @@
 import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { queryKeys } from "@/lib/query-keys";
-import type { Conversation, ConversationList, RecentConversation } from "@/api/types";
+import type { Conversation, ConversationList, ImuConversation, RecentConversation } from "@/api/types";
 
 export function useConversation(
   id: number,
@@ -36,6 +36,13 @@ export function useRecentConversations(limit = 10) {
   return useQuery({
     queryKey: ["conversations", "recent", limit],
     queryFn: () => api.get<RecentConversation[]>(`/conversations/recent?limit=${limit}`),
+  });
+}
+
+export function useImuConversations() {
+  return useQuery({
+    queryKey: ["imu", "conversations"],
+    queryFn: () => api.get<ImuConversation[]>("/imu/conversations"),
   });
 }
 

--- a/gui/frontend/src/layouts/AppLayout.tsx
+++ b/gui/frontend/src/layouts/AppLayout.tsx
@@ -4,8 +4,9 @@ import { useTheme } from "next-themes";
 import { ArrowLeft, LayoutDashboard, FolderKanban, Clock, BotMessageSquare, Users, Wrench, Bot, Brain, Pencil, Plus, Settings, Sun, Moon, Check, ChevronsUpDown, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useProject, useProjects } from "@/hooks/queries/use-projects";
-import { useProjectConversations } from "@/hooks/queries/use-conversations";
-import { useCreateConversation, useRenameConversation, useDeleteConversation } from "@/hooks/mutations/use-conversations";
+import { useImuConversations, useProjectConversations } from "@/hooks/queries/use-conversations";
+import { useCreateConversation, useCreateImuConversation, useDeleteImuConversation, useDeleteConversation, useRenameConversation, useRenameImuConversation } from "@/hooks/mutations/use-conversations";
+import type { ImuConversation } from "@/api/types";
 import { Input } from "@/components/ui/input";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import CommandPalette from "@/components/CommandPalette";
@@ -157,6 +158,160 @@ function ConversationSidebarItem({
   );
 }
 
+function ImuConversationSidebarItem({
+  conv,
+  isActive,
+  navigate,
+}: {
+  conv: ImuConversation;
+  isActive: boolean;
+  navigate: ReturnType<typeof useNavigate>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const rename = useRenameImuConversation();
+  const del = useDeleteImuConversation();
+
+  const startEdit = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setDraft(conv.title ?? "");
+    setEditing(true);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  };
+
+  const save = () => {
+    const trimmed = draft.trim();
+    rename.mutate({ conversationId: conv.id, title: trimmed || null });
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <div className="px-1">
+        <Input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={save}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") { e.preventDefault(); save(); }
+            if (e.key === "Escape") { e.stopPropagation(); setEditing(false); }
+          }}
+          onClick={(e) => e.stopPropagation()}
+          className="h-7 text-xs px-2"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      className={cn(
+        "flex items-center gap-1 rounded-md px-2 py-1.5 transition-colors",
+        isActive
+          ? "bg-accent text-accent-foreground"
+          : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground",
+      )}
+    >
+      <button
+        onClick={() => navigate(`/imu/${conv.id}`)}
+        className="flex-1 min-w-0 text-left text-sm"
+      >
+        <span className="truncate block">{conv.title ?? `Conversation #${conv.id}`}</span>
+      </button>
+      {confirming ? (
+        <div className="flex items-center gap-1 shrink-0">
+          <button
+            onClick={(e) => { e.stopPropagation(); del.mutate(conv.id); setConfirming(false); navigate("/imu"); }}
+            className="text-xs text-destructive hover:text-destructive/80 font-medium"
+            disabled={del.isPending}
+          >
+            Delete
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); setConfirming(false); }}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            No
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-0.5 shrink-0" style={{ opacity: hovered ? 1 : 0 }}>
+          <button
+            onClick={startEdit}
+            className="p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
+            title="Rename"
+          >
+            <Pencil className="h-3 w-3" />
+          </button>
+          {!isActive && (
+            <button
+              onClick={(e) => { e.stopPropagation(); setConfirming(true); }}
+              className="p-0.5 rounded text-muted-foreground hover:text-destructive transition-colors"
+              title="Delete"
+            >
+              <Trash2 className="h-3 w-3" />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ImuSidebar({ conversationId }: { conversationId: number }) {
+  const navigate = useNavigate();
+  const conversations = useImuConversations();
+  const createConversation = useCreateImuConversation();
+
+  return (
+    <aside className="flex w-56 flex-col border-r border-border bg-card">
+      <div className="flex h-14 items-center border-b border-border px-4">
+        <Link to="/" className="text-lg font-bold tracking-tight hover:text-foreground/80">StrawPot</Link>
+      </div>
+      <div className="flex flex-col gap-1 p-3 flex-1 min-h-0">
+        <button
+          onClick={() => navigate("/imu")}
+          className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground transition-colors"
+        >
+          <BotMessageSquare className="h-4 w-4 shrink-0" />
+          <span className="truncate">Bot Imu</span>
+        </button>
+
+        <div className="flex items-center justify-between px-3 pt-2 pb-1">
+          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">Conversations</span>
+          <button
+            onClick={() => createConversation.mutate(undefined, {
+              onSuccess: (conv) => navigate(`/imu/${conv.id}`),
+            })}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+            title="New conversation"
+          >
+            <Plus className="h-3.5 w-3.5" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto space-y-0.5">
+          {(conversations.data ?? []).map((conv) => (
+            <ImuConversationSidebarItem
+              key={conv.id}
+              conv={conv}
+              isActive={conv.id === conversationId}
+              navigate={navigate}
+            />
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
 function ConversationSidebar({ projectId, conversationId }: { projectId: number; conversationId: number }) {
   const navigate = useNavigate();
   const conversations = useProjectConversations(projectId, 1, 50);
@@ -219,6 +374,11 @@ function useBreadcrumbs() {
   const { data: conversationsListData } = useProjectConversations(projectId, 1, 50);
   const conversationTitle = conversationsListData?.items.find((c) => c.id === conversationId)?.title ?? null;
 
+  // Imu conversation title (cache hit from ImuSidebar)
+  const imuConvId = segments[0] === "imu" && segments[1] ? Number(segments[1]) : 0;
+  const { data: imuConversations } = useImuConversations();
+  const imuConvTitle = imuConversations?.find((c) => c.id === imuConvId)?.title ?? null;
+
   const crumbs: { label: string; href?: string; projectSwitcher?: boolean }[] = [
     { label: "Dashboard", href: "/" },
   ];
@@ -236,6 +396,13 @@ function useBreadcrumbs() {
       } else if (segments[2] === "conversations" && segments[3]) {
         crumbs.push({ label: conversationTitle ?? `Conversation #${segments[3]}` });
       }
+    }
+  }
+
+  if (segments[0] === "imu") {
+    crumbs.push({ label: "Bot Imu", href: "/imu" });
+    if (segments[1]) {
+      crumbs.push({ label: imuConvTitle ?? `Conversation #${segments[1]}` });
     }
   }
 
@@ -274,6 +441,8 @@ export default function AppLayout() {
   const convMatch = useMatch("/projects/:projectId/conversations/:conversationId");
   const convProjectId = convMatch ? Number(convMatch.params.projectId) : 0;
   const convId = convMatch ? Number(convMatch.params.conversationId) : 0;
+  const imuMatch = useMatch("/imu/:conversationId");
+  const imuConvId = imuMatch ? Number(imuMatch.params.conversationId) : 0;
 
   useKeyboardShortcuts({
     onCommandPalette: () => setCmdOpen(true),
@@ -285,6 +454,8 @@ export default function AppLayout() {
       {/* Sidebar */}
       {convMatch ? (
         <ConversationSidebar projectId={convProjectId} conversationId={convId} />
+      ) : imuMatch ? (
+        <ImuSidebar conversationId={imuConvId} />
       ) : (
         <aside className="flex w-56 flex-col border-r border-border bg-card">
           <div className="flex h-14 items-center border-b border-border px-4">

--- a/gui/frontend/src/pages/ImuPage.tsx
+++ b/gui/frontend/src/pages/ImuPage.tsx
@@ -1,7 +1,683 @@
-export default function ImuPage() {
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useConversationInfinite, useImuConversations } from "@/hooks/queries/use-conversations";
+import { useCreateImuConversation, useRenameImuConversation, useSubmitConversationTask } from "@/hooks/mutations/use-conversations";
+import { useStopSession } from "@/hooks/mutations/use-sessions";
+import { useSessionWS } from "@/hooks/useSessionWS";
+import { useResources } from "@/hooks/queries/use-registry";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { AlertCircle, BotMessageSquare, CheckCircle2, CornerDownLeft, Loader2, MessageSquare, Plus, Settings, Square, XCircle } from "lucide-react";
+import type { AskUserPending, ChatMessage, ConversationSession } from "@/api/types";
+import MarkdownContent from "@/components/MarkdownContent";
+
+const IMU_ROLE = "imu";
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return "";
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return rem > 0 ? `${m}m ${rem}s` : `${m}m`;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === "running" || status === "starting") {
+    return (
+      <Badge variant="outline" className="gap-1 border-blue-200 text-blue-700 dark:border-blue-800 dark:text-blue-400">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        {status === "starting" ? "Starting" : "Running"}
+      </Badge>
+    );
+  }
+  if (status === "completed") {
+    return (
+      <Badge variant="outline" className="gap-1 border-green-200 text-green-700 dark:border-green-800 dark:text-green-400">
+        <CheckCircle2 className="h-3 w-3" />
+        Completed
+      </Badge>
+    );
+  }
+  if (status === "failed") {
+    return (
+      <Badge variant="outline" className="gap-1 border-red-200 text-red-700 dark:border-red-800 dark:text-red-400">
+        <XCircle className="h-3 w-3" />
+        Failed
+      </Badge>
+    );
+  }
+  return <Badge variant="outline">{status}</Badge>;
+}
+
+function ImuAgentMessage({ session }: { session: ConversationSession }) {
+  const isActive = session.status === "running" || session.status === "starting";
   return (
-    <div className="flex h-full items-center justify-center text-muted-foreground">
-      Bot Imu — coming soon
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium text-muted-foreground">Bot Imu</span>
+        <StatusBadge status={session.status} />
+        {session.duration_ms !== null && (
+          <span className="text-xs text-muted-foreground">{formatDuration(session.duration_ms)}</span>
+        )}
+      </div>
+      <div className="rounded-lg border border-border bg-muted/30 p-3 text-sm">
+        {isActive ? (
+          <span className="flex items-center gap-2 text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Working…
+          </span>
+        ) : session.summary ? (
+          <MarkdownContent content={session.summary} className="text-sm text-foreground" />
+        ) : (
+          <span className="text-muted-foreground italic">
+            {session.status === "failed"
+              ? "Session failed without output."
+              : session.status === "stopped"
+              ? "Interrupted."
+              : "No summary available."}
+          </span>
+        )}
+      </div>
     </div>
   );
+}
+
+function UserMessage({ task }: { task: string }) {
+  return (
+    <div className="flex flex-col gap-1.5 items-end">
+      <span className="text-xs font-medium text-muted-foreground">You</span>
+      <div className="max-w-[80%] rounded-lg bg-primary px-3 py-2 text-sm text-primary-foreground">
+        <p className="whitespace-pre-wrap">{task}</p>
+      </div>
+    </div>
+  );
+}
+
+function ImuConversationView({ cid }: { cid: number }) {
+  const [task, setTask] = useState("");
+  const [interactive, setInteractive] = useState(true);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState("");
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [advRuntime, setAdvRuntime] = useState("");
+  const [advMemory, setAdvMemory] = useState("");
+  const [advSystemPrompt, setAdvSystemPrompt] = useState("");
+  const [advMaxDelegations, setAdvMaxDelegations] = useState("");
+  const [advCacheDelegations, setAdvCacheDelegations] = useState("");
+  const [advCacheMaxEntries, setAdvCacheMaxEntries] = useState("");
+  const [advCacheTtl, setAdvCacheTtl] = useState("");
+  const [askUserResponse, setAskUserResponse] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const prevScrollHeightRef = useRef(0);
+  const prevLastSessionIdRef = useRef<string | undefined>(undefined);
+  const prevChatLengthRef = useRef(0);
+  const titleInputRef = useRef<HTMLInputElement>(null);
+
+  const { data: agents } = useResources("agents");
+  const { data: memories } = useResources("memories");
+
+  const { data, isLoading, error, fetchPreviousPage, hasPreviousPage, isFetchingPreviousPage } =
+    useConversationInfinite(cid);
+
+  const allSessions = data?.pages.flatMap((p) => p.sessions) ?? [];
+  const conversation = data?.pages[data.pages.length - 1];
+  const lastSession = allSessions[allSessions.length - 1];
+  const hasActiveSession =
+    lastSession?.status === "running" || lastSession?.status === "starting";
+
+  useConversationInfinite(cid, { refetchInterval: hasActiveSession ? 2000 : false });
+
+  const submit = useSubmitConversationTask(cid);
+  const stop = useStopSession();
+  const rename = useRenameImuConversation();
+  const { pendingAskUsers, chatMessages, respond } = useSessionWS(
+    lastSession?.run_id ?? "",
+    !!lastSession && interactive,
+  );
+
+  const agentNames = (agents ?? []).map((a: { name: string }) => a.name);
+  const memoryNames = [...new Set((memories ?? []).map((m: { name: string }) => m.name)), "none"].sort();
+
+  const advRuntimeError =
+    advRuntime.trim() && agentNames.length > 0 && !agentNames.includes(advRuntime.trim())
+      ? "Runtime not found in installed agents"
+      : "";
+  const advMemoryError =
+    advMemory.trim() && memoryNames.length > 0 && !memoryNames.includes(advMemory.trim())
+      ? "Memory not found in installed providers"
+      : "";
+  const hasAdvError = !!advRuntimeError || !!advMemoryError;
+
+  const advCount = [
+    advRuntime, advMemory, advSystemPrompt, advMaxDelegations,
+    advCacheDelegations, advCacheMaxEntries, advCacheTtl,
+  ].filter((v) => v.trim()).length;
+
+  // Scroll anchor: restore position when older pages prepend
+  useEffect(() => {
+    if (!scrollRef.current) return;
+    const delta = scrollRef.current.scrollHeight - prevScrollHeightRef.current;
+    if (delta > 0) {
+      scrollRef.current.scrollTop += delta;
+      prevScrollHeightRef.current = 0;
+    }
+  }, [data?.pages.length]);
+
+  // Auto-scroll to bottom when newest session changes
+  useEffect(() => {
+    if (!scrollRef.current) return;
+    if (lastSession?.run_id !== prevLastSessionIdRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+    prevLastSessionIdRef.current = lastSession?.run_id;
+  }, [lastSession?.run_id]);
+
+  // Auto-scroll when new chat messages arrive
+  useEffect(() => {
+    if (!scrollRef.current) return;
+    if (chatMessages.length > prevChatLengthRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+    prevChatLengthRef.current = chatMessages.length;
+  }, [chatMessages.length]);
+
+  // IntersectionObserver: load older sessions when sentinel reaches top
+  useEffect(() => {
+    if (!sentinelRef.current || !scrollRef.current) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && hasPreviousPage && !isFetchingPreviousPage) {
+          prevScrollHeightRef.current = scrollRef.current?.scrollHeight ?? 0;
+          fetchPreviousPage();
+        }
+      },
+      { root: scrollRef.current, threshold: 0.1 },
+    );
+    observer.observe(sentinelRef.current);
+    return () => observer.disconnect();
+  }, [hasPreviousPage, isFetchingPreviousPage, fetchPreviousPage]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = task.trim();
+    if (!trimmed || hasActiveSession || hasAdvError) return;
+    submit.mutate(
+      {
+        task: trimmed,
+        role: IMU_ROLE,
+        interactive,
+        system_prompt: advSystemPrompt.trim() || undefined,
+        runtime: advRuntime.trim() || undefined,
+        memory: advMemory.trim() || undefined,
+        max_num_delegations: advMaxDelegations.trim() ? Number(advMaxDelegations) : undefined,
+        cache_delegations: advCacheDelegations ? advCacheDelegations === "true" : undefined,
+        cache_max_entries: advCacheMaxEntries.trim() ? Number(advCacheMaxEntries) : undefined,
+        cache_ttl_seconds: advCacheTtl.trim() ? Number(advCacheTtl) : undefined,
+      },
+      { onSuccess: () => setTask("") },
+    );
+  }
+
+  function handleAskUserResponse(pending: AskUserPending, text: string) {
+    if (!text.trim()) return;
+    respond(pending.request_id, text.trim());
+    setAskUserResponse("");
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e as unknown as React.FormEvent);
+    }
+  }
+
+  function startEditTitle() {
+    setTitleDraft(conversation?.title ?? "");
+    setEditingTitle(true);
+    setTimeout(() => titleInputRef.current?.select(), 0);
+  }
+
+  function commitTitle() {
+    const trimmed = titleDraft.trim();
+    rename.mutate({ conversationId: cid, title: trimmed || null });
+    setEditingTitle(false);
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center gap-2 text-destructive">
+        <AlertCircle className="h-4 w-4" />
+        <span>Error: {(error as Error).message}</span>
+      </div>
+    );
+  }
+
+  const title = conversation?.title ?? `Conversation #${cid}`;
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex flex-shrink-0 items-center justify-between border-b border-border pb-3 mb-4">
+        <div className="flex items-center gap-3">
+          {editingTitle ? (
+            <Input
+              ref={titleInputRef}
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              onBlur={commitTitle}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") { e.preventDefault(); commitTitle(); }
+                if (e.key === "Escape") setEditingTitle(false);
+              }}
+              className="h-7 text-sm font-semibold w-64"
+              placeholder={`Conversation #${cid}`}
+            />
+          ) : (
+            <h1
+              className="text-sm font-semibold cursor-pointer hover:text-muted-foreground"
+              onClick={startEditTitle}
+              title="Click to rename"
+            >
+              {title}
+            </h1>
+          )}
+        </div>
+        {allSessions.length > 0 && (
+          <span className="text-xs text-muted-foreground">
+            {allSessions.length} session{allSessions.length !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+
+      {/* Message list */}
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto w-full max-w-2xl space-y-6 py-4">
+          <div ref={sentinelRef} className="h-1" />
+          {isFetchingPreviousPage && (
+            <div className="flex justify-center py-2">
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            </div>
+          )}
+          {!isLoading && allSessions.length === 0 && (
+            <p className="text-center text-sm text-muted-foreground py-12">
+              Start a conversation with Bot Imu below.
+            </p>
+          )}
+          {allSessions.map((session, index) => {
+            const isLast = index === allSessions.length - 1;
+            return (
+              <div key={session.run_id} className="space-y-4">
+                {(session.user_task ?? session.task) && (
+                  <UserMessage task={(session.user_task ?? session.task)!} />
+                )}
+                {isLast &&
+                  chatMessages.map((msg: ChatMessage) => (
+                    <div
+                      key={msg.id}
+                      className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
+                    >
+                      <div
+                        className={`max-w-[80%] rounded-lg px-3 py-2 text-sm ${
+                          msg.role === "user"
+                            ? "bg-primary text-primary-foreground"
+                            : "bg-muted text-foreground"
+                        }`}
+                      >
+                        <p className="whitespace-pre-wrap">{msg.text}</p>
+                      </div>
+                    </div>
+                  ))}
+                <ImuAgentMessage session={session} />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Pending ask_user questions */}
+      {pendingAskUsers.length > 0 && (
+        <div className="flex-shrink-0 border-t border-border bg-background px-4 pt-3 pb-1">
+          <div className="mx-auto max-w-2xl space-y-2">
+            {pendingAskUsers.map((pending) => (
+              <div
+                key={pending.request_id}
+                className="rounded-lg border border-border bg-muted/30 p-3 space-y-2"
+              >
+                <p className="text-sm font-medium">{pending.question}</p>
+                {pending.why && (
+                  <p className="text-xs text-muted-foreground">{pending.why}</p>
+                )}
+                {pending.choices ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {pending.choices.map((choice) => (
+                      <Button
+                        key={choice}
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleAskUserResponse(pending, choice)}
+                      >
+                        {choice}
+                      </Button>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="flex gap-2">
+                    <Input
+                      value={askUserResponse}
+                      onChange={(e) => setAskUserResponse(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && !e.shiftKey) {
+                          e.preventDefault();
+                          handleAskUserResponse(pending, askUserResponse);
+                        }
+                      }}
+                      placeholder="Your answer…"
+                      autoFocus
+                      className="text-sm"
+                    />
+                    <Button
+                      type="button"
+                      size="icon"
+                      disabled={!askUserResponse.trim()}
+                      onClick={() => handleAskUserResponse(pending, askUserResponse)}
+                    >
+                      <CornerDownLeft className="h-4 w-4" />
+                    </Button>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Task input */}
+      <div className="flex-shrink-0 border-t border-border bg-background pt-4">
+        <form onSubmit={handleSubmit} className="mx-auto max-w-2xl space-y-2">
+          <Textarea
+            value={task}
+            onChange={(e) => setTask(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={
+              hasActiveSession
+                ? "Bot Imu is working…"
+                : "Ask Bot Imu anything… (Enter to send, Shift+Enter for new line)"
+            }
+            disabled={hasActiveSession || submit.isPending}
+            className="h-[80px] resize-none overflow-y-auto"
+            autoFocus
+          />
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs text-muted-foreground px-1">Role: {IMU_ROLE}</span>
+            <div className="flex items-center gap-1">
+              <Button
+                type="button"
+                variant={interactive ? "secondary" : "ghost"}
+                size="sm"
+                className="h-8 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+                onClick={() => setInteractive((v) => !v)}
+                title={
+                  interactive
+                    ? "Interactive: agent can ask questions"
+                    : "Auto: agent cannot ask questions"
+                }
+              >
+                <MessageSquare className="h-3.5 w-3.5" />
+                {interactive ? "Interactive" : "Auto"}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="relative h-8 w-8 text-muted-foreground hover:text-foreground"
+                onClick={() => setSettingsOpen(true)}
+                title="Advanced options"
+              >
+                <Settings className="h-4 w-4" />
+                {advCount > 0 && (
+                  <span className="absolute -right-0.5 -top-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-primary text-[9px] text-primary-foreground">
+                    {advCount}
+                  </span>
+                )}
+              </Button>
+              {hasActiveSession ? (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={() => lastSession && stop.mutate(lastSession.run_id)}
+                  disabled={stop.isPending}
+                >
+                  {stop.isPending ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Square className="mr-2 h-4 w-4 fill-current" />
+                  )}
+                  Stop
+                </Button>
+              ) : (
+                <Button
+                  type="submit"
+                  disabled={!task.trim() || submit.isPending || hasAdvError}
+                >
+                  {submit.isPending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <CornerDownLeft className="h-4 w-4" />
+                  )}
+                </Button>
+              )}
+            </div>
+          </div>
+        </form>
+      </div>
+
+      {/* Advanced settings dialog */}
+      <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Advanced Options</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Runtime</Label>
+                <Input
+                  list="imu-adv-runtime"
+                  value={advRuntime}
+                  onChange={(e) => setAdvRuntime(e.target.value)}
+                  placeholder="default"
+                  className="text-sm"
+                />
+                <datalist id="imu-adv-runtime">
+                  {agentNames.map((n) => (
+                    <option key={n} value={n} />
+                  ))}
+                </datalist>
+                {advRuntimeError && (
+                  <p className="text-xs text-destructive">{advRuntimeError}</p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label>Memory</Label>
+                <Input
+                  list="imu-adv-memory"
+                  value={advMemory}
+                  onChange={(e) => setAdvMemory(e.target.value)}
+                  placeholder="dial"
+                  className="text-sm"
+                />
+                <datalist id="imu-adv-memory">
+                  {memoryNames.map((n) => (
+                    <option key={n} value={n} />
+                  ))}
+                </datalist>
+                {advMemoryError && (
+                  <p className="text-xs text-destructive">{advMemoryError}</p>
+                )}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>System Prompt</Label>
+              <Textarea
+                value={advSystemPrompt}
+                onChange={(e) => setAdvSystemPrompt(e.target.value)}
+                placeholder="Additional instructions appended to conversation context…"
+                rows={3}
+                className="text-sm"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Max Delegations</Label>
+                <Input
+                  type="number"
+                  min="0"
+                  value={advMaxDelegations}
+                  onChange={(e) => setAdvMaxDelegations(e.target.value)}
+                  placeholder="0 (unlimited)"
+                  className="h-8 text-xs"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Cache Delegations</Label>
+                <Select
+                  value={advCacheDelegations || "__empty__"}
+                  onValueChange={(v) => setAdvCacheDelegations(v === "__empty__" ? "" : v)}
+                >
+                  <SelectTrigger className="h-8 text-xs">
+                    <SelectValue placeholder="Default (true)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__empty__" className="text-muted-foreground">
+                      Default (true)
+                    </SelectItem>
+                    <SelectItem value="true">true</SelectItem>
+                    <SelectItem value="false">false</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Cache Max Entries</Label>
+                <Input
+                  type="number"
+                  min="0"
+                  value={advCacheMaxEntries}
+                  onChange={(e) => setAdvCacheMaxEntries(e.target.value)}
+                  placeholder="0 (unlimited)"
+                  className="h-8 text-xs"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Cache TTL (seconds)</Label>
+                <Input
+                  type="number"
+                  min="0"
+                  value={advCacheTtl}
+                  onChange={(e) => setAdvCacheTtl(e.target.value)}
+                  placeholder="0 (unlimited)"
+                  className="h-8 text-xs"
+                />
+              </div>
+            </div>
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setAdvRuntime("");
+                setAdvMemory("");
+                setAdvSystemPrompt("");
+                setAdvMaxDelegations("");
+                setAdvCacheDelegations("");
+                setAdvCacheMaxEntries("");
+                setAdvCacheTtl("");
+              }}
+            >
+              Reset
+            </Button>
+            <Button size="sm" onClick={() => setSettingsOpen(false)}>
+              Done
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function ImuHome() {
+  const navigate = useNavigate();
+  const conversations = useImuConversations();
+  const createConversation = useCreateImuConversation();
+
+  // Redirect to most recent conversation when one exists
+  useEffect(() => {
+    if (conversations.data && conversations.data.length > 0) {
+      navigate(`/imu/${conversations.data[0].id}`, { replace: true });
+    }
+  }, [conversations.data, navigate]);
+
+  if (conversations.isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4">
+      <BotMessageSquare className="h-12 w-12 text-muted-foreground/40" />
+      <div className="text-center">
+        <h2 className="text-lg font-semibold">Bot Imu</h2>
+        <p className="text-sm text-muted-foreground mt-1">Your personal AI assistant</p>
+      </div>
+      <Button
+        onClick={() =>
+          createConversation.mutate(undefined, {
+            onSuccess: (conv) => navigate(`/imu/${conv.id}`),
+          })
+        }
+        disabled={createConversation.isPending}
+      >
+        {createConversation.isPending ? (
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        ) : (
+          <Plus className="mr-2 h-4 w-4" />
+        )}
+        New Conversation
+      </Button>
+    </div>
+  );
+}
+
+export default function ImuPage() {
+  const { conversationId } = useParams();
+  const cid = conversationId ? Number(conversationId) : null;
+
+  if (cid !== null) {
+    return <ImuConversationView cid={cid} />;
+  }
+
+  return <ImuHome />;
 }


### PR DESCRIPTION
## Summary

- **`ImuPage.tsx`** — Full rewrite replacing the placeholder. At `/imu`, auto-redirects to the most recent conversation (or shows an empty state with "New Conversation" button). At `/imu/:conversationId`, renders `ImuConversationView`: infinite-scroll message list, hardcoded `role: "imu"`, ask_user handling, interactive/auto toggle, advanced settings dialog (runtime, memory, system prompt, cache config).
- **`AppLayout.tsx`** — Adds `ImuSidebar` (conversation list with rename/delete per item, new conversation button) shown when on `/imu/:conversationId` routes, matching the existing `ConversationSidebar` pattern. Breadcrumbs handle `/imu` and `/imu/:conversationId` paths.
- **New hooks** — `useImuConversations` query; `useCreateImuConversation`, `useRenameImuConversation`, `useDeleteImuConversation` mutations (with optimistic delete). Query key: `["imu", "conversations"]`.
- **`ImuConversation`** type added to `api/types.ts`.

## Test plan

- [ ] Navigate to `/imu` — redirects to most recent conversation if one exists; shows empty state with "New Conversation" button if none
- [ ] Create a conversation from empty state — navigates to `/imu/<id>`, sidebar appears
- [ ] Submit a task — role shows as `imu`, message appears, polling starts
- [ ] Scroll to top with >20 sessions — older sessions load, scroll position preserved
- [ ] Rename conversation in sidebar — title updates
- [ ] Delete non-active conversation — removed from sidebar, navigates to `/imu`
- [ ] Breadcrumb shows "Bot Imu > Conversation #n" when viewing a conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)