### PR TITLE
Bot Imu: active session badge, imu role auto-install, deletion protection

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -227,6 +227,7 @@ export interface ImuConversation {
   created_at: string;
   updated_at: string | null;
   session_count: number;
+  active_session_count: number;
 }
 
 export interface Schedule {

--- a/gui/frontend/src/layouts/AppLayout.tsx
+++ b/gui/frontend/src/layouts/AppLayout.tsx
@@ -442,6 +442,8 @@ export default function AppLayout() {
   const crumbs = useBreadcrumbs();
   const navigate = useNavigate();
   const allProjects = useProjects();
+  const { data: imuConversations } = useImuConversations();
+  const hasActiveImuSession = (imuConversations ?? []).some((c) => c.active_session_count > 0);
   const { setTheme } = useTheme();
   const [cmdOpen, setCmdOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
@@ -489,6 +491,9 @@ export default function AppLayout() {
               >
                 <Icon className="h-4 w-4" />
                 {label}
+                {to === "/imu" && hasActiveImuSession && (
+                  <span className="ml-auto h-2 w-2 rounded-full bg-green-500 animate-pulse" />
+                )}
               </NavLink>
             ))}
 

--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -21,6 +21,22 @@ logger = logging.getLogger(__name__)
 from strawpot_gui.routers import config, conversations, files, fs, health, imu, logs, project_resources, projects, registry, schedules, sessions, sse, stats, ws
 
 
+def _ensure_imu_role() -> None:
+    """Install the imu role globally at startup if not already present."""
+    imu_role_path = get_strawpot_home() / "roles" / "imu" / "ROLE.md"
+    if not imu_role_path.exists():
+        logger.info("imu role not found, installing...")
+        result = subprocess.run(
+            ["strawhub", "install", "role", "imu", "--global", "-y"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            logger.info("imu role installed successfully")
+        else:
+            logger.warning("Failed to install imu role: %s", result.stderr[:200])
+
+
 def _auto_rebuild_frontend(dist_dir: Path) -> None:
     """Rebuild the frontend if source files are newer than dist."""
     frontend_dir = dist_dir.parent  # frontend/
@@ -72,6 +88,7 @@ def create_app(db_path: str | None = None) -> FastAPI:
         ensure_global_config()
         init_db(db_path)
         ensure_imu_project(db_path)
+        _ensure_imu_role()
         from strawpot_gui.db import mark_orphaned_sessions_stopped
         mark_orphaned_sessions_stopped(db_path)
         sync_sessions(db_path)

--- a/gui/src/strawpot_gui/routers/imu.py
+++ b/gui/src/strawpot_gui/routers/imu.py
@@ -19,7 +19,8 @@ def list_imu_conversations(
     """List Bot Imu conversations, newest first."""
     rows = conn.execute(
         """SELECT c.id, c.title, c.created_at, c.updated_at,
-                  COUNT(s.run_id) AS session_count
+                  COUNT(s.run_id) AS session_count,
+                  COUNT(CASE WHEN s.status IN ('running', 'starting') THEN 1 END) AS active_session_count
            FROM conversations c
            LEFT JOIN sessions s ON s.conversation_id = c.id
            WHERE c.project_id = ?

--- a/gui/src/strawpot_gui/routers/registry.py
+++ b/gui/src/strawpot_gui/routers/registry.py
@@ -311,10 +311,15 @@ def install_resource(data: dict = Body(...)):
     return run_strawhub("install", singular, "-y", name, "--global")
 
 
+_PROTECTED_ROLES = {"imu"}
+
+
 @router.delete("/{resource_type}/{name}")
 def uninstall_resource(resource_type: str, name: str):
     """Uninstall a resource via strawhub."""
     validate_type(resource_type)
+    if resource_type == "roles" and name in _PROTECTED_ROLES:
+        raise HTTPException(403, f"'{name}' is a built-in role and cannot be uninstalled.")
     singular = resource_type.rstrip("s") if resource_type != "memories" else "memory"
     return run_strawhub("uninstall", singular, name, "--global")
 

--- a/imu/DESIGN.md
+++ b/imu/DESIGN.md
@@ -61,7 +61,7 @@ the Bot Imu dedicated page using ConversationView.
 Bot Imu sessions use the standard session storage path. When launched
 from the CLI, sessions go under the current directory's
 `.strawpot/sessions/`. When launched from the GUI, sessions go to
-`~/.strawpot/.strawpot/sessions/` (working directory: `~/.strawpot`).
+`~/.strawpot/sessions/` (working directory: `~`).
 
 ### No Isolation
 
@@ -631,8 +631,8 @@ metadata:
 ## Session Storage
 
 Sessions are stored at `<project>/.strawpot/sessions/<run_id>/`.
-Bot Imu sessions are stored at `~/.strawpot/.strawpot/sessions/<run_id>/`
-(Bot Imu uses `~/.strawpot` as its working directory).
+Bot Imu sessions are stored at `~/.strawpot/sessions/<run_id>/`
+(Bot Imu uses `~` as its working directory).
 
 ## Find Sessions
 
@@ -759,11 +759,11 @@ A virtual project row is ensured at startup in `db.py`:
 
 ```sql
 INSERT OR IGNORE INTO projects (id, name, directory, created_at)
-VALUES (0, 'Bot Imu', '~/.strawpot', datetime('now'));
+VALUES (0, 'Bot Imu', '~', datetime('now'));
 ```
 
-Bot Imu's sessions are stored at `~/.strawpot/.strawpot/sessions/`
-(the virtual project uses `~/.strawpot` as its working directory).
+Bot Imu's sessions are stored at `~/.strawpot/sessions/`
+(the virtual project uses `~` as its working directory).
 
 **New endpoint (single addition):**
 
@@ -862,7 +862,7 @@ conversation.
   used on SessionDetail).
 ### Bot Imu Session Discovery
 
-The GUI session sync scans `~/.strawpot/.strawpot/sessions/` for Bot
+The GUI session sync scans `~/.strawpot/sessions/` for Bot
 Imu session history. These appear under the "Bot Imu" virtual project
 (project_id = 0, auto-created at startup alongside
 `mark_orphaned_sessions_stopped`).
@@ -908,8 +908,8 @@ infrastructure handles most of the work.
    row exists at `db.py` startup alongside `mark_orphaned_sessions_stopped`.
 4. **`GET /api/imu/conversations`** and **`POST /api/imu/conversations`** —
    list and create Bot Imu conversations (project_id=0).
-5. **Bot Imu session storage path** — IMU sessions use `~/.strawpot` as
-   the working directory, stored in `~/.strawpot/.strawpot/sessions/`.
+5. **Bot Imu session storage path** — IMU sessions use `~` as
+   the working directory, stored in `~/.strawpot/sessions/`.
 
 No `IMUManager`, no PTY, no `/api/imu/ws` — all handled by existing
 `/ws/sessions/{run_id}` and `/api/conversations/{id}/tasks`.
@@ -1081,17 +1081,17 @@ tried to create a PR. You can fix this by setting it in config:
 |---|------|-------|---------|
 | 1 | Create `imu` role (`ROLE.md`) | 1 — Role & Skills | Done |
 | 2 | Create six skills (`strawpot-cli`, `strawpot-gui-api`, `strawpot-config`, `strawpot-schedules`, `strawhub-cli`, `strawpot-sessions`) | 1 — Role & Skills | Done |
-| 3 | Virtual Bot Imu project (id=0) in `db.py` startup | 2 — Backend | Planned |
-| 4 | `GET /api/imu/conversations` and `POST /api/imu/conversations` | 2 — Backend | Planned |
-| 5 | Bot Imu session storage path (`~/.strawpot`) | 2 — Backend | Planned |
-| 6 | "Bot Imu" nav link in left sidebar | 3 — Frontend | Planned |
-| 7 | Dedicated page (`/imu`, `/imu/:conversationId`) with conversation list sidebar | 3 — Frontend | Planned |
-| 8 | Submit input (new session or ask_user reply) | 3 — Frontend | Planned |
-| 9 | Connection management + "Launching Bot Imu…" spinner | 3 — Frontend | Planned |
-| 10 | Active session badge on Bot Imu nav link | 4 — History | Planned |
-| 11 | Conversation history via `useConversationInfinite` + AgentMessage access | 4 — History | Planned |
+| 3 | Virtual Bot Imu project (id=0) in `db.py` startup | 2 — Backend | Done |
+| 4 | `GET /api/imu/conversations` and `POST /api/imu/conversations` | 2 — Backend | Done |
+| 5 | Bot Imu session storage path (`~` as working dir → `~/.strawpot/sessions/`) | 2 — Backend | Done |
+| 6 | "Bot Imu" nav link in left sidebar | 3 — Frontend | Done |
+| 7 | Dedicated page (`/imu`, `/imu/:conversationId`) with conversation list sidebar | 3 — Frontend | Done |
+| 8 | Submit input (new session or ask_user reply) | 3 — Frontend | Done |
+| 9 | Connection management + "Launching Bot Imu…" spinner | 3 — Frontend | Done |
+| 10 | Active session badge on Bot Imu nav link | 4 — History | Done |
+| 11 | Conversation history via `useConversationInfinite` + AgentMessage access | 4 — History | Done |
 | 12 | `strawpot schedule` CLI commands (optional) | 4 — History | Planned |
-| 13 | Memory provider for cross-session context | 5 — Memory | Planned |
+| 13 | Memory provider for cross-session context | 5 — Memory | Done (dial is the system default; imu uses `~/.strawpot/memory/dial-data`) |
 
 ---
 


### PR DESCRIPTION
## Summary

- **Active session badge**: pulsing green dot on Bot Imu nav link when any session is running/starting (`active_session_count` added to SQL query + type)
- **Auto-install imu role**: `_ensure_imu_role()` called at GUI startup — installs `imu` role globally via `strawhub` if not already present
- **Deletion protection**: `DELETE /api/registry/roles/imu` returns 403 — `imu` is a built-in role and cannot be uninstalled
- **DESIGN.md**: mark items 3–11 and 13 as Done; fix stale session path references (`~/.strawpot/.strawpot/sessions/` → `~/.strawpot/sessions/`)

## Test plan

- [ ] Nav shows pulsing green dot when Bot Imu session is running, none when idle
- [ ] Fresh install: GUI startup auto-installs imu role if missing
- [ ] Attempting to uninstall `imu` role via the GUI returns 403
- [ ] DESIGN.md implementation table shows items 1–11 and 13 as Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)