### PR TITLE
Structured context format and TODO update

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -78,6 +78,15 @@
   unpinned in strawpot's pyproject.toml, so `pip install --upgrade strawpot`
   may or may not pull a newer denden-server depending on resolver state.
 
+## Resources
+
+- [ ] **Support custom resource import**
+  Allow users to import custom resources (files, configs, templates) into
+  projects that agents can reference during sessions. Currently resources
+  are limited to roles, skills, and project files. Custom imports would
+  let users provide reference docs, API specs, or other context that agents
+  need but that don't fit existing resource types.
+
 ## Housekeeping
 
 - [ ] **Archive retention policy**

--- a/designs/context/DESIGN.md
+++ b/designs/context/DESIGN.md
@@ -135,8 +135,8 @@ This fits into the existing flow — the `summary` field already propagates thro
 | 5 | Filter out non-terminal sessions | Done |
 | 6 | Use `user_task` instead of `task` for asked lines | Done |
 | 7 | Cap turns + tiered condensation | Done |
-| 8 | File change tracking in trace events | Planned |
-| 9 | Structured context format | Planned |
+| 8 | File change tracking in trace events | Done |
+| 9 | Structured context format | Done |
 | 10 | Richer session summaries | Discussion |
 
 ## Key files

--- a/gui/src/strawpot_gui/routers/conversations.py
+++ b/gui/src/strawpot_gui/routers/conversations.py
@@ -59,7 +59,8 @@ _MAX_TURNS = 10
 def _build_conversation_context(conn, conversation_id: int) -> str:
     """Build a prior-turns summary to prepend to the next session's task."""
     rows = conn.execute(
-        "SELECT task, user_task, summary, exit_code, status, files_changed "
+        "SELECT task, user_task, summary, exit_code, status, "
+        "files_changed, duration_ms "
         "FROM sessions "
         "WHERE conversation_id = ? AND status IN ('completed', 'failed') "
         "ORDER BY started_at",
@@ -109,6 +110,27 @@ def _build_conversation_context(conn, conversation_id: int) -> str:
         else:
             task_limit, summary_limit = 200, 200
 
+        # Turn header: status, duration, files
+        meta = [row["status"]]
+        duration_ms = row["duration_ms"]
+        if duration_ms is not None:
+            if duration_ms < 60_000:
+                meta.append(f"{duration_ms // 1000}s")
+            else:
+                meta.append(f"{duration_ms // 60_000}m{(duration_ms % 60_000) // 1000}s")
+        header = f"**Turn {i}** [{', '.join(meta)}]"
+        # File paths for recent turns (last 3)
+        if remaining < 3 and row["files_changed"]:
+            try:
+                files = json.loads(row["files_changed"])
+                if files:
+                    file_list = ", ".join(files[:10])
+                    if len(files) > 10:
+                        file_list += f" (+{len(files) - 10} more)"
+                    header += f" | files: {file_list}"
+            except (json.JSONDecodeError, TypeError):
+                pass
+
         task_text = row["user_task"] or _strip_prior_context(row["task"])
         task_line = _condense(task_text, task_limit)
         if row["summary"]:
@@ -117,18 +139,10 @@ def _build_conversation_context(conn, conversation_id: int) -> str:
             result_line = f"(failed, exit code {row['exit_code']})"
         else:
             result_line = f"(exit code {row['exit_code']})"
-        turn_line = f"- Turn {i}: asked: {task_line} → did: {result_line}"
-        # Show file paths for recent turns (last 3) only
-        if remaining < 3 and row["files_changed"]:
-            try:
-                files = json.loads(row["files_changed"])
-                if files:
-                    turn_line += f" | files: {', '.join(files[:10])}"
-                    if len(files) > 10:
-                        turn_line += f" (+{len(files) - 10} more)"
-            except (json.JSONDecodeError, TypeError):
-                pass
-        parts.append(turn_line)
+
+        parts.append(header)
+        parts.append(f"- Asked: {task_line}")
+        parts.append(f"- Result: {result_line}")
 
     # Pending Follow-up: last session's summary for short follow-up turns
     last = rows[-1]

--- a/gui/tests/test_conversations.py
+++ b/gui/tests/test_conversations.py
@@ -487,11 +487,11 @@ class TestBuildConversationContext:
         with get_db(app.state.db_path) as conn:
             ctx = _build_conversation_context(conn, cid)
 
-        lines = [l for l in ctx.split("\n") if l.startswith("- Turn ")]
+        result_lines = [l for l in ctx.split("\n") if l.startswith("- Result: ")]
         # Turn 1-3 are old (4+ from end): summary should be truncated (has …)
-        assert "…" in lines[0]
+        assert "…" in result_lines[0]
         # Turn 5 is recent (1 from end): summary should be full (no …)
-        assert "…" not in lines[4]
+        assert "…" not in result_lines[4]
 
     def test_pending_followup_capped(self, client, tmp_path, app):
         """Pending Follow-up is capped at 800 chars."""
@@ -541,9 +541,9 @@ class TestBuildConversationContext:
         assert "src/file_3.py" in ctx
         assert "src/file_4.py" in ctx
         # Old turns (turns 1, 2) should NOT show files even if they had them
-        lines = [l for l in ctx.split("\n") if l.startswith("- Turn ")]
-        assert "files:" not in lines[0]  # Turn 1: no files_changed
-        assert "files:" not in lines[1]  # Turn 2: no files_changed (old turn)
+        turn_headers = [l for l in ctx.split("\n") if l.startswith("**Turn ")]
+        assert "files:" not in turn_headers[0]  # Turn 1: no files_changed
+        assert "files:" not in turn_headers[1]  # Turn 2: no files_changed (old turn)
 
     def test_files_changed_caps_at_10(self, client, tmp_path, app):
         """File list is capped at 10 with a +N more indicator."""


### PR DESCRIPTION
## Summary
- **Structured context format** — each turn now has a header line (`**Turn N** [status, duration]`) with metadata on separate `- Asked:` / `- Result:` lines, replacing the single flat `- Turn N: asked: X → did: Y` format
- **TODO.md** — added "Support custom resource import" item under new Resources section
- **DESIGN.md** — marked items 8 (file change tracking) and 9 (structured context) as Done

Implements item 9 from `designs/context/DESIGN.md`.

## Test plan
- [x] All 38 conversation tests pass (updated for new format)
- [x] All 13 sessions sync tests pass
- [x] 51 total tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)