### PR TITLE
Guard Imu role and Bot Imu project against deletion

### DIFF
--- a/gui/frontend/src/components/ResourceDetailSheet.tsx
+++ b/gui/frontend/src/components/ResourceDetailSheet.tsx
@@ -121,7 +121,7 @@ export default function ResourceDetailSheet({
   // and ResourceBrowser.tsx — all three must be updated together.
   const PROTECTED: Record<string, string[]> = {
     skills: ["denden", "strawpot-session-recap"],
-    roles: ["ai-ceo", "ai-employee"],
+    roles: ["imu", "ai-ceo", "ai-employee"],
     agents: ["strawpot-claude-code"],
     memories: ["dial"],
   };

--- a/gui/frontend/src/pages/ResourceBrowser.tsx
+++ b/gui/frontend/src/pages/ResourceBrowser.tsx
@@ -23,7 +23,7 @@ import { toast } from "sonner";
 // and ResourceDetailSheet.tsx — all three must be updated together.
 const PROTECTED: Record<string, string[]> = {
   skills: ["denden", "strawpot-session-recap"],
-  roles: ["ai-ceo", "ai-employee"],
+  roles: ["imu", "ai-ceo", "ai-employee"],
   agents: ["strawpot-claude-code"],
   memories: ["dial"],
 };

--- a/gui/src/strawpot_gui/routers/projects.py
+++ b/gui/src/strawpot_gui/routers/projects.py
@@ -99,6 +99,8 @@ def update_project(project_id: int, body: ProjectUpdate, conn=Depends(get_db_con
 
 @router.delete("/projects/{project_id}")
 def delete_project(project_id: int, conn=Depends(get_db_conn)):
+    if project_id == 0:
+        raise HTTPException(403, "Bot Imu project cannot be deleted")
     row = conn.execute("SELECT id FROM projects WHERE id = ?", (project_id,)).fetchone()
     if not row:
         raise HTTPException(404, "Project not found")


### PR DESCRIPTION
## Summary
- Add `"imu"` to frontend `PROTECTED` roles lists so the uninstall button is hidden (backend already rejects with 403 but UI was out of sync)
- Return 403 when attempting to delete project_id=0 (Bot Imu virtual project)

## Test plan
- [ ] Open Resource Browser → Roles → imu: verify no "Uninstall" button
- [ ] Open imu role detail sheet: verify no "Uninstall" button
- [ ] `curl -X DELETE localhost:8741/api/projects/0` returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)