### PR TITLE
Strip session recap from conversation view

### DIFF
--- a/gui/src/strawpot_gui/routers/conversations.py
+++ b/gui/src/strawpot_gui/routers/conversations.py
@@ -377,7 +377,10 @@ def get_conversation(
     sessions = list(reversed(rows[:limit]))  # ascending for display
 
     result = dict(row)
-    result["sessions"] = [dict(s) for s in sessions]
+    result["sessions"] = [
+        {**dict(s), "summary": _strip_recap(s["summary"]) if s["summary"] else s["summary"]}
+        for s in sessions
+    ]
     result["has_more"] = has_more
     return result
 

--- a/gui/tests/test_conversations.py
+++ b/gui/tests/test_conversations.py
@@ -116,6 +116,27 @@ class TestGetConversation:
         assert len(data["sessions"]) == 1
         assert data["has_more"] is False
 
+    def test_summary_strips_recap(self, app, client, tmp_path):
+        """Session recap block is stripped from summary in API response."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        summary = "Built the login page.\n\n## Session Recap\n### Accomplished\n- Login page done"
+        with get_db(app.state.db_path) as conn:
+            _insert_completed_session(
+                conn, pid, cid,
+                task="build login", user_task="build login",
+                summary=summary,
+            )
+
+        data = client.get(f"/api/conversations/{cid}").json()
+        returned_summary = data["sessions"][0]["summary"]
+        assert "## Session Recap" not in returned_summary
+        assert "Built the login page." in returned_summary
+
 
 class TestListProjectConversations:
     def test_empty_list(self, client, tmp_path):


### PR DESCRIPTION
## Summary

- Strip the `## Session Recap` block from session summaries in the `get_conversation` API response
- The recap is an internal mechanism for context handover between sessions, not user-facing content
- Full output (including recap) remains in the DB for the context builder and memory provider

## Test plan

- [x] `test_summary_strips_recap` — verifies recap is removed and main content preserved
- [x] All 58 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)