### PR TITLE
Add project-level resource config visibility

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -122,6 +122,7 @@ export interface ResourceDetail extends Resource {
 
 export interface ProjectResource extends Resource {
   type: string; // "roles" | "skills" | "agents" | "memories"
+  config_count: number;
 }
 
 export interface InstallResult {

--- a/gui/frontend/src/components/ProjectResourcesTab.tsx
+++ b/gui/frontend/src/components/ProjectResourcesTab.tsx
@@ -11,18 +11,22 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Skeleton } from "@/components/ui/skeleton";
 import ResourceDetailSheet from "@/components/ResourceDetailSheet";
 import InstallDialog from "@/components/InstallDialog";
 import { useUninstallProjectResource } from "@/hooks/mutations/use-project-resources";
-import { Download, Trash2 } from "lucide-react";
+import { Download, Settings, Trash2 } from "lucide-react";
 import { toast } from "sonner";
+import type { ProjectResource } from "@/api/types";
+
+const RESOURCE_TYPES = ["roles", "skills", "agents", "memories"] as const;
 
 const TYPE_LABELS: Record<string, string> = {
-  roles: "Role",
-  skills: "Skill",
-  agents: "Agent",
-  memories: "Memory",
+  roles: "Roles",
+  skills: "Skills",
+  agents: "Agents",
+  memories: "Memories",
 };
 
 interface Props {
@@ -52,11 +56,17 @@ export default function ProjectResourcesTab({
     { enabled: sheetOpen && !!selectedName && !!selectedType },
   );
 
+  const openDetail = (r: ProjectResource) => {
+    setSelectedName(r.name);
+    setSelectedType(r.type);
+    setSheetOpen(true);
+  };
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <p className="text-sm text-muted-foreground">
-          Resources installed to this project
+          Resources available to this project
         </p>
         <Button onClick={() => setInstallOpen(true)} size="sm">
           <Download className="mr-2 h-4 w-4" />
@@ -72,57 +82,40 @@ export default function ProjectResourcesTab({
         </div>
       ) : !resources || resources.length === 0 ? (
         <div className="rounded-lg border border-dashed border-border p-8 text-center text-muted-foreground">
-          No project resources installed yet.
+          No resources available yet.
         </div>
       ) : (
-        <Card>
-          <CardContent className="p-0">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Type</TableHead>
-                  <TableHead>Version</TableHead>
-                  <TableHead>Description</TableHead>
-                  <TableHead className="w-24" />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {resources.map((r) => (
-                  <TableRow
-                    key={`${r.type}-${r.name}`}
-                    className="cursor-pointer"
-                    onClick={() => {
-                      setSelectedName(r.name);
-                      setSelectedType(r.type);
-                      setSheetOpen(true);
-                    }}
-                  >
-                    <TableCell className="font-medium">{r.name}</TableCell>
-                    <TableCell>
-                      <Badge variant="outline" className="text-xs">
-                        {TYPE_LABELS[r.type] ?? r.type}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
-                      {r.version ?? "—"}
-                    </TableCell>
-                    <TableCell className="max-w-[300px] truncate text-sm">
-                      {r.description || "—"}
-                    </TableCell>
-                    <TableCell>
-                      <ProjectUninstallButton
-                        projectId={projectId}
-                        resourceType={r.type}
-                        name={r.name}
-                      />
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </CardContent>
-        </Card>
+        <Tabs defaultValue="all">
+          <TabsList>
+            <TabsTrigger value="all">All</TabsTrigger>
+            {RESOURCE_TYPES.map((t) => {
+              const count = resources.filter((r) => r.type === t).length;
+              return (
+                <TabsTrigger key={t} value={t} disabled={count === 0}>
+                  {TYPE_LABELS[t]} ({count})
+                </TabsTrigger>
+              );
+            })}
+          </TabsList>
+
+          <TabsContent value="all">
+            <ResourceTable
+              resources={resources}
+              showType
+              projectId={projectId}
+              onSelect={openDetail}
+            />
+          </TabsContent>
+          {RESOURCE_TYPES.map((t) => (
+            <TabsContent key={t} value={t}>
+              <ResourceTable
+                resources={resources.filter((r) => r.type === t)}
+                projectId={projectId}
+                onSelect={openDetail}
+              />
+            </TabsContent>
+          ))}
+        </Tabs>
       )}
 
       <ResourceDetailSheet
@@ -139,6 +132,95 @@ export default function ProjectResourcesTab({
         projectId={projectId}
       />
     </div>
+  );
+}
+
+function ResourceTable({
+  resources,
+  showType,
+  projectId,
+  onSelect,
+}: {
+  resources: ProjectResource[];
+  showType?: boolean;
+  projectId: number;
+  onSelect: (r: ProjectResource) => void;
+}) {
+  if (resources.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border p-8 text-center text-muted-foreground">
+        No resources in this category.
+      </div>
+    );
+  }
+
+  return (
+    <Card>
+      <CardContent className="p-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Source</TableHead>
+              {showType && <TableHead>Type</TableHead>}
+              <TableHead>Version</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead>Config</TableHead>
+              <TableHead className="w-24" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {resources.map((r) => (
+              <TableRow
+                key={`${r.type}-${r.name}`}
+                className="cursor-pointer"
+                onClick={() => onSelect(r)}
+              >
+                <TableCell className="font-medium">{r.name}</TableCell>
+                <TableCell>
+                  <Badge
+                    variant="outline"
+                    className={`text-xs ${r.source === "global" ? "border-dashed" : ""}`}
+                  >
+                    {r.source === "global" ? "Global" : "Project"}
+                  </Badge>
+                </TableCell>
+                {showType && (
+                  <TableCell>
+                    <Badge variant="outline" className="text-xs">
+                      {TYPE_LABELS[r.type] ?? r.type}
+                    </Badge>
+                  </TableCell>
+                )}
+                <TableCell className="text-sm text-muted-foreground">
+                  {r.version ?? "—"}
+                </TableCell>
+                <TableCell className="max-w-[300px] truncate text-sm">
+                  {r.description || "—"}
+                </TableCell>
+                <TableCell>
+                  {r.config_count > 0 && (
+                    <Badge variant="secondary" className="text-xs gap-1">
+                      <Settings className="h-3 w-3" />
+                      {r.config_count}
+                    </Badge>
+                  )}
+                </TableCell>
+                <TableCell>
+                  {r.source === "project" && (
+                    <ProjectUninstallButton
+                      projectId={projectId}
+                      resourceType={r.type}
+                      name={r.name}
+                    />
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/gui/frontend/src/components/ResourceConfigForm.tsx
+++ b/gui/frontend/src/components/ResourceConfigForm.tsx
@@ -130,7 +130,7 @@ export default function ResourceConfigForm({
                       {schema.description}
                     </p>
                   )}
-                  <div className="flex gap-1">
+                  <div className="relative">
                     <Input
                       type={isVisible ? "text" : "password"}
                       value={envState[key] ?? ""}
@@ -141,13 +141,11 @@ export default function ResourceConfigForm({
                         }))
                       }
                       placeholder={key}
-                      className="h-8 text-xs font-mono"
+                      className="h-8 pr-8 text-xs font-mono"
                     />
-                    <Button
+                    <button
                       type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="h-8 w-8 shrink-0 p-0"
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                       onClick={() => toggleVisible(key)}
                     >
                       {isVisible ? (
@@ -155,7 +153,7 @@ export default function ResourceConfigForm({
                       ) : (
                         <Eye className="h-3.5 w-3.5" />
                       )}
-                    </Button>
+                    </button>
                   </div>
                 </div>
               );

--- a/gui/frontend/src/components/ResourceDetailSheet.tsx
+++ b/gui/frontend/src/components/ResourceDetailSheet.tsx
@@ -125,14 +125,13 @@ export default function ResourceDetailSheet({
     agents: ["strawpot-claude-code"],
     memories: ["dial"],
   };
-  const isProtected =
-    !projectId && PROTECTED[resourceType]?.includes(resource.name);
+  const isProtected = PROTECTED[resourceType]?.includes(resource.name) ?? false;
 
   const metadata = resource.frontmatter?.metadata as Record<string, unknown> | undefined;
 
   return (
     <Sheet open={open} onOpenChange={(v) => { onOpenChange(v); setConfirming(false); }}>
-      <SheetContent side="right" className="flex h-full flex-col sm:max-w-lg">
+      <SheetContent side="right" className="flex h-full flex-col sm:max-w-xl overflow-x-hidden">
         <SheetHeader className="shrink-0">
           <SheetTitle className="flex items-center gap-2">
             {resource.name}
@@ -163,18 +162,20 @@ export default function ResourceDetailSheet({
           )}
         </div>
 
-        <ScrollArea className="min-h-0 flex-1 px-4">
-          {resourceType === "agents" && (
-            <AgentSetupGuide agentName={resource.name} />
-          )}
-          <ResourceConfigForm
-            resourceType={resourceType}
-            resourceName={resource.name}
-            enabled={open}
-            projectId={projectId}
-          />
-          <div className="prose prose-sm dark:prose-invert max-w-none whitespace-pre-wrap mt-4">
-            {resource.body || "No content."}
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="px-4 overflow-hidden">
+            {resourceType === "agents" && (
+              <AgentSetupGuide agentName={resource.name} />
+            )}
+            <ResourceConfigForm
+              resourceType={resourceType}
+              resourceName={resource.name}
+              enabled={open}
+              projectId={projectId}
+            />
+            <div className="prose prose-sm dark:prose-invert max-w-none whitespace-pre-wrap mt-4">
+              {resource.body || "No content."}
+            </div>
           </div>
         </ScrollArea>
 

--- a/gui/src/strawpot_gui/routers/project_resources.py
+++ b/gui/src/strawpot_gui/routers/project_resources.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 
-from strawpot.config import _read_toml, save_resource_config
+from strawpot.config import _read_toml, get_strawpot_home, save_resource_config
 
 from strawpot_gui.db import get_db_conn
 from strawpot_gui.routers.registry import (
@@ -35,40 +35,90 @@ def _get_project_dir(project_id: int, conn) -> str:
     return working_dir
 
 
+def _count_config_overrides(toml_data: dict, resource_type: str, name: str) -> int:
+    """Count the number of env/param overrides for a resource in TOML data."""
+    count = 0
+    if resource_type == "roles":
+        count = len(toml_data.get("roles", {}).get(name, {}))
+    elif resource_type == "skills":
+        count = len(toml_data.get("skills", {}).get(name, {}).get("env", {}))
+    elif resource_type == "agents":
+        agent_data = toml_data.get("agents", {}).get(name, {})
+        count = len(agent_data.get("env", {}))
+        # Count non-env params (keys other than "env")
+        count += sum(1 for k in agent_data if k != "env")
+    elif resource_type == "memories":
+        count = len(toml_data.get("memories", {}).get(name, {}).get("env", {}))
+        # memory_config is shared across all memory providers, count if any
+        count += len(toml_data.get("memory_config", {}))
+    return count
+
+
 @router.get("/{project_id}/resources")
 def list_project_resources(project_id: int, conn=Depends(get_db_conn)):
-    """List all installed resources across all types for a project."""
+    """List all resources available to a project (project-local + global).
+
+    Project-local resources take precedence over global ones with the same name.
+    Each resource includes a config_count of project-level overrides from
+    strawpot.toml.
+    """
     working_dir = _get_project_dir(project_id, conn)
-    base = Path(working_dir) / ".strawpot"
+    project_base = Path(working_dir) / ".strawpot"
+    global_base = get_strawpot_home()
+    toml_path = Path(working_dir) / "strawpot.toml"
+    toml_data = _read_toml(toml_path)
     results = []
     for rtype, (dir_name, manifest) in RESOURCE_TYPES.items():
-        for item in scan_dir(base, dir_name, manifest, rtype, "project"):
+        # Scan project-local first, track names to avoid duplicates
+        seen: set[str] = set()
+        for item in scan_dir(project_base, dir_name, manifest, rtype, "project"):
             item["type"] = rtype
+            item["config_count"] = _count_config_overrides(toml_data, rtype, item["name"])
             results.append(item)
+            seen.add(item["name"])
+        # Add global resources not shadowed by project-local ones
+        for item in scan_dir(global_base, dir_name, manifest, rtype, "global"):
+            if item["name"] not in seen:
+                item["type"] = rtype
+                item["config_count"] = _count_config_overrides(toml_data, rtype, item["name"])
+                results.append(item)
     return results
+
+
+def _resolve_resource_dir(
+    working_dir: str, dir_name: str, manifest: str, name: str
+) -> tuple[Path, str]:
+    """Find a resource directory, checking project-local first then global.
+
+    Returns (resource_dir, source) where source is "project" or "global".
+    Raises HTTPException(404) if not found in either location.
+    """
+    project_dir = Path(working_dir) / ".strawpot" / dir_name / name
+    if (project_dir / manifest).is_file():
+        return project_dir, "project"
+    global_dir = get_strawpot_home() / dir_name / name
+    if (global_dir / manifest).is_file():
+        return global_dir, "global"
+    raise HTTPException(404, f"Resource not found: {dir_name}/{name}")
 
 
 @router.get("/{project_id}/resources/{resource_type}/{name}")
 def get_project_resource(
     project_id: int, resource_type: str, name: str, conn=Depends(get_db_conn)
 ):
-    """Get detail for a single project-scoped resource."""
+    """Get detail for a resource available to this project."""
     working_dir = _get_project_dir(project_id, conn)
     dir_name, manifest = validate_type(resource_type)
+    resource_dir, source = _resolve_resource_dir(working_dir, dir_name, manifest, name)
 
-    resource_dir = Path(working_dir) / ".strawpot" / dir_name / name
-    manifest_path = resource_dir / manifest
-    if not manifest_path.is_file():
-        raise HTTPException(404, f"Resource not found: {resource_type}/{name}")
-
-    fm, body = parse_manifest(manifest_path, resource_type)
+    fm, body = parse_manifest(resource_dir / manifest, resource_type)
     return {
         "name": fm.get("name", name),
         "version": read_version(resource_dir, fm),
         "description": fm.get("description", ""),
         "frontmatter": fm,
         "body": body,
-        "source": "project",
+        "source": source,
         "path": str(resource_dir),
     }
 
@@ -80,13 +130,9 @@ def get_project_resource_config(
     """Get env/params schema and saved values from project's strawpot.toml."""
     working_dir = _get_project_dir(project_id, conn)
     dir_name, manifest = validate_type(resource_type)
+    resource_dir, _ = _resolve_resource_dir(working_dir, dir_name, manifest, name)
 
-    resource_dir = Path(working_dir) / ".strawpot" / dir_name / name
-    manifest_path = resource_dir / manifest
-    if not manifest_path.is_file():
-        raise HTTPException(404, f"Resource not found: {resource_type}/{name}")
-
-    fm, _ = parse_manifest(manifest_path, resource_type)
+    fm, _ = parse_manifest(resource_dir / manifest, resource_type)
     strawpot_meta = fm.get("metadata", {}).get("strawpot", {})
 
     env_schema = strawpot_meta.get("env", {})
@@ -127,10 +173,8 @@ def put_project_resource_config(
     """Save env and param values for a project-scoped resource."""
     working_dir = _get_project_dir(project_id, conn)
     dir_name, manifest = validate_type(resource_type)
-
-    manifest_path = Path(working_dir) / ".strawpot" / dir_name / name / manifest
-    if not manifest_path.is_file():
-        raise HTTPException(404, f"Resource not found: {resource_type}/{name}")
+    resource_dir, _ = _resolve_resource_dir(working_dir, dir_name, manifest, name)
+    manifest_path = resource_dir / manifest
 
     env_values = data.get("env_values")
     params_values = data.get("params_values")

--- a/gui/tests/test_project_resources.py
+++ b/gui/tests/test_project_resources.py
@@ -1,0 +1,202 @@
+"""Tests for project-scoped resource endpoints."""
+
+import pytest
+import tomli_w
+
+
+@pytest.fixture
+def global_home(tmp_path, monkeypatch):
+    """Patch get_strawpot_home to use a temp directory for global resources."""
+    home = tmp_path / "global_home"
+    home.mkdir()
+    monkeypatch.setattr(
+        "strawpot_gui.routers.project_resources.get_strawpot_home", lambda: home
+    )
+    return home
+
+
+def _setup_project(client, tmp_path):
+    """Create a project and return (project_id, project_dir)."""
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+    (project_dir / ".strawpot").mkdir()
+    resp = client.post("/api/projects", json={
+        "display_name": "Test",
+        "working_dir": str(project_dir),
+    })
+    return resp.json()["id"], project_dir
+
+
+def _install_skill(base_dir, name, env_schema=None):
+    """Create a minimal skill manifest under base_dir/skills/."""
+    skill_dir = base_dir / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    env_block = ""
+    if env_schema:
+        env_lines = "\n".join(
+            f"      {k}:\n        description: '{v}'" for k, v in env_schema.items()
+        )
+        env_block = f"\n  strawpot:\n    env:\n{env_lines}"
+    content = (
+        f"---\nname: {name}\ndescription: A test skill\n"
+        f"metadata:\n  version: '1.0'{env_block}\n---\nSkill body"
+    )
+    (skill_dir / "SKILL.md").write_text(content)
+
+
+def _install_role(base_dir, name):
+    """Create a minimal role manifest under base_dir/roles/."""
+    role_dir = base_dir / "roles" / name
+    role_dir.mkdir(parents=True, exist_ok=True)
+    content = (
+        f"---\nname: {name}\ndescription: A test role\n"
+        f"metadata:\n  version: '1.0'\n  strawpot:\n    default_agent: default\n"
+        f"---\nRole body"
+    )
+    (role_dir / "ROLE.md").write_text(content)
+
+
+def _write_toml(project_dir, data):
+    """Write strawpot.toml in the project directory."""
+    (project_dir / "strawpot.toml").write_bytes(tomli_w.dumps(data).encode())
+
+
+class TestListProjectResources:
+    def test_empty(self, client, tmp_path, global_home):
+        pid, _ = _setup_project(client, tmp_path)
+        resp = client.get(f"/api/projects/{pid}/resources")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_lists_project_resources(self, client, tmp_path, global_home):
+        pid, project_dir = _setup_project(client, tmp_path)
+        _install_skill(project_dir / ".strawpot", "my-skill")
+        resp = client.get(f"/api/projects/{pid}/resources")
+        assert resp.status_code == 200
+        resources = resp.json()
+        assert len(resources) == 1
+        assert resources[0]["name"] == "my-skill"
+        assert resources[0]["type"] == "skills"
+        assert resources[0]["source"] == "project"
+
+    def test_includes_global_resources(self, client, tmp_path, global_home):
+        pid, _ = _setup_project(client, tmp_path)
+        _install_skill(global_home, "global-skill")
+        resp = client.get(f"/api/projects/{pid}/resources")
+        resources = resp.json()
+        assert len(resources) == 1
+        assert resources[0]["name"] == "global-skill"
+        assert resources[0]["source"] == "global"
+
+    def test_project_shadows_global(self, client, tmp_path, global_home):
+        """When same name exists in both, project-local wins."""
+        pid, project_dir = _setup_project(client, tmp_path)
+        _install_skill(global_home, "shared-skill")
+        _install_skill(project_dir / ".strawpot", "shared-skill")
+        resp = client.get(f"/api/projects/{pid}/resources")
+        resources = resp.json()
+        skills = [r for r in resources if r["name"] == "shared-skill"]
+        assert len(skills) == 1
+        assert skills[0]["source"] == "project"
+
+    def test_config_count_zero_without_toml(self, client, tmp_path, global_home):
+        pid, project_dir = _setup_project(client, tmp_path)
+        _install_skill(project_dir / ".strawpot", "bare-skill")
+        resp = client.get(f"/api/projects/{pid}/resources")
+        resources = resp.json()
+        assert resources[0]["config_count"] == 0
+
+    def test_config_count_skill_env(self, client, tmp_path, global_home):
+        pid, project_dir = _setup_project(client, tmp_path)
+        _install_skill(project_dir / ".strawpot", "api-skill")
+        _write_toml(project_dir, {
+            "skills": {
+                "api-skill": {
+                    "env": {"API_KEY": "secret", "API_URL": "https://example.com"}
+                }
+            }
+        })
+        resp = client.get(f"/api/projects/{pid}/resources")
+        resources = resp.json()
+        assert resources[0]["config_count"] == 2
+
+    def test_config_count_role_params(self, client, tmp_path, global_home):
+        pid, project_dir = _setup_project(client, tmp_path)
+        _install_role(project_dir / ".strawpot", "leader")
+        _write_toml(project_dir, {
+            "roles": {"leader": {"default_agent": "claude"}}
+        })
+        resp = client.get(f"/api/projects/{pid}/resources")
+        role = [r for r in resp.json() if r["type"] == "roles"][0]
+        assert role["config_count"] == 1
+
+    def test_config_count_on_global_resource(self, client, tmp_path, global_home):
+        """Global resources show project-level config overrides."""
+        pid, project_dir = _setup_project(client, tmp_path)
+        _install_skill(global_home, "twitter-api")
+        _write_toml(project_dir, {
+            "skills": {
+                "twitter-api": {"env": {"TWITTER_TOKEN": "tok123"}}
+            }
+        })
+        resp = client.get(f"/api/projects/{pid}/resources")
+        resources = resp.json()
+        skill = [r for r in resources if r["name"] == "twitter-api"][0]
+        assert skill["source"] == "global"
+        assert skill["config_count"] == 1
+
+    def test_config_count_mixed(self, client, tmp_path, global_home):
+        """Resources without overrides show 0, those with overrides show count."""
+        pid, project_dir = _setup_project(client, tmp_path)
+        _install_skill(project_dir / ".strawpot", "configured")
+        _install_skill(project_dir / ".strawpot", "unconfigured")
+        _write_toml(project_dir, {
+            "skills": {
+                "configured": {"env": {"TOKEN": "abc"}}
+            }
+        })
+        resp = client.get(f"/api/projects/{pid}/resources")
+        resources = {r["name"]: r for r in resp.json()}
+        assert resources["configured"]["config_count"] == 1
+        assert resources["unconfigured"]["config_count"] == 0
+
+
+class TestGetProjectResource:
+    def test_get_project_resource(self, client, tmp_path, global_home):
+        pid, project_dir = _setup_project(client, tmp_path)
+        _install_skill(project_dir / ".strawpot", "local-skill")
+        resp = client.get(f"/api/projects/{pid}/resources/skills/local-skill")
+        assert resp.status_code == 200
+        assert resp.json()["source"] == "project"
+
+    def test_get_global_resource(self, client, tmp_path, global_home):
+        pid, _ = _setup_project(client, tmp_path)
+        _install_skill(global_home, "global-skill")
+        resp = client.get(f"/api/projects/{pid}/resources/skills/global-skill")
+        assert resp.status_code == 200
+        assert resp.json()["source"] == "global"
+
+    def test_not_found(self, client, tmp_path, global_home):
+        pid, _ = _setup_project(client, tmp_path)
+        resp = client.get(f"/api/projects/{pid}/resources/skills/nonexistent")
+        assert resp.status_code == 404
+
+
+class TestProjectResourceConfig:
+    def test_get_config_for_global_resource(self, client, tmp_path, global_home):
+        """Can read config schema from global resource + saved values from project toml."""
+        pid, project_dir = _setup_project(client, tmp_path)
+        _install_skill(global_home, "api-skill", env_schema={"API_KEY": "Your API key"})
+        _write_toml(project_dir, {
+            "skills": {"api-skill": {"env": {"API_KEY": "secret"}}}
+        })
+        resp = client.get(f"/api/projects/{pid}/resources/skills/api-skill/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "API_KEY" in data["env_schema"]
+        assert data["env_values"]["API_KEY"] == "secret"
+
+    def test_config_not_found(self, client, tmp_path, global_home):
+        pid, _ = _setup_project(client, tmp_path)
+        resp = client.get(f"/api/projects/{pid}/resources/skills/missing/config")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Merge global + project resources in the project Resources tab so users can see and configure all available resources in one place
- Add config override count (env vars + params) from project's `strawpot.toml` to the resource list
- Split resources into sub-tabs per type (All, Roles, Skills, Agents, Memories) with counts
- Show Source column (Global with dashed border / Project), hide uninstall for global resources
- Fix detail sheet overflow clipping: move eye icon inside input, widen sheet, fix ScrollArea padding
- Protect built-in resources from uninstall regardless of viewing context (global or project)

## Test plan
- [x] 14 new backend tests covering merged resource list, config counts, detail/config for global resources
- [x] All 315 existing tests pass
- [ ] Manual: open a project with both global and project-local resources, verify sub-tabs filter correctly
- [ ] Manual: verify config count badge shows correct override count
- [ ] Manual: click a global resource, verify env var editing works with eye icon visible
- [ ] Manual: verify protected resources (denden, imu, etc.) hide uninstall button

🤖 Generated with [Claude Code](https://claude.com/claude-code)