### PR TITLE
Use project-scoped roles in all dialogs

### DIFF
--- a/gui/frontend/src/components/CreateScheduleDialog.tsx
+++ b/gui/frontend/src/components/CreateScheduleDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import cronstrue from "cronstrue";
 import { useProjects } from "@/hooks/queries/use-projects";
-import { useRoles } from "@/hooks/queries/use-roles";
+import { useProjectResources } from "@/hooks/queries/use-project-resources";
 import { useCreateSchedule, useUpdateSchedule } from "@/hooks/mutations/use-schedules";
 import { Button } from "@/components/ui/button";
 import {
@@ -55,7 +55,6 @@ export default function CreateScheduleDialog({
   editing,
 }: CreateScheduleDialogProps) {
   const { data: projects } = useProjects();
-  const { data: roles } = useRoles();
   const createSchedule = useCreateSchedule();
   const updateSchedule = useUpdateSchedule();
 
@@ -67,6 +66,16 @@ export default function CreateScheduleDialog({
   const [systemPrompt, setSystemPrompt] = useState("");
   const [skipIfRunning, setSkipIfRunning] = useState(true);
   const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  const selectedProjectId = editing ? editing.project_id : Number(projectId) || 0;
+  const { data: projectResources } = useProjectResources(selectedProjectId);
+  const roles = useMemo(
+    () =>
+      (projectResources ?? [])
+        .filter((r) => r.type === "roles")
+        .map((r) => r.name),
+    [projectResources],
+  );
 
   useEffect(() => {
     if (open && editing) {
@@ -235,14 +244,17 @@ export default function CreateScheduleDialog({
               id="sched-role"
               value={role}
               onChange={(e) => setRole(e.target.value)}
-              placeholder={roles?.[0] ?? "orchestrator"}
+              placeholder={roles[0] ?? "orchestrator"}
               list="sched-role-list"
             />
             <datalist id="sched-role-list">
-              {(roles ?? []).map((r) => (
+              {roles.map((r) => (
                 <option key={r} value={r} />
               ))}
             </datalist>
+            {role.trim() && roles.length > 0 && !roles.includes(role.trim()) && (
+              <p className="text-xs text-destructive">Role not found in installed roles</p>
+            )}
           </div>
 
           <label className="flex items-center gap-2 cursor-pointer">
@@ -302,7 +314,7 @@ export default function CreateScheduleDialog({
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={isPending}>
+            <Button type="submit" disabled={isPending || (!!role.trim() && roles.length > 0 && !roles.includes(role.trim()))}>
               {isPending
                 ? "Saving..."
                 : editing

--- a/gui/frontend/src/components/LaunchDialog.tsx
+++ b/gui/frontend/src/components/LaunchDialog.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useProjectConfig, useProjectFiles } from "@/hooks/queries/use-projects";
-import { useRoles } from "@/hooks/queries/use-roles";
+import { useProjectResources } from "@/hooks/queries/use-project-resources";
 import { useResources } from "@/hooks/queries/use-registry";
 import { useResourceConfig } from "@/hooks/queries/use-resource-config";
 import { useLaunchSession } from "@/hooks/mutations/use-sessions";
@@ -53,7 +53,7 @@ export default function LaunchDialog({
 }: LaunchDialogProps) {
   const navigate = useNavigate();
   const config = useProjectConfig(projectId);
-  const roles = useRoles();
+  const { data: projectResources } = useProjectResources(projectId);
   const { data: agents } = useResources("agents");
   const { data: memories } = useResources("memories");
   const projectFiles = useProjectFiles(projectId);
@@ -173,7 +173,10 @@ export default function LaunchDialog({
   };
 
   const defaultRole = defaults?.orchestrator_role ?? "orchestrator";
-  const installedRoles = (roles.data ?? []).filter((v) => v !== defaultRole);
+  const projectRoleNames = (projectResources ?? [])
+    .filter((r) => r.type === "roles")
+    .map((r) => r.name);
+  const installedRoles = projectRoleNames.filter((v) => v !== defaultRole);
   const allRoles = [defaultRole, ...installedRoles];
   const agentNames = (agents ?? []).map((a) => a.name);
   const memoryNames = new Set((memories ?? []).map((m) => m.name));

--- a/gui/frontend/src/pages/ConversationView.tsx
+++ b/gui/frontend/src/pages/ConversationView.tsx
@@ -5,7 +5,7 @@ import { useConversationInfinite } from "@/hooks/queries/use-conversations";
 import { useSubmitConversationTask, useRenameConversation, useCancelPendingTask } from "@/hooks/mutations/use-conversations";
 import { useStopSession } from "@/hooks/mutations/use-sessions";
 import { useSessionWS } from "@/hooks/useSessionWS";
-import { useRoles } from "@/hooks/queries/use-roles";
+import { useProjectResources } from "@/hooks/queries/use-project-resources";
 import { useProjectFiles, useProjectConfig } from "@/hooks/queries/use-projects";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -166,7 +166,10 @@ export default function ConversationView() {
   const titleInputRef = useRef<HTMLInputElement>(null);
   const qc = useQueryClient();
 
-  const roles = useRoles();
+  const { data: projectResources } = useProjectResources(pid);
+  const projectRoleNames = (projectResources ?? [])
+    .filter((r) => r.type === "roles")
+    .map((r) => r.name);
   const { data: agents } = useResources("agents");
   const { data: memories } = useResources("memories");
   const config = useProjectConfig(pid);
@@ -201,7 +204,7 @@ export default function ConversationView() {
   );
 
   const roleError =
-    role.trim() && !(roles.data ?? []).includes(role.trim())
+    role.trim() && !projectRoleNames.includes(role.trim())
       ? "Role not found in installed roles"
       : "";
 
@@ -636,7 +639,7 @@ export default function ConversationView() {
                 )}
               </div>
               <datalist id="datalist-role">
-                {(roles.data ?? []).map((r) => (
+                {projectRoleNames.map((r) => (
                   <option key={r} value={r} />
                 ))}
               </datalist>


### PR DESCRIPTION
## Summary
- Replace `useRoles()` (global-only) with `useProjectResources()` (project-local + global) in CreateScheduleDialog, LaunchDialog, and ConversationView
- Role lists now correctly include project-local roles alongside global ones
- Add role validation to CreateScheduleDialog (error message + disabled submit)

## Test plan
- [ ] Install a role at project level only — verify it appears in Launch Session, Conversation, and Create Schedule role lists
- [ ] Verify global-only roles still appear when no project-local override exists
- [ ] In Create Schedule, type an invalid role name — verify error message and disabled submit button
- [ ] In Create Schedule, change project selection — verify role list updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)