### PR TITLE
Check project-local resources for role/skill staging

### DIFF
--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -267,32 +267,40 @@ def discover_global_skills(
     return global_skills
 
 
-def _discover_all_roles() -> list[tuple[str, str]]:
-    """Discover all globally installed roles.
+def _discover_all_roles(working_dir: str | None = None) -> list[tuple[str, str]]:
+    """Discover all installed roles, checking project-local first then global.
 
-    Scans ``~/.strawpot/roles/`` for installed role directories.
-    Accepts both plain slug directories (``ai-ceo``) and versioned
-    directories (``ai-ceo-1.0.0``).
+    Project-local roles take precedence over global ones with the same slug.
 
     Returns:
         List of (slug, path) tuples for each installed role.
     """
     from strawhub.version_spec import parse_dir_name
 
-    roles_dir = get_strawpot_home() / "roles"
-    if not roles_dir.is_dir():
-        return []
-
+    seen: set[str] = set()
     roles: list[tuple[str, str]] = []
-    for entry in sorted(roles_dir.iterdir()):
-        if not entry.is_dir():
-            continue
-        role_md = entry / "ROLE.md"
-        if not role_md.is_file():
-            continue
-        parsed = parse_dir_name(entry.name)
-        slug = parsed[0] if parsed else entry.name
-        roles.append((slug, str(entry)))
+
+    dirs_to_scan: list[Path] = []
+    if working_dir:
+        local_roles = Path(working_dir) / ".strawpot" / "roles"
+        if local_roles.is_dir():
+            dirs_to_scan.append(local_roles)
+    global_roles = get_strawpot_home() / "roles"
+    if global_roles.is_dir():
+        dirs_to_scan.append(global_roles)
+
+    for roles_dir in dirs_to_scan:
+        for entry in sorted(roles_dir.iterdir()):
+            if not entry.is_dir():
+                continue
+            role_md = entry / "ROLE.md"
+            if not role_md.is_file():
+                continue
+            parsed = parse_dir_name(entry.name)
+            slug = parsed[0] if parsed else entry.name
+            if slug not in seen:
+                seen.add(slug)
+                roles.append((slug, str(entry)))
     return roles
 
 
@@ -484,6 +492,7 @@ def stage_role(
     session_dir: str,
     resolved: dict,
     global_skills: list[tuple[str, str, str]] | None = None,
+    working_dir: str | None = None,
 ) -> tuple[str, str]:
     """Stage a resolved role into the session directory.
 
@@ -549,17 +558,17 @@ def stage_role(
                 _symlink(gpath, dest)
 
     # Always stage denden — required for agent communication
-    _ensure_denden_staged(skills_dir)
+    _ensure_denden_staged(skills_dir, working_dir)
     # Always stage session-recap — required for memory summary quality
-    _ensure_session_recap_staged(skills_dir)
+    _ensure_session_recap_staged(skills_dir, working_dir)
 
     # Stage role deps
     roles_dir = os.path.join(role_stage_dir, "roles")
     os.makedirs(roles_dir, exist_ok=True)
 
     if wildcard_roles:
-        # "*" — stage all globally installed roles
-        for role_slug, role_path in _discover_all_roles():
+        # "*" — stage all installed roles (project-local + global)
+        for role_slug, role_path in _discover_all_roles(working_dir):
             if role_slug == slug:  # skip self
                 continue
             dest = os.path.join(roles_dir, role_slug)
@@ -578,24 +587,36 @@ def stage_role(
     return skills_dir, roles_dir
 
 
-def _ensure_denden_staged(skills_dir: str) -> None:
+def _find_skill(slug: str, working_dir: str | None) -> Path | None:
+    """Find a skill directory, checking project-local first then global."""
+    if working_dir:
+        local = Path(working_dir) / ".strawpot" / "skills" / slug
+        if local.is_dir() and (local / "SKILL.md").is_file():
+            return local
+    global_path = get_strawpot_home() / "skills" / slug
+    if global_path.is_dir() and (global_path / "SKILL.md").is_file():
+        return global_path
+    return None
+
+
+def _ensure_denden_staged(skills_dir: str, working_dir: str | None = None) -> None:
     """Always stage the denden skill — it is required for agent communication."""
     dest = os.path.join(skills_dir, "denden")
     if os.path.exists(dest):
         return
-    denden_path = get_strawpot_home() / "skills" / "denden"
-    if denden_path.is_dir() and (denden_path / "SKILL.md").is_file():
-        _symlink(str(denden_path), dest)
+    path = _find_skill("denden", working_dir)
+    if path:
+        _symlink(str(path), dest)
 
 
-def _ensure_session_recap_staged(skills_dir: str) -> None:
+def _ensure_session_recap_staged(skills_dir: str, working_dir: str | None = None) -> None:
     """Always stage the session-recap skill — it is required for memory summary quality."""
     dest = os.path.join(skills_dir, "strawpot-session-recap")
     if os.path.exists(dest):
         return
-    recap_path = get_strawpot_home() / "skills" / "strawpot-session-recap"
-    if recap_path.is_dir() and (recap_path / "SKILL.md").is_file():
-        _symlink(str(recap_path), dest)
+    path = _find_skill("strawpot-session-recap", working_dir)
+    if path:
+        _symlink(str(path), dest)
 
 
 def create_agent_workspace(session_dir: str, agent_id: str) -> str:
@@ -820,7 +841,7 @@ def handle_delegate(
     #    Candidates come from the role's own declared role dependencies.
     _, role_dep_slugs, wildcard = _parse_role_deps(resolved["path"])
     if wildcard:
-        role_dep_slugs = [slug for slug, _ in _discover_all_roles()]
+        role_dep_slugs = [slug for slug, _ in _discover_all_roles(working_dir)]
     delegatable = _build_delegatable_roles(
         role_dep_slugs, request.role_slug, resolve_role_dirs,
         requester_role=request.parent_role,
@@ -836,7 +857,8 @@ def handle_delegate(
 
     # 5. Stage role (session-level, idempotent)
     skills_dir, roles_dir = stage_role(
-        session_dir, resolved, global_skills=global_skills or None
+        session_dir, resolved, global_skills=global_skills or None,
+        working_dir=working_dir,
     )
 
     # 6-9. Spawn/wait loop with retry on format validation failure

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -394,7 +394,7 @@ class Session:
             # Build delegatable roles so the orchestrator prompt lists them
             _, role_dep_slugs, wildcard = _parse_role_deps(resolved["path"])
             if wildcard:
-                role_dep_slugs = [slug for slug, _ in _discover_all_roles()]
+                role_dep_slugs = [slug for slug, _ in _discover_all_roles(working_dir)]
             delegatable = _build_delegatable_roles(
                 role_dep_slugs,
                 self.config.orchestrator_role,
@@ -414,6 +414,7 @@ class Session:
             skills_dir, roles_dir = stage_role(
                 self._session_dir(), resolved,
                 global_skills=global_skills or None,
+                working_dir=working_dir,
             )
             workspace = create_agent_workspace(
                 self._session_dir(), agent_id

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -17,6 +17,7 @@ from strawpot.delegation import (
     _check_inherit_global_skills,
     _check_policy,
     _collect_transitive_skills,
+    _find_skill,
     _format_memory_prompt,
     _get_default_agent,
     _merge_env_entry,
@@ -2116,6 +2117,191 @@ class TestStageRoleGlobalSkills:
         assert os.path.islink(staged)
         # Should point to dep path, not global
         assert os.readlink(staged) == denden_dep
+
+
+# ---------------------------------------------------------------------------
+# Project-local resource discovery
+# ---------------------------------------------------------------------------
+
+
+class TestFindSkill:
+    """Tests for _find_skill — project-local first, then global."""
+
+    def test_prefers_local_over_global(self, tmp_path, monkeypatch):
+        global_home = tmp_path / "global"
+        monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
+        # Install in both locations
+        for base in [tmp_path / "project" / ".strawpot", global_home]:
+            skill_dir = base / "skills" / "my-skill"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text("---\nname: my-skill\n---\n")
+
+        result = _find_skill("my-skill", str(tmp_path / "project"))
+        assert result == tmp_path / "project" / ".strawpot" / "skills" / "my-skill"
+
+    def test_falls_back_to_global(self, tmp_path, monkeypatch):
+        global_home = tmp_path / "global"
+        monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
+        skill_dir = global_home / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: my-skill\n---\n")
+
+        result = _find_skill("my-skill", str(tmp_path / "project"))
+        assert result == skill_dir
+
+    def test_returns_none_when_not_found(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "empty"))
+        assert _find_skill("missing", str(tmp_path / "project")) is None
+
+    def test_none_working_dir_checks_global_only(self, tmp_path, monkeypatch):
+        global_home = tmp_path / "global"
+        monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
+        skill_dir = global_home / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: my-skill\n---\n")
+
+        result = _find_skill("my-skill", None)
+        assert result == skill_dir
+
+
+class TestDiscoverAllRolesLocal:
+    """Tests for _discover_all_roles with project-local roles."""
+
+    def test_local_takes_precedence(self, tmp_path, monkeypatch):
+        global_home = tmp_path / "global"
+        monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
+        project = tmp_path / "project"
+        # Install same role in both locations
+        for base in [project / ".strawpot", global_home]:
+            role_dir = base / "roles" / "reviewer"
+            role_dir.mkdir(parents=True)
+            (role_dir / "ROLE.md").write_text("---\nname: reviewer\n---\n")
+
+        result = _discover_all_roles(str(project))
+        slugs = [s for s, _ in result]
+        assert slugs.count("reviewer") == 1
+        # Should point to local
+        path = dict(result)["reviewer"]
+        assert "project" in path
+
+    def test_merges_local_and_global(self, tmp_path, monkeypatch):
+        global_home = tmp_path / "global"
+        monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
+        project = tmp_path / "project"
+        # Local-only role
+        local_dir = project / ".strawpot" / "roles" / "local-role"
+        local_dir.mkdir(parents=True)
+        (local_dir / "ROLE.md").write_text("---\nname: local-role\n---\n")
+        # Global-only role
+        global_dir = global_home / "roles" / "global-role"
+        global_dir.mkdir(parents=True)
+        (global_dir / "ROLE.md").write_text("---\nname: global-role\n---\n")
+
+        result = _discover_all_roles(str(project))
+        slugs = [s for s, _ in result]
+        assert "local-role" in slugs
+        assert "global-role" in slugs
+
+    def test_no_working_dir_returns_global_only(self, tmp_path, monkeypatch):
+        global_home = tmp_path / "global"
+        monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
+        role_dir = global_home / "roles" / "reviewer"
+        role_dir.mkdir(parents=True)
+        (role_dir / "ROLE.md").write_text("---\nname: reviewer\n---\n")
+
+        result = _discover_all_roles(None)
+        assert len(result) == 1
+        assert result[0][0] == "reviewer"
+
+
+class TestEnsureStagedLocal:
+    """Tests for denden/session-recap staging with project-local skills."""
+
+    def test_denden_staged_from_local(self, tmp_path, monkeypatch):
+        """Denden is staged from project-local when available."""
+        global_home = tmp_path / "global"
+        monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
+        project = tmp_path / "project"
+
+        # Install denden locally only
+        local_denden = project / ".strawpot" / "skills" / "denden"
+        local_denden.mkdir(parents=True)
+        (local_denden / "SKILL.md").write_text("---\nname: denden\n---\n")
+
+        registry = str(tmp_path / "registry")
+        role_path = _write_role(registry, "worker")
+        resolved = {
+            "slug": "worker", "kind": "role", "version": "1.0.0",
+            "path": role_path, "source": "local", "dependencies": [],
+        }
+
+        session = str(tmp_path / "session")
+        skills_dir, _ = stage_role(
+            session, resolved, global_skills=None, working_dir=str(project),
+        )
+
+        staged = os.path.join(skills_dir, "denden")
+        assert os.path.islink(staged)
+        assert os.readlink(staged) == str(local_denden)
+
+    def test_denden_prefers_local_over_global(self, tmp_path, monkeypatch):
+        """When denden exists in both scopes, project-local wins."""
+        global_home = tmp_path / "global"
+        monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
+        project = tmp_path / "project"
+
+        # Install in both
+        for base in [project / ".strawpot", global_home]:
+            d = base / "skills" / "denden"
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text("---\nname: denden\n---\n")
+
+        registry = str(tmp_path / "registry")
+        role_path = _write_role(registry, "worker")
+        resolved = {
+            "slug": "worker", "kind": "role", "version": "1.0.0",
+            "path": role_path, "source": "local", "dependencies": [],
+        }
+
+        session = str(tmp_path / "session")
+        skills_dir, _ = stage_role(
+            session, resolved, global_skills=None, working_dir=str(project),
+        )
+
+        staged = os.path.join(skills_dir, "denden")
+        assert os.path.islink(staged)
+        assert os.readlink(staged) == str(project / ".strawpot" / "skills" / "denden")
+
+    def test_wildcard_roles_includes_local(self, tmp_path, monkeypatch):
+        """Wildcard '*' role deps stage project-local roles too."""
+        global_home = tmp_path / "global"
+        monkeypatch.setenv("STRAWPOT_HOME", str(global_home))
+        project = tmp_path / "project"
+
+        # Global role
+        g_role = global_home / "roles" / "global-role"
+        g_role.mkdir(parents=True)
+        (g_role / "ROLE.md").write_text("---\nname: global-role\n---\n")
+        # Local-only role
+        l_role = project / ".strawpot" / "roles" / "local-role"
+        l_role.mkdir(parents=True)
+        (l_role / "ROLE.md").write_text("---\nname: local-role\n---\n")
+
+        registry = str(tmp_path / "registry")
+        role_path = _write_role(registry, "orchestrator", role_deps=["*"])
+        resolved = {
+            "slug": "orchestrator", "kind": "role", "version": "1.0.0",
+            "path": role_path, "source": "local", "dependencies": [],
+        }
+
+        session = str(tmp_path / "session")
+        _, roles_dir = stage_role(
+            session, resolved, global_skills=None, working_dir=str(project),
+        )
+
+        staged_slugs = os.listdir(roles_dir)
+        assert "global-role" in staged_slugs
+        assert "local-role" in staged_slugs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `_discover_all_roles` now scans project-local `.strawpot/roles/` first, then global, with deduplication (local takes precedence)
- `_ensure_denden_staged` and `_ensure_session_recap_staged` check project-local skills before falling back to global
- New `_find_skill` helper for local-first skill lookup
- Wildcard `*` role deps now stage project-local roles alongside global ones
- All functions accept optional `working_dir` parameter, preserving backward compatibility when `None`

## Test plan
- [x] 10 new tests covering local precedence, merging, fallback, and staging — all pass
- [x] All 144 existing delegation tests still pass
- [ ] Manual: install denden only at project level, verify session still launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)