### PR TITLE
Use project-scoped agents and memories in dialogs

### DIFF
--- a/gui/frontend/src/components/LaunchDialog.tsx
+++ b/gui/frontend/src/components/LaunchDialog.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useProjectConfig, useProjectFiles } from "@/hooks/queries/use-projects";
 import { useProjectResources } from "@/hooks/queries/use-project-resources";
-import { useResources } from "@/hooks/queries/use-registry";
 import { useResourceConfig } from "@/hooks/queries/use-resource-config";
 import { useLaunchSession } from "@/hooks/mutations/use-sessions";
 import { api } from "@/api/client";
@@ -54,8 +53,6 @@ export default function LaunchDialog({
   const navigate = useNavigate();
   const config = useProjectConfig(projectId);
   const { data: projectResources } = useProjectResources(projectId);
-  const { data: agents } = useResources("agents");
-  const { data: memories } = useResources("memories");
   const projectFiles = useProjectFiles(projectId);
   const launchSession = useLaunchSession();
   const defaults = config.data?.merged as
@@ -178,8 +175,14 @@ export default function LaunchDialog({
     .map((r) => r.name);
   const installedRoles = projectRoleNames.filter((v) => v !== defaultRole);
   const allRoles = [defaultRole, ...installedRoles];
-  const agentNames = (agents ?? []).map((a) => a.name);
-  const memoryNames = new Set((memories ?? []).map((m) => m.name));
+  const agentNames = (projectResources ?? [])
+    .filter((r) => r.type === "agents")
+    .map((r) => r.name);
+  const memoryNames = new Set(
+    (projectResources ?? [])
+      .filter((r) => r.type === "memories")
+      .map((r) => r.name),
+  );
   memoryNames.add("none");
   const memoryOptions = [...memoryNames].sort();
 

--- a/gui/frontend/src/pages/ConversationView.tsx
+++ b/gui/frontend/src/pages/ConversationView.tsx
@@ -31,7 +31,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { useResources } from "@/hooks/queries/use-registry";
 import { api } from "@/api/client";
 import { queryKeys } from "@/lib/query-keys";
 import { AlertCircle, CheckCircle2, CornerDownLeft, ExternalLink, Loader2, MessageSquare, Paperclip, Settings, Square, Upload, X, XCircle } from "lucide-react";
@@ -170,8 +169,6 @@ export default function ConversationView() {
   const projectRoleNames = (projectResources ?? [])
     .filter((r) => r.type === "roles")
     .map((r) => r.name);
-  const { data: agents } = useResources("agents");
-  const { data: memories } = useResources("memories");
   const config = useProjectConfig(pid);
   const projectFiles = useProjectFiles(pid);
   const defaults = config.data?.merged as {
@@ -254,8 +251,13 @@ export default function ConversationView() {
     return () => observer.disconnect();
   }, [hasPreviousPage, isFetchingPreviousPage, fetchPreviousPage]);
 
-  const agentNames = (agents ?? []).map((a: { name: string }) => a.name);
-  const memoryNames = [...new Set((memories ?? []).map((m: { name: string }) => m.name)), "none"].sort();
+  const agentNames = (projectResources ?? [])
+    .filter((r) => r.type === "agents")
+    .map((r) => r.name);
+  const memoryNames = [
+    ...new Set((projectResources ?? []).filter((r) => r.type === "memories").map((r) => r.name)),
+    "none",
+  ].sort();
 
   const advRuntimeError = advRuntime.trim() && agentNames.length > 0 && !agentNames.includes(advRuntime.trim())
     ? "Runtime not found in installed agents" : "";


### PR DESCRIPTION
## Summary
- Replace global-only `useResources("agents")` and `useResources("memories")` with project-scoped data from `useProjectResources` in LaunchDialog and ConversationView
- Consistent with the roles change in PR #246

## Test plan
- [ ] Open Launch Session — verify agent and memory dropdowns show project-local + global resources
- [ ] Open Conversation view — verify same for advanced options

🤖 Generated with [Claude Code](https://claude.com/claude-code)