### PR TITLE
Improve ask_user UX, chat persistence, and markdown rendering

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -189,6 +189,8 @@ export interface ConversationSession {
   ended_at: string | null;
   duration_ms: number | null;
   role: string;
+  interactive?: boolean;
+  chat_messages?: ChatMessage[];
 }
 
 export interface Conversation {

--- a/gui/frontend/src/components/ChatPanel.tsx
+++ b/gui/frontend/src/components/ChatPanel.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
+import MarkdownContent from "@/components/MarkdownContent";
 import { MessageSquare, Send } from "lucide-react";
 
 export default function ChatPanel({
@@ -119,7 +120,7 @@ export default function ChatPanel({
                           : "bg-muted",
                       )}
                     >
-                      <p className="whitespace-pre-wrap">{msg.text}</p>
+                      <MarkdownContent content={msg.text} className="whitespace-pre-wrap" />
                     </div>
                   </div>
                   {/* Inline choice buttons for pending questions */}

--- a/gui/frontend/src/hooks/mutations/use-conversations.ts
+++ b/gui/frontend/src/hooks/mutations/use-conversations.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { queryKeys } from "@/lib/query-keys";
 import type { Conversation, ConversationList, ImuConversation } from "@/api/types";
+import type { InfiniteData } from "@tanstack/react-query";
 
 interface CreateConversationBody {
   project_id: number;
@@ -39,11 +40,29 @@ export function useSubmitConversationTask(conversationId: number) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (body: SubmitTaskBody) =>
-      api.post<{ run_id: string; conversation_id: number }>(
+      api.post<{ run_id?: string; queued?: boolean; conversation_id: number }>(
         `/conversations/${conversationId}/tasks`,
         body,
       ),
-    onSuccess: () => {
+    onSuccess: (data, variables) => {
+      if (data.queued) {
+        // Optimistically append to pending_task in the infinite query cache
+        qc.setQueryData<InfiniteData<Conversation>>(
+          queryKeys.conversations.detail(conversationId),
+          (old) => {
+            if (!old) return old;
+            const pages = old.pages.map((page, i) => {
+              if (i !== old.pages.length - 1) return page;
+              const existing = page.pending_task || "";
+              const newPending = existing
+                ? `${existing}\n\n${variables.task}`
+                : variables.task;
+              return { ...page, pending_task: newPending };
+            });
+            return { ...old, pages };
+          },
+        );
+      }
       qc.invalidateQueries({
         queryKey: queryKeys.conversations.detail(conversationId),
       });

--- a/gui/frontend/src/pages/ConversationView.tsx
+++ b/gui/frontend/src/pages/ConversationView.tsx
@@ -163,6 +163,7 @@ export default function ConversationView() {
   const prevLastSessionIdRef = useRef<string | undefined>(undefined);
   const prevChatLengthRef = useRef(0);
   const titleInputRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const qc = useQueryClient();
 
   const { data: projectResources } = useProjectResources(pid);
@@ -197,7 +198,7 @@ export default function ConversationView() {
   const rename = useRenameConversation(pid);
   const { pendingAskUsers, chatMessages, respond } = useSessionWS(
     lastSession?.run_id ?? "",
-    !!lastSession && interactive,
+    hasActiveSession && interactive,
   );
 
   const roleError =
@@ -315,7 +316,7 @@ export default function ConversationView() {
       cache_ttl_seconds: advCacheTtl.trim() ? Number(advCacheTtl) : undefined,
     };
     submit.mutate(body, {
-      onSuccess: () => { setTask(""); setSelectedFiles([]); setShowAllFiles(false); },
+      onSuccess: () => { setTask(""); setSelectedFiles([]); setShowAllFiles(false); setTimeout(() => textareaRef.current?.focus(), 0); },
     });
   }
 
@@ -412,7 +413,8 @@ export default function ConversationView() {
             return (
               <div key={session.run_id} className="space-y-4">
                 {(session.user_task ?? session.task) && <UserMessage task={(session.user_task ?? session.task)!} />}
-                {isLast && chatMessages.map((msg: ChatMessage) => (
+                {/* Chat messages: live from WS for active session, persisted for completed */}
+                {(isLast && hasActiveSession ? chatMessages : session.chat_messages ?? []).map((msg: ChatMessage) => (
                   <div
                     key={msg.id}
                     className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
@@ -424,7 +426,7 @@ export default function ConversationView() {
                           : "bg-muted text-foreground"
                       }`}
                     >
-                      <p className="whitespace-pre-wrap">{msg.text}</p>
+                      <MarkdownContent content={msg.text} className="whitespace-pre-wrap" />
                     </div>
                   </div>
                 ))}
@@ -436,27 +438,37 @@ export default function ConversationView() {
       </div>
 
       {/* Pending (queued) task indicator */}
-      {conversation?.pending_task && (
-        <div className="flex-shrink-0 border-t border-border bg-background px-4 py-2">
-          <div className="mx-auto max-w-2xl flex items-center gap-2 rounded-lg border border-dashed border-primary/40 bg-primary/5 px-3 py-2">
-            <Loader2 className="h-3.5 w-3.5 animate-spin text-primary flex-shrink-0" />
-            <span className="text-xs text-muted-foreground flex-1 truncate">
-              Queued: <span className="text-foreground">{conversation.pending_task.split("\n")[0]}</span>
-            </span>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-6 px-2 text-xs text-muted-foreground hover:text-destructive"
-              onClick={() => cancelPending.mutate()}
-              disabled={cancelPending.isPending}
-            >
-              <X className="h-3 w-3 mr-1" />
-              Cancel
-            </Button>
+      {conversation?.pending_task && (() => {
+        const queuedTasks = conversation.pending_task.split("\n\n").filter(Boolean);
+        return (
+          <div className="flex-shrink-0 border-t border-border bg-background px-4 py-2">
+            <div className="mx-auto max-w-2xl space-y-1.5">
+              {queuedTasks.map((qt, i) => (
+                <div key={i} className="flex items-center gap-2 rounded-lg border border-dashed border-primary/40 bg-primary/5 px-3 py-2">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin text-primary flex-shrink-0" />
+                  <span className="text-xs text-muted-foreground flex-1 truncate">
+                    Queued{queuedTasks.length > 1 ? ` (${i + 1}/${queuedTasks.length})` : ""}:{" "}
+                    <span className="text-foreground">{qt.split("\n")[0]}</span>
+                  </span>
+                </div>
+              ))}
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs text-muted-foreground hover:text-destructive"
+                  onClick={() => cancelPending.mutate()}
+                  disabled={cancelPending.isPending}
+                >
+                  <X className="h-3 w-3 mr-1" />
+                  Cancel all
+                </Button>
+              </div>
+            </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
 
       {/* Pending ask_user questions */}
       {pendingAskUsers.length > 0 && (
@@ -464,11 +476,11 @@ export default function ConversationView() {
           <div className="mx-auto max-w-2xl space-y-2">
             {pendingAskUsers.map((pending) => (
               <div key={pending.request_id} className="rounded-lg border border-border bg-muted/30 p-3 space-y-2">
-                <p className="text-sm font-medium">{pending.question}</p>
+                <MarkdownContent content={pending.question} className="text-sm font-medium" />
                 {pending.why && (
-                  <p className="text-xs text-muted-foreground">{pending.why}</p>
+                  <MarkdownContent content={pending.why} className="text-xs text-muted-foreground" />
                 )}
-                {pending.choices ? (
+                {pending.choices && (
                   <div className="flex flex-wrap gap-1.5">
                     {pending.choices.map((choice) => (
                       <Button
@@ -482,31 +494,30 @@ export default function ConversationView() {
                       </Button>
                     ))}
                   </div>
-                ) : (
-                  <div className="flex gap-2">
-                    <Input
-                      value={askUserResponse}
-                      onChange={(e) => setAskUserResponse(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" && !e.shiftKey) {
-                          e.preventDefault();
-                          handleAskUserResponse(pending, askUserResponse);
-                        }
-                      }}
-                      placeholder="Your answer…"
-                      autoFocus
-                      className="text-sm"
-                    />
-                    <Button
-                      type="button"
-                      size="icon"
-                      disabled={!askUserResponse.trim()}
-                      onClick={() => handleAskUserResponse(pending, askUserResponse)}
-                    >
-                      <CornerDownLeft className="h-4 w-4" />
-                    </Button>
-                  </div>
                 )}
+                <div className="flex gap-2">
+                  <Input
+                    value={askUserResponse}
+                    onChange={(e) => setAskUserResponse(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && !e.shiftKey) {
+                        e.preventDefault();
+                        handleAskUserResponse(pending, askUserResponse);
+                      }
+                    }}
+                    placeholder="Your answer…"
+                    autoFocus
+                    className="text-sm"
+                  />
+                  <Button
+                    type="button"
+                    size="icon"
+                    disabled={!askUserResponse.trim()}
+                    onClick={() => handleAskUserResponse(pending, askUserResponse)}
+                  >
+                    <CornerDownLeft className="h-4 w-4" />
+                  </Button>
+                </div>
               </div>
             ))}
           </div>
@@ -525,6 +536,7 @@ export default function ConversationView() {
             onDrop={handleDrop}
           >
             <Textarea
+              ref={textareaRef}
               value={task}
               onChange={(e) => setTask(e.target.value)}
               onKeyDown={handleKeyDown}

--- a/gui/frontend/src/pages/ImuPage.tsx
+++ b/gui/frontend/src/pages/ImuPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { useConversationInfinite, useImuConversations } from "@/hooks/queries/use-conversations";
-import { useCreateImuConversation, useDeleteImuConversation, useRenameImuConversation, useSubmitConversationTask } from "@/hooks/mutations/use-conversations";
+import { useCreateImuConversation, useDeleteImuConversation, useRenameImuConversation, useSubmitConversationTask, useCancelPendingTask } from "@/hooks/mutations/use-conversations";
 import { useStopSession } from "@/hooks/mutations/use-sessions";
 import { useProjectSessions } from "@/hooks/queries/use-sessions";
 import { useSessionWS } from "@/hooks/useSessionWS";
@@ -162,6 +162,7 @@ function ImuConversationView({ cid }: { cid: number }) {
   const prevLastSessionIdRef = useRef<string | undefined>(undefined);
   const prevChatLengthRef = useRef(0);
   const titleInputRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const { data: agents } = useResources("agents");
   const { data: memories } = useResources("memories");
@@ -185,10 +186,11 @@ function ImuConversationView({ cid }: { cid: number }) {
 
   const submit = useSubmitConversationTask(cid);
   const stop = useStopSession();
+  const cancelPending = useCancelPendingTask(cid);
   const rename = useRenameImuConversation();
   const { pendingAskUsers, chatMessages, respond } = useSessionWS(
     lastSession?.run_id ?? "",
-    !!lastSession && interactive,
+    hasActiveSession && interactive,
   );
 
   const agentNames = (agents ?? []).map((a: { name: string }) => a.name);
@@ -279,7 +281,7 @@ function ImuConversationView({ cid }: { cid: number }) {
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     const trimmed = task.trim();
-    if (!trimmed || hasActiveSession || hasAdvError) return;
+    if (!trimmed || hasAdvError) return;
     submit.mutate(
       {
         task: trimmed,
@@ -294,7 +296,7 @@ function ImuConversationView({ cid }: { cid: number }) {
         cache_max_entries: advCacheMaxEntries.trim() ? Number(advCacheMaxEntries) : undefined,
         cache_ttl_seconds: advCacheTtl.trim() ? Number(advCacheTtl) : undefined,
       },
-      { onSuccess: () => { setTask(""); setSelectedFiles([]); setShowAllFiles(false); } },
+      { onSuccess: () => { setTask(""); setSelectedFiles([]); setShowAllFiles(false); setTimeout(() => textareaRef.current?.focus(), 0); } },
     );
   }
 
@@ -390,8 +392,8 @@ function ImuConversationView({ cid }: { cid: number }) {
                 {(session.user_task ?? session.task) && (
                   <UserMessage task={(session.user_task ?? session.task)!} />
                 )}
-                {isLast &&
-                  chatMessages.map((msg: ChatMessage) => (
+                {/* Chat messages: live from WS for active session, persisted for completed */}
+                {(isLast && hasActiveSession ? chatMessages : session.chat_messages ?? []).map((msg: ChatMessage) => (
                     <div
                       key={msg.id}
                       className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
@@ -403,7 +405,7 @@ function ImuConversationView({ cid }: { cid: number }) {
                             : "bg-muted text-foreground"
                         }`}
                       >
-                        <p className="whitespace-pre-wrap">{msg.text}</p>
+                        <MarkdownContent content={msg.text} className="whitespace-pre-wrap" />
                       </div>
                     </div>
                   ))}
@@ -414,6 +416,39 @@ function ImuConversationView({ cid }: { cid: number }) {
         </div>
       </div>
 
+      {/* Pending (queued) task indicator */}
+      {conversation?.pending_task && (() => {
+        const queuedTasks = conversation.pending_task.split("\n\n").filter(Boolean);
+        return (
+          <div className="flex-shrink-0 border-t border-border bg-background px-4 py-2">
+            <div className="mx-auto max-w-2xl space-y-1.5">
+              {queuedTasks.map((qt, i) => (
+                <div key={i} className="flex items-center gap-2 rounded-lg border border-dashed border-primary/40 bg-primary/5 px-3 py-2">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin text-primary flex-shrink-0" />
+                  <span className="text-xs text-muted-foreground flex-1 truncate">
+                    Queued{queuedTasks.length > 1 ? ` (${i + 1}/${queuedTasks.length})` : ""}:{" "}
+                    <span className="text-foreground">{qt.split("\n")[0]}</span>
+                  </span>
+                </div>
+              ))}
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 px-2 text-xs text-muted-foreground hover:text-destructive"
+                  onClick={() => cancelPending.mutate()}
+                  disabled={cancelPending.isPending}
+                >
+                  <X className="h-3 w-3 mr-1" />
+                  Cancel all
+                </Button>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
+
       {/* Pending ask_user questions */}
       {pendingAskUsers.length > 0 && (
         <div className="flex-shrink-0 border-t border-border bg-background px-4 pt-3 pb-1">
@@ -423,11 +458,11 @@ function ImuConversationView({ cid }: { cid: number }) {
                 key={pending.request_id}
                 className="rounded-lg border border-border bg-muted/30 p-3 space-y-2"
               >
-                <p className="text-sm font-medium">{pending.question}</p>
+                <MarkdownContent content={pending.question} className="text-sm font-medium" />
                 {pending.why && (
-                  <p className="text-xs text-muted-foreground">{pending.why}</p>
+                  <MarkdownContent content={pending.why} className="text-xs text-muted-foreground" />
                 )}
-                {pending.choices ? (
+                {pending.choices && (
                   <div className="flex flex-wrap gap-1.5">
                     {pending.choices.map((choice) => (
                       <Button
@@ -441,31 +476,30 @@ function ImuConversationView({ cid }: { cid: number }) {
                       </Button>
                     ))}
                   </div>
-                ) : (
-                  <div className="flex gap-2">
-                    <Input
-                      value={askUserResponse}
-                      onChange={(e) => setAskUserResponse(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" && !e.shiftKey) {
-                          e.preventDefault();
-                          handleAskUserResponse(pending, askUserResponse);
-                        }
-                      }}
-                      placeholder="Your answer…"
-                      autoFocus
-                      className="text-sm"
-                    />
-                    <Button
-                      type="button"
-                      size="icon"
-                      disabled={!askUserResponse.trim()}
-                      onClick={() => handleAskUserResponse(pending, askUserResponse)}
-                    >
-                      <CornerDownLeft className="h-4 w-4" />
-                    </Button>
-                  </div>
                 )}
+                <div className="flex gap-2">
+                  <Input
+                    value={askUserResponse}
+                    onChange={(e) => setAskUserResponse(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && !e.shiftKey) {
+                        e.preventDefault();
+                        handleAskUserResponse(pending, askUserResponse);
+                      }
+                    }}
+                    placeholder="Your answer…"
+                    autoFocus
+                    className="text-sm"
+                  />
+                  <Button
+                    type="button"
+                    size="icon"
+                    disabled={!askUserResponse.trim()}
+                    onClick={() => handleAskUserResponse(pending, askUserResponse)}
+                  >
+                    <CornerDownLeft className="h-4 w-4" />
+                  </Button>
+                </div>
               </div>
             ))}
           </div>
@@ -483,15 +517,16 @@ function ImuConversationView({ cid }: { cid: number }) {
             onDrop={handleDrop}
           >
             <Textarea
+              ref={textareaRef}
               value={task}
               onChange={(e) => setTask(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder={
                 hasActiveSession
-                  ? "Bot Imu is working…"
+                  ? "Queue a follow-up task… (Enter to queue, runs after current session)"
                   : "Ask Bot Imu anything… (Enter to send, Shift+Enter for new line, drag & drop files to attach)"
               }
-              disabled={hasActiveSession || submit.isPending}
+              disabled={submit.isPending}
               className="h-[80px] resize-none overflow-y-auto"
               autoFocus
             />
@@ -612,7 +647,7 @@ function ImuConversationView({ cid }: { cid: number }) {
                   </span>
                 )}
               </Button>
-              {hasActiveSession ? (
+              {hasActiveSession && (
                 <Button
                   type="button"
                   variant="destructive"
@@ -626,18 +661,19 @@ function ImuConversationView({ cid }: { cid: number }) {
                   )}
                   Stop
                 </Button>
-              ) : (
-                <Button
-                  type="submit"
-                  disabled={!task.trim() || submit.isPending || hasAdvError}
-                >
-                  {submit.isPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <CornerDownLeft className="h-4 w-4" />
-                  )}
-                </Button>
               )}
+              <Button
+                type="submit"
+                disabled={!task.trim() || submit.isPending || hasAdvError}
+                variant={hasActiveSession ? "outline" : "default"}
+                title={hasActiveSession ? "Queue task (runs after current session)" : undefined}
+              >
+                {submit.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <CornerDownLeft className="h-4 w-4" />
+                )}
+              </Button>
             </div>
           </div>
         </form>

--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -146,6 +146,9 @@ def create_app(db_path: str | None = None) -> FastAPI:
             file_path = frontend_dir / full_path
             if full_path and file_path.is_file():
                 return FileResponse(str(file_path))
-            return FileResponse(str(index_html))
+            return FileResponse(
+                str(index_html),
+                headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
+            )
 
     return app

--- a/gui/src/strawpot_gui/routers/conversations.py
+++ b/gui/src/strawpot_gui/routers/conversations.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from strawpot_gui.db import _extract_recap, _strip_recap, get_db_conn
 from strawpot_gui.routers.sessions import _refresh_session_status, launch_session_subprocess
+from strawpot_gui.routers.ws import _read_chat_messages
 
 router = APIRouter(prefix="/api", tags=["conversations"])
 
@@ -361,14 +362,14 @@ def get_conversation(
         if not cursor_row:
             raise HTTPException(400, "Invalid before_id")
         rows = conn.execute(
-            "SELECT run_id, task, user_task, summary, status, exit_code, started_at, ended_at, duration_ms, role "
+            "SELECT run_id, task, user_task, summary, status, exit_code, started_at, ended_at, duration_ms, role, interactive, session_dir "
             "FROM sessions WHERE conversation_id = ? AND started_at < ? "
             "ORDER BY started_at DESC LIMIT ?",
             (conversation_id, cursor_row["started_at"], limit + 1),
         ).fetchall()
     else:
         rows = conn.execute(
-            "SELECT run_id, task, user_task, summary, status, exit_code, started_at, ended_at, duration_ms, role "
+            "SELECT run_id, task, user_task, summary, status, exit_code, started_at, ended_at, duration_ms, role, interactive, session_dir "
             "FROM sessions WHERE conversation_id = ? "
             "ORDER BY started_at DESC LIMIT ?",
             (conversation_id, limit + 1),
@@ -378,10 +379,14 @@ def get_conversation(
     sessions = list(reversed(rows[:limit]))  # ascending for display
 
     result = dict(row)
-    result["sessions"] = [
-        {**dict(s), "summary": _strip_recap(s["summary"]) if s["summary"] else s["summary"]}
-        for s in sessions
-    ]
+    result["sessions"] = []
+    for s in sessions:
+        d = {k: s[k] for k in s.keys() if k != "session_dir"}
+        d["summary"] = _strip_recap(d["summary"]) if d["summary"] else d["summary"]
+        d["interactive"] = bool(d.get("interactive"))
+        if d["interactive"] and s["session_dir"]:
+            d["chat_messages"] = _read_chat_messages(s["session_dir"])
+        result["sessions"].append(d)
     result["has_more"] = has_more
     return result
 

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -528,7 +528,7 @@ def get_session(project_id: int, run_id: str, conn=Depends(get_db_conn)):
 def stop_session(run_id: str, conn=Depends(get_db_conn)):
     """Stop a running session by sending SIGTERM to the orchestrator PID."""
     row = conn.execute(
-        "SELECT run_id, status, session_dir, project_id FROM sessions WHERE run_id = ?",
+        "SELECT run_id, status, session_dir, project_id, conversation_id FROM sessions WHERE run_id = ?",
         (run_id,),
     ).fetchone()
     if not row:
@@ -540,6 +540,14 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
         )
 
     project_id = row["project_id"]
+    conversation_id = row["conversation_id"]
+
+    # Clear any queued pending_task — user explicitly interrupted the flow
+    if conversation_id:
+        conn.execute(
+            "UPDATE conversations SET pending_task = NULL WHERE id = ?",
+            (conversation_id,),
+        )
 
     # Read PID from session.json
     session_dir = Path(row["session_dir"])

--- a/gui/tests/test_conversations.py
+++ b/gui/tests/test_conversations.py
@@ -361,22 +361,25 @@ def _insert_completed_session(
     conn, project_id, conversation_id, *,
     task="do something", user_task=None, summary="done", exit_code=0,
     status="completed", started_at=None, files_changed=None,
+    session_dir=None, interactive=False,
 ):
     """Insert a session row directly for testing context building."""
     run_id = uuid.uuid4().hex[:12]
     if started_at is None:
         started_at = "2026-01-01T00:00:00"
+    if session_dir is None:
+        session_dir = f"/tmp/{run_id}"
     import json as _json
     fc_json = _json.dumps(files_changed) if files_changed else None
     conn.execute(
         "INSERT INTO sessions "
         "(run_id, project_id, role, runtime, isolation, status, task, user_task, "
         "summary, exit_code, conversation_id, started_at, session_dir, "
-        "files_changed) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "files_changed, interactive) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (run_id, project_id, "default", "claude-code", "none", status, task,
          user_task, summary, exit_code, conversation_id, started_at,
-         f"/tmp/{run_id}", fc_json),
+         session_dir, fc_json, int(interactive)),
     )
     return run_id
 
@@ -1043,3 +1046,119 @@ class TestWriteConversationHistory:
         assert "5 earlier turns omitted" in content
         assert "task-00" not in content
         assert "task-14" in content
+
+
+class TestChatMessagePersistence:
+    """Tests for chat message persistence in conversation responses."""
+
+    def test_interactive_session_includes_chat_messages(self, client, tmp_path, app):
+        """Interactive sessions with chat_messages.jsonl return messages in API."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        # Create a session dir with chat_messages.jsonl
+        import json as _json
+        session_dir = tmp_path / "session_with_chat"
+        session_dir.mkdir()
+        messages = [
+            {"id": "req_1", "role": "agent", "text": "What color?", "timestamp": 1000.0},
+            {"id": "user-req_1", "role": "user", "text": "Blue", "timestamp": 1001.0},
+        ]
+        with open(session_dir / "chat_messages.jsonl", "w") as f:
+            for msg in messages:
+                f.write(_json.dumps(msg) + "\n")
+
+        with get_db(app.state.db_path) as conn:
+            _insert_completed_session(
+                conn, pid, cid,
+                task="interactive task", user_task="interactive task",
+                summary="done",
+                session_dir=str(session_dir),
+                interactive=True,
+            )
+
+        data = client.get(f"/api/conversations/{cid}").json()
+        session = data["sessions"][0]
+        assert session["interactive"] is True
+        assert len(session["chat_messages"]) == 2
+        assert session["chat_messages"][0]["text"] == "What color?"
+        assert session["chat_messages"][1]["text"] == "Blue"
+
+    def test_non_interactive_session_has_no_chat_messages(self, client, tmp_path, app):
+        """Non-interactive sessions do not include chat_messages field."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        with get_db(app.state.db_path) as conn:
+            _insert_completed_session(
+                conn, pid, cid,
+                task="normal task", user_task="normal task",
+                summary="done",
+            )
+
+        data = client.get(f"/api/conversations/{cid}").json()
+        session = data["sessions"][0]
+        assert session.get("interactive") is False
+        assert "chat_messages" not in session
+
+    def test_interactive_session_without_chat_file_returns_empty(self, client, tmp_path, app):
+        """Interactive session with no chat_messages.jsonl returns empty list."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        session_dir = tmp_path / "session_no_chat"
+        session_dir.mkdir()
+
+        with get_db(app.state.db_path) as conn:
+            _insert_completed_session(
+                conn, pid, cid,
+                task="interactive no chat", user_task="interactive no chat",
+                summary="done",
+                session_dir=str(session_dir),
+                interactive=True,
+            )
+
+        data = client.get(f"/api/conversations/{cid}").json()
+        session = data["sessions"][0]
+        assert session["interactive"] is True
+        assert session["chat_messages"] == []
+
+    def test_chat_messages_preserved_across_multiple_sessions(self, client, tmp_path, app):
+        """Each interactive session keeps its own chat messages."""
+        import json as _json
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        for i in range(2):
+            session_dir = tmp_path / f"session_{i}"
+            session_dir.mkdir()
+            msgs = [{"id": f"q_{i}", "role": "agent", "text": f"Question {i}", "timestamp": float(1000 + i)}]
+            with open(session_dir / "chat_messages.jsonl", "w") as f:
+                f.write(_json.dumps(msgs[0]) + "\n")
+
+            with get_db(app.state.db_path) as conn:
+                _insert_completed_session(
+                    conn, pid, cid,
+                    task=f"task-{i}", user_task=f"task-{i}",
+                    summary=f"done-{i}",
+                    started_at=f"2026-01-01T00:0{i}:00",
+                    session_dir=str(session_dir),
+                    interactive=True,
+                )
+
+        data = client.get(f"/api/conversations/{cid}").json()
+        assert len(data["sessions"]) == 2
+        assert data["sessions"][0]["chat_messages"][0]["text"] == "Question 0"
+        assert data["sessions"][1]["chat_messages"][0]["text"] == "Question 1"


### PR DESCRIPTION
## Summary
- **Markdown rendering**: ask_user question/why text and chat balloons now render as markdown via `MarkdownContent` (ImuPage, ConversationView, ChatPanel)
- **Chat message persistence**: Conversation API now returns `chat_messages` for completed interactive sessions, so Q&A history survives session end and page reloads
- **Ask_user UX**: Dedicated text input always visible alongside choice buttons; WebSocket active guard fixed to clear ask_user on session end
- **Message queuing fixes**: Optimistic cache updates, textarea focus retention, pending_task cleared on stop, Cache-Control headers on index.html

## Files changed
- `gui/frontend/src/api/types.ts` — Add `interactive` and `chat_messages` to `ConversationSession`
- `gui/frontend/src/components/ChatPanel.tsx` — Use `MarkdownContent` for chat balloons
- `gui/frontend/src/pages/ConversationView.tsx` — Markdown in ask_user panel, persisted chat messages for completed sessions
- `gui/frontend/src/pages/ImuPage.tsx` — Same changes aligned with ConversationView
- `gui/frontend/src/hooks/mutations/use-conversations.ts` — Optimistic cache update for queued messages
- `gui/src/strawpot_gui/routers/conversations.py` — Include `chat_messages` from `chat_messages.jsonl` for interactive sessions
- `gui/src/strawpot_gui/routers/sessions.py` — Clear `pending_task` on session stop
- `gui/src/strawpot_gui/app.py` — Cache-Control headers for index.html
- `gui/tests/test_conversations.py` — 4 new tests for chat message persistence

## Test plan
- [x] `pytest gui/tests/test_conversations.py` — 68 tests pass (4 new)
- [ ] Manual: submit interactive task, verify ask_user renders markdown
- [ ] Manual: after session ends, verify chat Q&A still visible
- [ ] Manual: queue multiple messages, verify real-time display

🤖 Generated with [Claude Code](https://claude.com/claude-code)