### PR TITLE
Fix _strip_recap returning empty when output is only a recap

### DIFF
--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -261,7 +261,8 @@ def _strip_recap(content: str) -> str:
     idx = content.rfind(marker)
     if idx == -1:
         return content
-    return content[:idx].rstrip()
+    before = content[:idx].rstrip()
+    return before if before else content
 
 
 def _parse_trace(trace_path: str, session_dir: str | None = None) -> dict:

--- a/gui/tests/test_conversations.py
+++ b/gui/tests/test_conversations.py
@@ -744,6 +744,11 @@ class TestStripRecap:
         assert "more output" in result
         assert "actual recap" not in result
 
+    def test_returns_full_content_when_only_recap(self):
+        content = "## Session Recap\n- Implemented the login page"
+        result = _strip_recap(content)
+        assert result == content
+
 
 class TestRecapInstruction:
     def test_enhanced_recap_instruction(self, client, tmp_path, app):


### PR DESCRIPTION
## Summary
- When the agent outputs only a `## Session Recap` with no preceding text, `_strip_recap()` returned an empty string
- The frontend then shows "No summary available" instead of the recap content
- Fix: fall back to the full content instead of returning empty

## Test plan
- [x] Added `test_returns_full_content_when_only_recap` test case
- [x] All existing `TestStripRecap` tests still pass
- [ ] Verify in GUI that recap-only sessions now display their content

🤖 Generated with [Claude Code](https://claude.com/claude-code)