### PR TITLE
Remove recap instruction from conversation context

### DIFF
--- a/gui/src/strawpot_gui/routers/conversations.py
+++ b/gui/src/strawpot_gui/routers/conversations.py
@@ -182,21 +182,6 @@ def _build_conversation_context(conn, conversation_id: int, *, history_path: str
             "read it if you need more detail than the summaries above."
         )
 
-    # Recap instruction: ask the agent to produce a structured recap
-    parts.append("")
-    parts.append(
-        '**Recap Instruction:** When you finish, end your response with a '
-        '"## Session Recap" section containing:\n'
-        "### Accomplished\n"
-        "- What was done, with specifics (file paths, function names, error fixes)\n"
-        "### Changes Made\n"
-        "- Files modified and what changed in each\n"
-        "### Decisions\n"
-        '- Key choices and why (e.g., "used X over Y because...")\n'
-        "### Open Items\n"
-        "- What's left to do, blockers, or questions for the user"
-    )
-
     return "\n".join(parts)
 
 

--- a/gui/tests/test_conversations.py
+++ b/gui/tests/test_conversations.py
@@ -540,8 +540,8 @@ class TestBuildConversationContext:
         with get_db(app.state.db_path) as conn:
             ctx = _build_conversation_context(conn, cid)
 
-        # Extract text between "**Pending Follow-up:**" and "**Recap Instruction:**"
-        followup = ctx.split("**Pending Follow-up:**\n")[1].split("\n\n**Recap Instruction:**")[0]
+        # Extract text after "**Pending Follow-up:**"
+        followup = ctx.split("**Pending Follow-up:**\n")[1]
         assert len(followup) <= 2010  # 2000 + "…"
 
     def test_pending_followup_dual_with_recap(self, client, tmp_path, app):
@@ -616,7 +616,7 @@ class TestBuildConversationContext:
         with get_db(app.state.db_path) as conn:
             ctx = _build_conversation_context(conn, cid)
 
-        raw_section = ctx.split("**Recent output:**\n")[1].split("\n\n**Recap Instruction:**")[0]
+        raw_section = ctx.split("**Recent output:**\n")[1]
         assert len(raw_section) <= 1500
 
     def test_files_changed_shown_for_recent_turns(self, client, tmp_path, app):
@@ -748,44 +748,6 @@ class TestStripRecap:
         content = "## Session Recap\n- Implemented the login page"
         result = _strip_recap(content)
         assert result == content
-
-
-class TestRecapInstruction:
-    def test_enhanced_recap_instruction(self, client, tmp_path, app):
-        """Recap instruction includes structured sections."""
-        d = tmp_path / "proj"
-        d.mkdir()
-        pid = _register_project(client, d)
-        conv = _create_conversation(client, pid)
-        cid = conv["id"]
-
-        with get_db(app.state.db_path) as conn:
-            _insert_completed_session(
-                conn, pid, cid,
-                task="first task", user_task="first task",
-                summary="done",
-            )
-
-        with get_db(app.state.db_path) as conn:
-            ctx = _build_conversation_context(conn, cid)
-
-        assert "### Accomplished" in ctx
-        assert "### Changes Made" in ctx
-        assert "### Decisions" in ctx
-        assert "### Open Items" in ctx
-
-    def test_no_context_means_no_recap_instruction(self, client, tmp_path, app):
-        """First turn (no prior sessions) should have no recap instruction."""
-        d = tmp_path / "proj"
-        d.mkdir()
-        pid = _register_project(client, d)
-        conv = _create_conversation(client, pid)
-        cid = conv["id"]
-
-        with get_db(app.state.db_path) as conn:
-            ctx = _build_conversation_context(conn, cid)
-
-        assert ctx == ""
 
 
 class TestHistoryFileHint:


### PR DESCRIPTION
## Summary
- Removes the duplicate recap instruction from `_build_conversation_context()` — the `strawpot-session-recap` skill is now the single source of truth
- Removes `TestRecapInstruction` test class and fixes 2 tests that split on the removed `**Recap Instruction:**` delimiter
- Companion PR: strawpot/skills#TBD updates the skill to the 4-subsection format

## Context
Agents were producing "recap only" responses because they received conflicting instructions: the skill said "1-2 sentences" while conversation context injected a 4-subsection format. By making the skill authoritative and removing the duplicate, there's one clear instruction.

## Test plan
- [x] `pytest gui/tests/test_conversations.py` — 67 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)