### PR TITLE
Add interactive agent picker and onboarding wizard

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -34,6 +34,15 @@ def cli():
 # ---------------------------------------------------------------------------
 
 
+_SEEDED_AGENTS = [
+    ("strawpot-claude-code", "Anthropic Claude Code — requires Anthropic account or API key"),
+    ("strawpot-gemini", "Google Gemini CLI — requires Google account or API key"),
+    ("strawpot-codex", "OpenAI Codex CLI — requires OpenAI API key"),
+    ("strawpot-openhands", "OpenHands — open-source, configurable LLM backend"),
+    ("strawpot-pi", "Pi coding-agent — requires Anthropic account or API key"),
+]
+
+
 def needs_onboarding(config, working_dir: str) -> bool:
     """Return True when the first-run onboarding wizard should be shown.
 
@@ -49,6 +58,67 @@ def needs_onboarding(config, working_dir: str) -> bool:
         return False  # default agent already installed
     except (FileNotFoundError, ValueError):
         return True
+
+
+def _pick_agent() -> str | None:
+    """Display the agent picker and return the selected agent name.
+
+    Returns ``None`` if the user cancels (Ctrl-C or invalid input).
+    """
+    click.echo("\nChoose your default agent:\n")
+    for i, (name, desc) in enumerate(_SEEDED_AGENTS, 1):
+        click.echo(f"  {i}) {name}")
+        click.echo(f"     {desc}\n")
+
+    raw = click.prompt("Enter number (1-5)", default="1")
+    try:
+        idx = int(raw)
+        if 1 <= idx <= len(_SEEDED_AGENTS):
+            return _SEEDED_AGENTS[idx - 1][0]
+    except ValueError:
+        pass
+    click.echo(f"Invalid selection: {raw}", err=True)
+    return None
+
+
+def _onboarding_wizard(working_dir: str) -> str | None:
+    """Run the first-run onboarding wizard.
+
+    Returns the selected agent name so the caller can continue with a
+    normal start/gui flow, or ``None`` if the user cancelled.
+    """
+    click.echo("Welcome to StrawPot! Let's set up your first agent.\n")
+
+    # Step 2: Agent selection
+    agent_name = _pick_agent()
+    if agent_name is None:
+        return None
+
+    click.echo(f"\nSelected: {agent_name}")
+
+    # Step 3: Install agent wrapper from StrawHub
+    _ensure_agent_installed(agent_name, working_dir, auto_setup=True)
+
+    # Step 7: Save default runtime to global config
+    from strawpot.config import save_resource_config
+
+    save_resource_config(None, "agents", agent_name)
+
+    # Persist runtime choice to global strawpot.toml
+    import tomli_w
+
+    from strawpot.config import _read_toml
+
+    global_toml = get_strawpot_home() / "strawpot.toml"
+    data = _read_toml(global_toml)
+    data["runtime"] = agent_name
+    global_toml.parent.mkdir(parents=True, exist_ok=True)
+    with open(global_toml, "wb") as f:
+        tomli_w.dump(data, f)
+
+    click.echo(f"Saved runtime = \"{agent_name}\" to {global_toml}\n")
+
+    return agent_name
 
 
 # ---------------------------------------------------------------------------
@@ -348,12 +418,12 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task, head
 
     # 0. First-run onboarding
     if not headless and needs_onboarding(config, working_dir):
-        click.echo(
-            "No agent runtime configured. "
-            "Run the onboarding wizard to get started."
-        )
-        # TODO: call _onboarding_wizard() (implementation steps 2-7)
-        sys.exit(1)
+        agent_name = _onboarding_wizard(working_dir)
+        if agent_name is None:
+            sys.exit(1)
+        # Reload config now that runtime has been saved
+        config = load_config(Path(working_dir))
+        runtime = agent_name
 
     # 0a. Recover stale sessions from previous crashes
     recovered = recover_stale_sessions(working_dir, config)
@@ -649,12 +719,10 @@ def gui(port):
     working_dir = str(Path.cwd())
 
     if needs_onboarding(config, working_dir):
-        click.echo(
-            "No agent runtime configured. "
-            "Run the onboarding wizard to get started."
-        )
-        # TODO: call _onboarding_wizard() (implementation steps 2-7)
-        sys.exit(1)
+        agent_name = _onboarding_wizard(working_dir)
+        if agent_name is None:
+            sys.exit(1)
+        config = load_config(Path(working_dir))
 
     from strawpot_gui.server import DEFAULT_PORT
     from strawpot_gui.server import main as gui_main

--- a/cli/tests/test_cli_bootstrap.py
+++ b/cli/tests/test_cli_bootstrap.py
@@ -6,10 +6,13 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 
 from strawpot.cli import (
+    _SEEDED_AGENTS,
     _ensure_agent_installed,
     _ensure_memory_installed,
     _ensure_role_installed,
     _ensure_skill_installed,
+    _onboarding_wizard,
+    _pick_agent,
     needs_onboarding,
 )
 from strawpot.config import StrawPotConfig
@@ -422,3 +425,94 @@ def test_needs_onboarding_false_agent_installed(tmp_path, monkeypatch):
     with patch("strawpot.cli.resolve_agent") as mock_resolve:
         mock_resolve.return_value = MagicMock()  # agent found
         assert needs_onboarding(config, str(tmp_path / "project")) is False
+
+
+# ---------------------------------------------------------------------------
+# _pick_agent
+# ---------------------------------------------------------------------------
+
+
+@patch("strawpot.cli.click.prompt", return_value="1")
+def test_pick_agent_selects_first(mock_prompt):
+    """Selecting 1 returns the first seeded agent."""
+    result = _pick_agent()
+    assert result == _SEEDED_AGENTS[0][0]
+
+
+@patch("strawpot.cli.click.prompt", return_value="3")
+def test_pick_agent_selects_third(mock_prompt):
+    """Selecting 3 returns the third seeded agent."""
+    result = _pick_agent()
+    assert result == _SEEDED_AGENTS[2][0]
+
+
+@patch("strawpot.cli.click.prompt", return_value="5")
+def test_pick_agent_selects_fifth(mock_prompt):
+    """Selecting 5 returns the fifth seeded agent."""
+    result = _pick_agent()
+    assert result == _SEEDED_AGENTS[4][0]
+
+
+@patch("strawpot.cli.click.prompt", return_value="0")
+def test_pick_agent_invalid_zero(mock_prompt):
+    """Out-of-range selection returns None."""
+    assert _pick_agent() is None
+
+
+@patch("strawpot.cli.click.prompt", return_value="abc")
+def test_pick_agent_invalid_text(mock_prompt):
+    """Non-numeric input returns None."""
+    assert _pick_agent() is None
+
+
+# ---------------------------------------------------------------------------
+# _onboarding_wizard
+# ---------------------------------------------------------------------------
+
+
+def test_onboarding_wizard_saves_runtime(tmp_path, monkeypatch):
+    """Wizard saves runtime to global strawpot.toml and returns agent name."""
+    import tomllib
+
+    global_dir = tmp_path / "global"
+    global_dir.mkdir()
+    monkeypatch.setenv("STRAWPOT_HOME", str(global_dir))
+
+    with patch("strawpot.cli._pick_agent", return_value="strawpot-gemini"), \
+         patch("strawpot.cli._ensure_agent_installed"), \
+         patch("strawpot.cli.click.echo"):
+        result = _onboarding_wizard(str(tmp_path / "project"))
+
+    assert result == "strawpot-gemini"
+    with open(global_dir / "strawpot.toml", "rb") as f:
+        data = tomllib.load(f)
+    assert data["runtime"] == "strawpot-gemini"
+
+
+def test_onboarding_wizard_returns_none_on_cancel(tmp_path, monkeypatch):
+    """Wizard returns None when user cancels agent selection."""
+    global_dir = tmp_path / "global"
+    global_dir.mkdir()
+    monkeypatch.setenv("STRAWPOT_HOME", str(global_dir))
+
+    with patch("strawpot.cli._pick_agent", return_value=None), \
+         patch("strawpot.cli.click.echo"):
+        result = _onboarding_wizard(str(tmp_path / "project"))
+
+    assert result is None
+
+
+def test_onboarding_wizard_calls_ensure_agent_installed(tmp_path, monkeypatch):
+    """Wizard calls _ensure_agent_installed with auto_setup=True."""
+    global_dir = tmp_path / "global"
+    global_dir.mkdir()
+    monkeypatch.setenv("STRAWPOT_HOME", str(global_dir))
+
+    with patch("strawpot.cli._pick_agent", return_value="strawpot-codex"), \
+         patch("strawpot.cli._ensure_agent_installed") as mock_install, \
+         patch("strawpot.cli.click.echo"):
+        _onboarding_wizard(str(tmp_path / "project"))
+
+    mock_install.assert_called_once_with(
+        "strawpot-codex", str(tmp_path / "project"), auto_setup=True,
+    )


### PR DESCRIPTION
## Summary
- Implements onboarding step 2: interactive agent picker with 5 seeded agents and descriptions
- Adds `_onboarding_wizard()` that orchestrates: picker → auto-install via StrawHub → save runtime to global `strawpot.toml`
- Replaces TODO stubs in both `start` and `gui` commands with actual wizard calls
- On successful onboarding, reloads config and continues normal execution flow

## Test plan
- [x] `_pick_agent` — valid selections (1, 3, 5), invalid (0, non-numeric) return None
- [x] `_onboarding_wizard` — saves runtime to TOML, returns None on cancel, calls `_ensure_agent_installed` with `auto_setup=True`
- [x] All 590 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)