### PR TITLE
Fix session logs, stale prompts, and interactive flag overwrites

### DIFF
--- a/gui/frontend/src/components/AgentLogViewer.tsx
+++ b/gui/frontend/src/components/AgentLogViewer.tsx
@@ -38,13 +38,16 @@ export default function AgentLogViewer({
   const rootId = agentIds.find((id) => agents[id].parent === null) ?? agentIds[0] ?? "";
   const [selectedAgent, setSelectedAgent] = useState(rootId);
 
-  // Subscribe/unsubscribe to agent logs via WS
+  // Subscribe to agent logs via WS; only unsubscribe when switching agents
+  const prevAgentRef = useRef<string | null>(null);
   useEffect(() => {
     if (!selectedAgent || !wsConnected) return;
+    // Unsubscribe from the previous agent when switching
+    if (prevAgentRef.current && prevAgentRef.current !== selectedAgent) {
+      unsubscribeLogs(prevAgentRef.current);
+    }
+    prevAgentRef.current = selectedAgent;
     subscribeLogs(selectedAgent);
-    return () => {
-      unsubscribeLogs(selectedAgent);
-    };
   }, [selectedAgent, wsConnected, subscribeLogs, unsubscribeLogs]);
 
   const logState = agentLogs.get(selectedAgent);

--- a/gui/frontend/src/hooks/useSessionWS.ts
+++ b/gui/frontend/src/hooks/useSessionWS.ts
@@ -221,6 +221,7 @@ export function useSessionWS(
 
           case "stream_complete":
             streamDoneRef.current = true;
+            setPendingAskUsers([]);
             ws.close();
             wsRef.current = null;
             setConnected(false);

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -66,7 +66,7 @@ export default function SessionDetail() {
   const isInteractive = !!sessionData?.interactive;
   const { pendingAskUsers, chatMessages, traceEvents, treeData: wsTreeData, connected, agentLogs, respond, subscribeLogs, unsubscribeLogs } = useSessionWS(
     runId ?? "",
-    active || isInteractive,
+    true,  // always connect — terminal sessions get snapshots then close
   );
   const treeData = wsTreeData ?? sessionData?.tree ?? null;
   const restEvents = sessionData?.events ?? [];

--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -468,7 +468,7 @@ def _upsert_session(
              task        = excluded.task,
              summary     = COALESCE(excluded.summary, sessions.summary),
              files_changed = COALESCE(excluded.files_changed, sessions.files_changed),
-             interactive = excluded.interactive
+             interactive = MAX(sessions.interactive, excluded.interactive)
              -- conversation_id intentionally omitted: preserve existing FK""",
         (
             run_id,

--- a/gui/src/strawpot_gui/routers/ws.py
+++ b/gui/src/strawpot_gui/routers/ws.py
@@ -167,17 +167,23 @@ async def session_ws(websocket: WebSocket, run_id: str) -> None:
 
     await websocket.accept()
 
-    # ---- Read optional init message for trace offset resumption ----
+    # ---- Read early messages (init + subscribe_logs) ----
     trace_offset = 0
     early_subscribes: list[dict] = []
     try:
-        raw = await asyncio.wait_for(websocket.receive_text(), timeout=1.0)
-        msg = json.loads(raw)
-        if msg.get("type") == "init":
-            trace_offset = int(msg.get("trace_offset", 0))
-        elif msg.get("type") == "subscribe_logs":
-            early_subscribes.append(msg)
-    except (asyncio.TimeoutError, json.JSONDecodeError, ValueError, WebSocketDisconnect):
+        while True:
+            raw = await asyncio.wait_for(websocket.receive_text(), timeout=1.0)
+            try:
+                msg = json.loads(raw)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if msg.get("type") == "init":
+                trace_offset = int(msg.get("trace_offset", 0))
+            elif msg.get("type") == "subscribe_logs":
+                early_subscribes.append(msg)
+            else:
+                break  # unknown message type — stop reading
+    except (asyncio.TimeoutError, WebSocketDisconnect):
         pass
 
     # ---- Build and send initial state ----
@@ -199,13 +205,18 @@ async def session_ws(websocket: WebSocket, run_id: str) -> None:
         await websocket.send_json({"type": "chat_history", "messages": chat_messages})
 
     known_pending_ids: set[str] = set()
-    pending_map = _scan_pending_ask_users(session_dir)
-    for req_id, ask_data in pending_map.items():
-        known_pending_ids.add(req_id)
-        await websocket.send_json({"type": "ask_user", **ask_data})
+    is_terminal = status in ("completed", "failed", "stopped") or state.is_terminal
+
+    # Only send pending ask_users for active sessions — terminal ones will
+    # never process responses.
+    if not is_terminal:
+        pending_map = _scan_pending_ask_users(session_dir)
+        for req_id, ask_data in pending_map.items():
+            known_pending_ids.add(req_id)
+            await websocket.send_json({"type": "ask_user", **ask_data})
 
     # Terminal sessions: handle pending subscribe_logs, send final state, close
-    if status in ("completed", "failed", "stopped") or state.is_terminal:
+    if is_terminal:
         async def _send_log_snapshot(agent_id: str) -> None:
             if validate_agent(session_dir, agent_id):
                 lines, offset = read_log_tail(
@@ -231,7 +242,7 @@ async def session_ws(websocket: WebSocket, run_id: str) -> None:
         # Drain additional subscribe_logs from the client
         try:
             while True:
-                raw = await asyncio.wait_for(websocket.receive_text(), timeout=0.5)
+                raw = await asyncio.wait_for(websocket.receive_text(), timeout=2.0)
                 try:
                     msg = json.loads(raw)
                 except json.JSONDecodeError:

--- a/gui/tests/test_session_ws.py
+++ b/gui/tests/test_session_ws.py
@@ -145,8 +145,8 @@ class TestSessionWSTerminalSession:
 
 
 class TestSessionWSAskUser:
-    def test_pending_ask_user_sent_on_connect(self, client, tmp_path):
-        """ask_user messages are sent for pre-existing pending files."""
+    def test_pending_ask_user_not_sent_for_terminal_session(self, client, tmp_path):
+        """Terminal sessions do not send stale ask_user messages."""
         _register_project(client, tmp_path)
         session_dir = _write_session(tmp_path, "run_ws6", archived=True)
         pending_path = os.path.join(session_dir, "ask_user_pending_req1.json")
@@ -163,9 +163,7 @@ class TestSessionWSAskUser:
             messages = _collect_until(ws, "stream_complete")
 
         ask = next((m for m in messages if m.get("type") == "ask_user"), None)
-        assert ask is not None
-        assert ask["request_id"] == "req1"
-        assert ask["question"] == "Choose a color?"
+        assert ask is None, "Terminal sessions should not send stale ask_user messages"
 
     def test_ask_user_response_writes_file(self, tmp_path):
         """_write_ask_user_response writes the correct response file.


### PR DESCRIPTION
## Summary

- **Session logs broken ("No log output")**: WS early message reader only captured one message, missing `subscribe_logs` sent right after `init`. Also increased drain timeout from 0.5s to 2.0s for terminal sessions.
- **Logs appearing then disappearing**: `AgentLogViewer` was unsubscribing (and deleting log data) on WS disconnect instead of only when switching agents.
- **Imu session detail logs broken**: `SessionDetail` only connected WS for `active || isInteractive` sessions — all completed Imu sessions are non-interactive in DB, so they never got a WS connection.
- **Stopped sessions showing stale "waiting for response"**: Terminal sessions now skip sending pending `ask_user` messages, and `stream_complete` clears `pendingAskUsers`.
- **Imu sessions always `interactive=0`**: The sync upsert was overwriting `interactive` based on `chat_messages.jsonl` file presence. Now uses `MAX()` so it never downgrades from 1 to 0.

## Test plan

- [ ] Run `pytest gui/tests/ -v` — existing + updated tests pass
- [ ] Open a completed Imu session → logs should display correctly
- [ ] Open a stopped session → no stale "waiting for response" prompt
- [ ] Start a new interactive Imu session → verify `interactive=1` persists in DB after sync
- [ ] Switch between agents in log viewer → logs should not disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)