### PR TITLE
Add frontend types and hooks for one-time schedules

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -241,7 +241,9 @@ export interface Schedule {
   project_name: string;
   role: string | null;
   task: string;
-  cron_expr: string;
+  cron_expr: string | null;
+  schedule_type: "recurring" | "one_time";
+  run_at: string | null;
   enabled: boolean;
   system_prompt: string | null;
   skip_if_running: boolean;
@@ -249,4 +251,20 @@ export interface Schedule {
   next_run_at: string | null;
   last_error: string | null;
   created_at: string;
+}
+
+export interface ScheduleRun {
+  run_id: string;
+  schedule_id: number;
+  schedule_name: string;
+  schedule_type: "recurring" | "one_time";
+  project_id: number;
+  project_name: string;
+  role: string;
+  status: string;
+  started_at: string;
+  ended_at: string | null;
+  duration_ms: number | null;
+  exit_code: number | null;
+  task: string | null;
 }

--- a/gui/frontend/src/components/CreateScheduleDialog.tsx
+++ b/gui/frontend/src/components/CreateScheduleDialog.tsx
@@ -82,7 +82,7 @@ export default function CreateScheduleDialog({
       setName(editing.name);
       setProjectId(String(editing.project_id));
       setTask(editing.task);
-      setCronExpr(editing.cron_expr);
+      setCronExpr(editing.cron_expr ?? "");
       setRole(editing.role ?? "");
       setSystemPrompt(editing.system_prompt ?? "");
       setSkipIfRunning(editing.skip_if_running);

--- a/gui/frontend/src/hooks/mutations/use-schedules.ts
+++ b/gui/frontend/src/hooks/mutations/use-schedules.ts
@@ -13,10 +13,20 @@ interface CreateScheduleBody {
   skip_if_running?: boolean;
 }
 
+interface CreateOneTimeScheduleBody {
+  name: string;
+  project_id: number;
+  task: string;
+  run_at: string;
+  role?: string;
+  system_prompt?: string;
+}
+
 interface UpdateScheduleBody {
   name?: string;
   task?: string;
   cron_expr?: string;
+  run_at?: string;
   role?: string;
   system_prompt?: string;
   skip_if_running?: boolean;
@@ -27,6 +37,17 @@ export function useCreateSchedule() {
   return useMutation({
     mutationFn: (body: CreateScheduleBody) =>
       api.post<Schedule>("/schedules", body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.schedules.all });
+    },
+  });
+}
+
+export function useCreateOneTimeSchedule() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateOneTimeScheduleBody) =>
+      api.post<Schedule>("/schedules/one-time", body),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.schedules.all });
     },

--- a/gui/frontend/src/hooks/queries/use-schedules.ts
+++ b/gui/frontend/src/hooks/queries/use-schedules.ts
@@ -1,12 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { queryKeys } from "@/lib/query-keys";
-import type { Schedule, Session } from "@/api/types";
+import type { Schedule, ScheduleRun, Session } from "@/api/types";
 
-export function useSchedules() {
+export function useSchedules(type?: "recurring" | "one_time") {
   return useQuery({
-    queryKey: queryKeys.schedules.all,
-    queryFn: () => api.get<Schedule[]>("/schedules"),
+    queryKey: type
+      ? [...queryKeys.schedules.all, type]
+      : queryKeys.schedules.all,
+    queryFn: () =>
+      api.get<Schedule[]>(
+        type ? `/schedules?type=${type}` : "/schedules",
+      ),
   });
 }
 
@@ -23,5 +28,12 @@ export function useScheduleHistory(id: number) {
     queryKey: queryKeys.schedules.history(id),
     queryFn: () => api.get<Session[]>(`/schedules/${id}/history`),
     enabled: id > 0,
+  });
+}
+
+export function useScheduleRuns() {
+  return useQuery({
+    queryKey: queryKeys.schedules.runs,
+    queryFn: () => api.get<ScheduleRun[]>("/schedules/runs"),
   });
 }

--- a/gui/frontend/src/lib/query-keys.ts
+++ b/gui/frontend/src/lib/query-keys.ts
@@ -36,6 +36,7 @@ export const queryKeys = {
     all: ["schedules"] as const,
     detail: (id: number) => ["schedules", id] as const,
     history: (id: number) => ["schedules", id, "history"] as const,
+    runs: ["schedules", "runs"] as const,
   },
   conversations: {
     all: (projectId: number) => ["conversations", projectId] as const,


### PR DESCRIPTION
## Summary
- **types.ts**: `Schedule.cron_expr` nullable, added `schedule_type` and `run_at` fields, new `ScheduleRun` interface
- **use-schedules.ts (queries)**: `useSchedules(type?)` optional type filter, new `useScheduleRuns()` hook
- **use-schedules.ts (mutations)**: new `useCreateOneTimeSchedule()` mutation, `run_at` in `UpdateScheduleBody`
- **query-keys.ts**: added `runs` key
- **CreateScheduleDialog.tsx**: null-safe fix for nullable `cron_expr`

Implements DESIGN.md items #23-25. Frontend compiles cleanly with `tsc --noEmit`.

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [ ] Existing schedule page still works (hooks are backward-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)