### PR TITLE
Fix inaccurate file limits in StrawHub docs

### DIFF
--- a/docs/strawhub/api/reference.mdx
+++ b/docs/strawhub/api/reference.mdx
@@ -56,7 +56,9 @@ GET /api/v1/skills?limit=50&sort=updated
       "updatedAt": 1700000000000
     }
   ],
-  "count": 1
+  "totalCount": 1,
+  "continueCursor": "...",
+  "isDone": true
 }
 ```
 
@@ -93,7 +95,7 @@ Content-Type: multipart/form-data
 | `changelog` | Version changelog |
 | `dependencies` | Optional JSON: `{"skills": ["dep-a", "dep-b==1.0.0"]}` |
 | `customTags` | Optional tags |
-| `files[]` | File uploads (must include `SKILL.md`, max 20 files, 512 KB each, any file type) |
+| `files[]` | File uploads (must include `SKILL.md`, max 100 files, 10 MB each, 50 MB total) |
 
 ### Delete Skill
 
@@ -204,7 +206,7 @@ POST /api/v1/memories
 Content-Type: multipart/form-data
 ```
 
-Same payload as Publish Skill. Must include a `MEMORY.md` file. Max 50 files, 10 MB each.
+Same payload as Publish Skill. Must include a `MEMORY.md` file. Max 100 files, 10 MB each, 50 MB total.
 
 ### Delete Memory
 

--- a/docs/strawhub/concepts/memories.mdx
+++ b/docs/strawhub/concepts/memories.mdx
@@ -17,7 +17,7 @@ A memory directory can contain additional files alongside `MEMORY.md`:
 
 - Data files, indexes, binary assets
 - Any file type is allowed (including binaries)
-- Max 50 files, 10 MB each, 50 MB total
+- Max 100 files, 10 MB each, 50 MB total
 
 ## Skills vs Roles vs Agents vs Memories
 

--- a/docs/strawhub/concepts/skills.mdx
+++ b/docs/strawhub/concepts/skills.mdx
@@ -113,7 +113,7 @@ A skill directory can contain additional files alongside `SKILL.md`:
 
 - Scripts, references, examples
 - Any file type is allowed
-- Max 20 files, 512 KB each
+- Max 100 files, 10 MB each, 50 MB total
 
 ## How Agents Use Skills
 

--- a/docs/strawhub/publishing/guide.mdx
+++ b/docs/strawhub/publishing/guide.mdx
@@ -134,8 +134,8 @@ description: "A brief description"
 | Constraint | Limit |
 |------------|-------|
 | Required file | `SKILL.md` (skills), `ROLE.md` (roles), or `MEMORY.md` (memories) |
-| Max files per package | 20 (skills/roles), 50 (memories) |
-| Max file size | 512 KB (skills/roles), 10 MB (memories) |
+| Max files per package | 100 |
+| Max file size | 10 MB |
 | Max total size | 50 MB |
 
 ## Dependency Validation


### PR DESCRIPTION
## Summary
- Fix outdated skill upload limits (20 files/512 KB → 100 files/10 MB each/50 MB total)
- Fix memory file count (50 → 100) to match `publishValidation.ts`
- Fix list API response format (`count` → `totalCount` + `continueCursor` + `isDone`)
- Unify publishing guide limits table across all content types

## Test plan
- [ ] Verify limits match `convex/lib/publishValidation.ts` in strawhub repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)