### PR TITLE
Fix conversation output showing only recap

### DIFF
--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -297,27 +297,52 @@ def get_db_conn(request: Request):
 # ---------------------------------------------------------------------------
 
 
+_CANONICAL_RECAP_MARKER = "## Session Recap"
+_RECAP_MARKERS = (_CANONICAL_RECAP_MARKER, "**Session Recap**")
+
+
+def _normalize_recap_marker(content: str) -> str:
+    """Replace non-canonical recap markers with the heading format."""
+    for m in _RECAP_MARKERS:
+        if m != _CANONICAL_RECAP_MARKER and m in content:
+            content = content.replace(m, _CANONICAL_RECAP_MARKER)
+    return content
+
+
+def _find_recap(content: str) -> tuple[int, int]:
+    """Find the last occurrence of any recap marker.
+
+    Returns (start_index, marker_length) or (-1, 0) if not found.
+    """
+    best = -1
+    best_len = 0
+    for m in _RECAP_MARKERS:
+        idx = content.rfind(m)
+        if idx > best:
+            best = idx
+            best_len = len(m)
+    return best, best_len
+
+
 def _extract_recap(content: str) -> str:
-    """Extract a '## Session Recap' block from agent output.
+    """Extract a Session Recap block from agent output.
 
     If present, returns the recap section (without the heading).
     Otherwise returns the full content unchanged.
     """
-    marker = "## Session Recap"
-    idx = content.rfind(marker)
+    idx, mlen = _find_recap(content)
     if idx == -1:
         return content
-    recap = content[idx + len(marker) :].strip()
+    recap = content[idx + mlen :].strip()
     return recap if recap else content
 
 
 def _strip_recap(content: str) -> str:
-    """Return agent output with the '## Session Recap' block removed.
+    """Return agent output with the Session Recap block removed.
 
     If no recap is found, returns the full content unchanged.
     """
-    marker = "## Session Recap"
-    idx = content.rfind(marker)
+    idx, _ = _find_recap(content)
     if idx == -1:
         return content
     before = content[:idx].rstrip()
@@ -348,15 +373,15 @@ def _parse_trace(trace_path: str, session_dir: str | None = None) -> dict:
                     if "duration_ms" in data:
                         result["duration_ms"] = data["duration_ms"]
                     result["exit_code"] = data.get("exit_code", 0)
-                    # session_end carries the final output ref
+                    # session_end carries the final output — always prefer it
                     output_ref = data.get("output_ref")
-                    if output_ref and session_dir and "summary" not in result:
+                    if output_ref and session_dir:
                         artifact_path = os.path.join(session_dir, "artifacts", output_ref)
                         try:
                             with open(artifact_path, encoding="utf-8") as af:
                                 content = af.read().strip()
                             if content:
-                                result["summary"] = content
+                                result["summary"] = _normalize_recap_marker(content)
                         except OSError:
                             pass
                     files_changed = data.get("files_changed")
@@ -371,7 +396,7 @@ def _parse_trace(trace_path: str, session_dir: str | None = None) -> dict:
                             with open(artifact_path, encoding="utf-8") as af:
                                 content = af.read().strip()
                             if content:
-                                result["summary"] = content
+                                result["summary"] = _normalize_recap_marker(content)
                         except OSError:
                             pass
     except OSError:

--- a/gui/tests/test_conversations.py
+++ b/gui/tests/test_conversations.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from test_sessions_sync import _register_project
 
-from strawpot_gui.db import _extract_recap, _strip_recap, get_db
+from strawpot_gui.db import _extract_recap, _normalize_recap_marker, _strip_recap, get_db
 from strawpot_gui.routers.conversations import _build_conversation_context
 
 
@@ -718,6 +718,16 @@ class TestExtractRecap:
         content = "some output\n\n## Session Recap\n"
         assert _extract_recap(content) == content
 
+    def test_bold_marker(self):
+        content = (
+            "Here is the output.\n\n"
+            "**Session Recap**\n\n"
+            "### Accomplished\n- Did things"
+        )
+        result = _extract_recap(content)
+        assert result.startswith("### Accomplished")
+        assert "Here is the output" not in result
+
 
 class TestStripRecap:
     def test_strips_recap_block(self):
@@ -748,6 +758,33 @@ class TestStripRecap:
         content = "## Session Recap\n- Implemented the login page"
         result = _strip_recap(content)
         assert result == content
+
+    def test_bold_marker(self):
+        content = (
+            "Here is the output.\n\n"
+            "**Session Recap**\n\n"
+            "### Accomplished\n- Did things"
+        )
+        result = _strip_recap(content)
+        assert result == "Here is the output."
+        assert "Session Recap" not in result
+
+
+class TestNormalizeRecapMarker:
+    def test_replaces_bold_with_heading(self):
+        content = "Output\n\n**Session Recap**\n\n- Did things"
+        result = _normalize_recap_marker(content)
+        assert "**Session Recap**" not in result
+        assert "## Session Recap" in result
+
+    def test_leaves_heading_unchanged(self):
+        content = "Output\n\n## Session Recap\n\n- Did things"
+        result = _normalize_recap_marker(content)
+        assert result == content
+
+    def test_no_recap(self):
+        content = "Just output, no recap."
+        assert _normalize_recap_marker(content) == content
 
 
 class TestHistoryFileHint:


### PR DESCRIPTION
## Summary
- **session_end priority**: `_parse_trace()` now always prefers `session_end` output over `delegate_end` fallback, fixing cases where orchestrator output was lost in favor of sub-agent recap
- **Multi-marker support**: `_strip_recap()` and `_extract_recap()` now handle both `## Session Recap` (canonical) and `**Session Recap**` (bold variant agents sometimes produce)
- **Marker normalization**: Non-canonical recap markers are normalized to heading format at storage time via `_normalize_recap_marker()`, preventing bold markers from polluting memory and conversation context

## Test plan
- [x] All 72 conversation tests pass including 5 new tests
- [x] `TestNormalizeRecapMarker` — bold→heading replacement, heading unchanged, no-recap passthrough
- [x] `TestExtractRecap.test_bold_marker` — extracts recap body from bold format
- [x] `TestStripRecap.test_bold_marker` — strips bold recap from conversation view

🤖 Generated with [Claude Code](https://claude.com/claude-code)