### PR TITLE
Add integration CRUD API and manifest parser

### DIFF
--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -18,7 +18,7 @@ from strawpot_gui.event_bus import event_bus
 from strawpot_gui.scheduler import Scheduler
 
 logger = logging.getLogger(__name__)
-from strawpot_gui.routers import config, conversations, files, fs, health, imu, logs, project_resources, projects, registry, schedules, sessions, sse, stats, ws
+from strawpot_gui.routers import config, conversations, files, fs, health, imu, integrations, logs, project_resources, projects, registry, schedules, sessions, sse, stats, ws
 
 
 def _ensure_imu_role() -> None:
@@ -126,6 +126,7 @@ def create_app(db_path: str | None = None) -> FastAPI:
     app.include_router(logs.router)
     app.include_router(fs.router)
     app.include_router(registry.router)
+    app.include_router(integrations.router)
     app.include_router(project_resources.router)
     app.include_router(schedules.router)
     app.include_router(stats.router)

--- a/gui/src/strawpot_gui/routers/integrations.py
+++ b/gui/src/strawpot_gui/routers/integrations.py
@@ -1,0 +1,206 @@
+"""Integration management endpoints — list, detail, config CRUD."""
+
+from pathlib import Path
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+
+from strawpot.config import get_strawpot_home
+from strawpot.context import parse_frontmatter
+
+from strawpot_gui.db import get_db_conn
+
+router = APIRouter(prefix="/api/integrations", tags=["integrations"])
+
+MANIFEST = "INTEGRATION.md"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_integration_manifest(manifest_path: Path) -> tuple[dict, str]:
+    """Parse an INTEGRATION.md file and return (frontmatter, body)."""
+    text = manifest_path.read_text(encoding="utf-8")
+    parsed = parse_frontmatter(text)
+    return parsed.get("frontmatter", {}), parsed.get("body", "")
+
+
+def scan_integrations(base_dir: Path) -> list[dict]:
+    """Scan ``base_dir/integrations/*/INTEGRATION.md`` for installed integrations."""
+    scan_path = base_dir / "integrations"
+    if not scan_path.is_dir():
+        return []
+    items: list[dict] = []
+    for entry in sorted(scan_path.iterdir()):
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        manifest_path = entry / MANIFEST
+        if not manifest_path.is_file():
+            continue
+        try:
+            fm, _body = parse_integration_manifest(manifest_path)
+        except Exception:
+            fm = {}
+        strawpot_meta = fm.get("metadata", {}).get("strawpot", {})
+        items.append({
+            "name": fm.get("name", entry.name),
+            "description": fm.get("description", ""),
+            "entry_point": strawpot_meta.get("entry_point", ""),
+            "auto_start": strawpot_meta.get("auto_start", False),
+            "config_schema": strawpot_meta.get("config", {}),
+            "health_check": strawpot_meta.get("health_check"),
+            "path": str(entry),
+        })
+    return items
+
+
+def _get_db_state(conn, name: str) -> dict | None:
+    """Read runtime state from the integrations DB table."""
+    row = conn.execute(
+        "SELECT status, pid, auto_start, last_error, started_at, created_at "
+        "FROM integrations WHERE name = ?",
+        (name,),
+    ).fetchone()
+    if row is None:
+        return None
+    return dict(row)
+
+
+def _get_db_config(conn, name: str) -> dict[str, str]:
+    """Read saved config values from integration_config table."""
+    rows = conn.execute(
+        "SELECT key, value FROM integration_config WHERE integration_name = ?",
+        (name,),
+    ).fetchall()
+    return {r["key"]: r["value"] for r in rows}
+
+
+def _ensure_db_row(conn, name: str) -> None:
+    """Insert a row into integrations if it doesn't exist yet."""
+    conn.execute(
+        "INSERT OR IGNORE INTO integrations (name) VALUES (?)",
+        (name,),
+    )
+
+
+def _merge_integration(manifest: dict, db_state: dict | None, db_config: dict) -> dict:
+    """Merge filesystem manifest with DB runtime state."""
+    result = {**manifest}
+    if db_state:
+        result["status"] = db_state["status"]
+        result["pid"] = db_state["pid"]
+        result["last_error"] = db_state["last_error"]
+        result["started_at"] = db_state["started_at"]
+    else:
+        result["status"] = "stopped"
+        result["pid"] = None
+        result["last_error"] = None
+        result["started_at"] = None
+    result["config_values"] = db_config
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("")
+def list_integrations(conn=Depends(get_db_conn)):
+    """List all installed integrations with their runtime state."""
+    home = get_strawpot_home()
+    manifests = scan_integrations(home)
+    results = []
+    for manifest in manifests:
+        name = manifest["name"]
+        db_state = _get_db_state(conn, name)
+        db_config = _get_db_config(conn, name)
+        results.append(_merge_integration(manifest, db_state, db_config))
+    return results
+
+
+@router.get("/{name}")
+def get_integration(name: str, conn=Depends(get_db_conn)):
+    """Get detail for a single integration."""
+    home = get_strawpot_home()
+    integration_dir = home / "integrations" / name
+    manifest_path = integration_dir / MANIFEST
+    if not manifest_path.is_file():
+        raise HTTPException(404, f"Integration not found: {name}")
+
+    fm, body = parse_integration_manifest(manifest_path)
+    strawpot_meta = fm.get("metadata", {}).get("strawpot", {})
+    manifest = {
+        "name": fm.get("name", name),
+        "description": fm.get("description", ""),
+        "entry_point": strawpot_meta.get("entry_point", ""),
+        "auto_start": strawpot_meta.get("auto_start", False),
+        "config_schema": strawpot_meta.get("config", {}),
+        "health_check": strawpot_meta.get("health_check"),
+        "path": str(integration_dir),
+        "body": body,
+        "frontmatter": fm,
+    }
+
+    db_state = _get_db_state(conn, name)
+    db_config = _get_db_config(conn, name)
+    return _merge_integration(manifest, db_state, db_config)
+
+
+@router.get("/{name}/config")
+def get_integration_config(name: str, conn=Depends(get_db_conn)):
+    """Get config schema and saved values for an integration."""
+    home = get_strawpot_home()
+    manifest_path = home / "integrations" / name / MANIFEST
+    if not manifest_path.is_file():
+        raise HTTPException(404, f"Integration not found: {name}")
+
+    fm, _ = parse_integration_manifest(manifest_path)
+    config_schema = fm.get("metadata", {}).get("strawpot", {}).get("config", {})
+    config_values = _get_db_config(conn, name)
+
+    return {
+        "config_schema": config_schema,
+        "config_values": config_values,
+    }
+
+
+@router.put("/{name}/config")
+def put_integration_config(
+    name: str, data: dict = Body(...), conn=Depends(get_db_conn)
+):
+    """Save config values for an integration."""
+    home = get_strawpot_home()
+    manifest_path = home / "integrations" / name / MANIFEST
+    if not manifest_path.is_file():
+        raise HTTPException(404, f"Integration not found: {name}")
+
+    config_values = data.get("config_values", {})
+    if not isinstance(config_values, dict):
+        raise HTTPException(400, "config_values must be a dict")
+
+    _ensure_db_row(conn, name)
+
+    # Delete existing config and re-insert
+    conn.execute(
+        "DELETE FROM integration_config WHERE integration_name = ?", (name,)
+    )
+    for key, value in config_values.items():
+        conn.execute(
+            "INSERT INTO integration_config (integration_name, key, value) "
+            "VALUES (?, ?, ?)",
+            (name, key, str(value) if value is not None else None),
+        )
+
+    return {"ok": True}
+
+
+@router.delete("/{name}/config")
+def delete_integration_config(name: str, conn=Depends(get_db_conn)):
+    """Clear all saved config for an integration."""
+    conn.execute(
+        "DELETE FROM integration_config WHERE integration_name = ?", (name,)
+    )
+    conn.execute("DELETE FROM integrations WHERE name = ?", (name,))
+    return {"ok": True}

--- a/gui/tests/test_integrations_api.py
+++ b/gui/tests/test_integrations_api.py
@@ -1,0 +1,154 @@
+"""Tests for integration management API endpoints."""
+
+import pytest
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """Patch get_strawpot_home to use a temp directory."""
+    monkeypatch.setattr(
+        "strawpot_gui.routers.integrations.get_strawpot_home", lambda: tmp_path
+    )
+    return tmp_path
+
+
+def _create_integration(home, name, extra_meta=""):
+    """Create a minimal INTEGRATION.md manifest."""
+    integration_dir = home / "integrations" / name
+    integration_dir.mkdir(parents=True)
+    content = (
+        f"---\nname: {name}\ndescription: A test {name} adapter\n"
+        f"metadata:\n  strawpot:\n    entry_point: python adapter.py\n"
+        f"    auto_start: false\n"
+        f"    config:\n"
+        f"      bot_token:\n"
+        f"        type: secret\n"
+        f"        required: true\n"
+        f"        description: Bot API token\n"
+        f"{extra_meta}"
+        f"---\n# {name.title()} Adapter\n\nBody text."
+    )
+    (integration_dir / "INTEGRATION.md").write_text(content)
+    return integration_dir
+
+
+class TestListIntegrations:
+    def test_list_empty(self, client, home):
+        resp = client.get("/api/integrations")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_one(self, client, home):
+        _create_integration(home, "telegram")
+        resp = client.get("/api/integrations")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        item = data[0]
+        assert item["name"] == "telegram"
+        assert item["description"] == "A test telegram adapter"
+        assert item["entry_point"] == "python adapter.py"
+        assert item["status"] == "stopped"
+        assert item["pid"] is None
+
+    def test_list_multiple(self, client, home):
+        _create_integration(home, "telegram")
+        _create_integration(home, "slack")
+        resp = client.get("/api/integrations")
+        names = [i["name"] for i in resp.json()]
+        assert "slack" in names
+        assert "telegram" in names
+
+    def test_excludes_hidden_dirs(self, client, home):
+        _create_integration(home, "telegram")
+        hidden = home / "integrations" / ".hidden"
+        hidden.mkdir(parents=True)
+        (hidden / "INTEGRATION.md").write_text("---\nname: hidden\n---\n")
+        resp = client.get("/api/integrations")
+        names = [i["name"] for i in resp.json()]
+        assert "telegram" in names
+        assert "hidden" not in names
+
+
+class TestGetIntegration:
+    def test_get_detail(self, client, home):
+        _create_integration(home, "telegram")
+        resp = client.get("/api/integrations/telegram")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "telegram"
+        assert data["body"].strip().startswith("# Telegram Adapter")
+        assert "frontmatter" in data
+        assert data["status"] == "stopped"
+
+    def test_get_not_found(self, client, home):
+        resp = client.get("/api/integrations/nonexistent")
+        assert resp.status_code == 404
+
+
+class TestIntegrationConfig:
+    def test_get_config_schema(self, client, home):
+        _create_integration(home, "telegram")
+        resp = client.get("/api/integrations/telegram/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "bot_token" in data["config_schema"]
+        assert data["config_schema"]["bot_token"]["type"] == "secret"
+        assert data["config_values"] == {}
+
+    def test_put_config(self, client, home):
+        _create_integration(home, "telegram")
+        resp = client.put(
+            "/api/integrations/telegram/config",
+            json={"config_values": {"bot_token": "123:ABC"}},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+        # Verify saved
+        resp = client.get("/api/integrations/telegram/config")
+        assert resp.json()["config_values"]["bot_token"] == "123:ABC"
+
+    def test_put_config_updates_existing(self, client, home):
+        _create_integration(home, "telegram")
+        client.put(
+            "/api/integrations/telegram/config",
+            json={"config_values": {"bot_token": "old"}},
+        )
+        client.put(
+            "/api/integrations/telegram/config",
+            json={"config_values": {"bot_token": "new"}},
+        )
+        resp = client.get("/api/integrations/telegram/config")
+        assert resp.json()["config_values"]["bot_token"] == "new"
+
+    def test_put_config_not_found(self, client, home):
+        resp = client.put(
+            "/api/integrations/nonexistent/config",
+            json={"config_values": {"key": "val"}},
+        )
+        assert resp.status_code == 404
+
+    def test_delete_config(self, client, home):
+        _create_integration(home, "telegram")
+        client.put(
+            "/api/integrations/telegram/config",
+            json={"config_values": {"bot_token": "123:ABC"}},
+        )
+        resp = client.delete("/api/integrations/telegram/config")
+        assert resp.status_code == 200
+
+        # Config should be cleared
+        resp = client.get("/api/integrations/telegram/config")
+        assert resp.json()["config_values"] == {}
+
+    def test_config_visible_in_list(self, client, home):
+        """Saved config values appear when listing integrations."""
+        _create_integration(home, "telegram")
+        client.put(
+            "/api/integrations/telegram/config",
+            json={"config_values": {"bot_token": "123:ABC"}},
+        )
+        resp = client.get("/api/integrations")
+        item = resp.json()[0]
+        assert item["config_values"]["bot_token"] == "123:ABC"


### PR DESCRIPTION
## Summary
- Add integrations router with CRUD endpoints for managing chat integrations (GET list/detail, GET/PUT/DELETE config)
- Scan `~/.strawpot/integrations/*/INTEGRATION.md` manifests and merge with DB runtime state
- Integrations are global-only — no project binding, entry point is always imu
- 12 tests covering list, detail, config CRUD, not-found, and edge cases

## Test plan
- [x] All 12 new tests in `test_integrations_api.py` pass
- [x] All 376 existing tests still pass
- [ ] Manual: place a test INTEGRATION.md in `~/.strawpot/integrations/test/` and verify endpoints return expected data

🤖 Generated with [Claude Code](https://claude.com/claude-code)