### PR TITLE
Remove global_skills / inherit_global_skills support

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -597,19 +597,13 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task, head
         from strawpot.delegation import (
             _collect_saved_env,
             _get_default_agent,
-            _parse_role_deps,
             collect_skill_env,
-            discover_global_skills,
             validate_skill_env,
         )
 
         resolved = _resolve(config.orchestrator_role, kind="role")
-        first_order_skills, _, _, _ = _parse_role_deps(resolved["path"])
-        global_skills = discover_global_skills(
-            resolved["path"], exclude_slugs=set(first_order_skills),
-        )
-        skill_env = collect_skill_env(resolved, global_skills=global_skills or None)
-        saved_env = _collect_saved_env(config, resolved, global_skills=global_skills or None)
+        skill_env = collect_skill_env(resolved)
+        saved_env = _collect_saved_env(config, resolved)
         skill_validation = validate_skill_env(skill_env, saved_env=saved_env)
 
         if skill_validation.missing_env:

--- a/cli/src/strawpot/context.py
+++ b/cli/src/strawpot/context.py
@@ -65,11 +65,9 @@ def build_prompt(
         role_slug: The role's slug identifier.
         role_path: Path to the role's package directory (contains ROLE.md).
         skills: optional list of (slug, description) tuples for all
-            skills available to this agent (first-order dependencies,
-            global skills, and built-ins combined).  Listed by description
-            only — the agent reads ``skills/<slug>/SKILL.md`` for details.
-            Callers are responsible for filtering to first-order deps and
-            excluding duplicates between dependency and global skills.
+            skills available to this agent (first-order dependencies
+            and built-ins combined).  Listed by description only — the
+            agent reads ``skills/<slug>/SKILL.md`` for details.
         delegatable_roles: optional list of (slug, description) tuples.
             When provided, a Delegation section is appended listing
             roles the agent can delegate to via denden.

--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -185,26 +185,6 @@ def _parse_skill_env(skill_path: str) -> dict[str, dict]:
     return env
 
 
-# ---------------------------------------------------------------------------
-# Global skill discovery
-# ---------------------------------------------------------------------------
-
-
-def _check_inherit_global_skills(role_path: str) -> bool:
-    """Check if a role inherits global skills.
-
-    Reads ``metadata.strawpot.inherit_global_skills`` from ROLE.md frontmatter.
-    Defaults to ``False`` if the field is not present.
-    """
-    role_md = Path(role_path) / "ROLE.md"
-    if not role_md.exists():
-        return False
-    text = role_md.read_text(encoding="utf-8")
-    parsed = parse_frontmatter(text)
-    fm = parsed.get("frontmatter", {})
-    return _strawpot_meta(fm).get("inherit_global_skills", False)
-
-
 def _get_default_agent(role_path: str) -> str | None:
     """Extract ``default_agent`` from ROLE.md frontmatter.
 
@@ -220,72 +200,20 @@ def _get_default_agent(role_path: str) -> str | None:
     return _strawpot_meta(fm).get("default_agent")
 
 
-def discover_global_skills(
-    role_path: str,
-    exclude_slugs: set[str] | None = None,
-) -> list[tuple[str, str, str]]:
-    """Discover globally installed skills not already in the exclude set.
-
-    Scans ``~/.strawpot/skills/`` for installed skill directories.
-    Skips skills whose slug appears in *exclude_slugs* (typically the
-    role's first-order skill dependencies).
-    Respects the ``inherit_global_skills`` flag in ROLE.md.
-
-    Args:
-        role_path: Path to the role's package directory (contains ROLE.md).
-        exclude_slugs: Slugs to skip (e.g. first-order skill deps).
-
-    Returns:
-        List of (slug, description, path) tuples for global skills.
-        Empty list if the role opts out or no global skills are found.
-    """
-    if not _check_inherit_global_skills(role_path):
-        return []
-
-    skills_dir = get_strawpot_home() / "skills"
-    if not skills_dir.is_dir():
-        return []
-
-    from strawhub.version_spec import parse_dir_name
-
-    skip = exclude_slugs or set()
-
-    global_skills: list[tuple[str, str, str]] = []
-    for entry in sorted(skills_dir.iterdir()):
-        if not entry.is_dir():
-            continue
-        skill_md = entry / "SKILL.md"
-        if not skill_md.is_file():
-            continue
-        parsed = parse_dir_name(entry.name)
-        slug = parsed[0] if parsed else entry.name
-        if slug in skip:
-            continue
-        validate_frontmatter_slug(str(entry), slug, "skill")
-        desc = read_skill_description(str(entry))
-        global_skills.append((slug, desc, str(entry)))
-
-    return global_skills
-
 
 def build_skill_descriptions(
     resolved: dict,
-    global_skills: list[tuple[str, str, str]] | None = None,
     working_dir: str | None = None,
 ) -> list[tuple[str, str]]:
     """Build the combined (slug, description) list for ``build_prompt``.
 
     Extracts first-order skill dependencies from the role's frontmatter,
-    looks up their paths in the resolved dependency tree to read descriptions,
-    then appends global skills. If the role declares ``skills: ["*"]``,
-    all available skills (project-local + global) are included.
+    looks up their paths in the resolved dependency tree to read descriptions.
+    If the role declares ``skills: ["*"]``, all available skills
+    (project-local + global) are included.
 
     Args:
         resolved: Resolved role dict from strawhub.resolver.resolve().
-        global_skills: Optional list of (slug, description, path) tuples
-            from :func:`discover_global_skills`.  Expected to already
-            exclude first-order skill dependencies (handled by passing
-            ``exclude_slugs`` to :func:`discover_global_skills`).
         working_dir: Working directory for discovering project-local skills
             when wildcard is used.
 
@@ -322,10 +250,6 @@ def build_skill_descriptions(
             continue
         desc = read_skill_description(skill_path)
         if desc:
-            skills.append((slug, desc))
-
-    if global_skills:
-        for slug, desc, _path in global_skills:
             skills.append((slug, desc))
 
     # Always include built-in skills
@@ -442,7 +366,6 @@ def _merge_env_entry(target: dict[str, dict], var: str, meta: dict) -> None:
 
 def collect_skill_env(
     resolved: dict,
-    global_skills: list[tuple[str, str, str]] | None = None,
 ) -> dict[str, dict]:
     """Collect env requirements from all skills in a role's dependency tree.
 
@@ -450,13 +373,11 @@ def collect_skill_env(
 
     1. The role's own transitive skill dependencies (skill → skill chain).
     2. Each delegatable role's transitive skill dependencies (recursive).
-    3. Global skills (if ``inherit_global_skills`` is true).
 
     If the same var appears in multiple skills, ``required: True`` wins.
 
     Args:
         resolved: Resolved role dict from ``strawhub.resolver.resolve()``.
-        global_skills: Optional list of ``(slug, description, path)`` tuples.
 
     Returns:
         Merged dict mapping var name to metadata.
@@ -492,12 +413,6 @@ def collect_skill_env(
 
     # Start from the resolved role itself
     _collect_from_role(resolved["path"], resolved["slug"])
-
-    if global_skills:
-        for _slug, _desc, gpath in global_skills:
-            for var, meta in _parse_skill_env(gpath).items():
-                _merge_env_entry(merged, var, meta)
-                merged[var].setdefault("_source_skill", _slug)
 
     return merged
 
@@ -542,20 +457,16 @@ def validate_skill_env(
 def _collect_saved_env(
     config: StrawPotConfig,
     resolved: dict,
-    global_skills: list[tuple[str, str, str]] | None = None,
 ) -> dict[str, str]:
     """Collect saved env values from config for all skills in a role's tree.
 
-    Walks the dependency list and global skills, returning a flat dict of
-    saved env key-value pairs from ``config.skills``.
+    Walks the dependency list, returning a flat dict of saved env key-value
+    pairs from ``config.skills``.
     """
     saved: dict[str, str] = {}
     for dep in resolved.get("dependencies", []):
         if dep["kind"] == "skill":
             saved.update(config.skills.get(dep["slug"], {}))
-    if global_skills:
-        for slug, _desc, _path in global_skills:
-            saved.update(config.skills.get(slug, {}))
     return saved
 
 
@@ -616,7 +527,6 @@ def _read_staged_paths(
 def stage_role(
     session_dir: str,
     resolved: dict,
-    global_skills: list[tuple[str, str, str]] | None = None,
     working_dir: str | None = None,
 ) -> tuple[str, str]:
     """Stage a resolved role into the session directory.
@@ -626,7 +536,6 @@ def stage_role(
         session_dir/roles/<slug>/
             ROLE.md                  — copied from installed path
             skills/<dep_slug>/       — symlinked (transitive skill deps only)
-            skills/<global_slug>/    — symlinked (global skills, if not already present)
             roles/<dep_slug>/        — symlinked (direct role deps only)
 
     Idempotent: if the directory already exists, returns paths from the
@@ -635,8 +544,6 @@ def stage_role(
     Args:
         session_dir: Session directory path.
         resolved: Resolved role dict from strawhub.resolver.resolve().
-        global_skills: Optional list of (slug, description, path) tuples
-            for globally installed skills to stage alongside deps.
 
     Returns:
         (skills_dir, roles_dir) — parent directories containing staged
@@ -673,14 +580,6 @@ def stage_role(
     for dep in skill_deps:
         dest = os.path.join(skills_dir, dep["slug"])
         _symlink(dep["path"], dest)
-
-    # Stage global skills (skip if slug already present from deps)
-    if global_skills:
-        for gslug, _desc, gpath in global_skills:
-            validate_frontmatter_slug(gpath, gslug, "skill")
-            dest = os.path.join(skills_dir, gslug)
-            if not os.path.exists(dest):
-                _symlink(gpath, dest)
 
     # Always stage denden — required for agent communication
     _ensure_denden_staged(skills_dir, working_dir)
@@ -926,15 +825,9 @@ def handle_delegate(
     # 2. Resolve role + skills
     resolved = resolve_role(request.role_slug, kind="role")
 
-    # 2b. Discover global skills (exclude first-order skill deps)
-    first_order_skills, _, _, _ = _parse_role_deps(resolved["path"])
-    global_skills = discover_global_skills(
-        resolved["path"], exclude_slugs=set(first_order_skills),
-    )
-
-    # 2c. Validate skill env requirements (non-interactive)
-    skill_env = collect_skill_env(resolved, global_skills=global_skills or None)
-    saved_env = _collect_saved_env(config, resolved, global_skills=global_skills or None)
+    # 2b. Validate skill env requirements (non-interactive)
+    skill_env = collect_skill_env(resolved)
+    saved_env = _collect_saved_env(config, resolved)
     skill_validation = validate_skill_env(skill_env, saved_env=saved_env)
     if not skill_validation.ok:
         missing = ", ".join(skill_validation.missing_env)
@@ -982,9 +875,7 @@ def handle_delegate(
     )
 
     # 4. Build prompt
-    skill_descs = build_skill_descriptions(
-        resolved, global_skills=global_skills or None, working_dir=working_dir,
-    )
+    skill_descs = build_skill_descriptions(resolved, working_dir=working_dir)
     role_prompt = build_prompt(
         resolved["slug"],
         resolved["path"],
@@ -995,8 +886,7 @@ def handle_delegate(
 
     # 5. Stage role (session-level, idempotent)
     skills_dir, roles_dir = stage_role(
-        session_dir, resolved, global_skills=global_skills or None,
-        working_dir=working_dir,
+        session_dir, resolved, working_dir=working_dir,
     )
 
     # 6-9. Spawn/wait loop with retry on format validation failure

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -37,7 +37,6 @@ from strawpot.delegation import (
     _parse_role_deps,
     build_skill_descriptions,
     create_agent_workspace,
-    discover_global_skills,
     handle_delegate,
     stage_role,
 )
@@ -390,11 +389,8 @@ class Session:
             resolved = self._resolve_role(
                 self.config.orchestrator_role, kind="role"
             )
-            first_order_skills, role_dep_slugs, _, wildcard = _parse_role_deps(
+            _, role_dep_slugs, _, wildcard = _parse_role_deps(
                 resolved["path"]
-            )
-            global_skills = discover_global_skills(
-                resolved["path"], exclude_slugs=set(first_order_skills),
             )
 
             # Build delegatable roles so the orchestrator prompt lists them
@@ -407,8 +403,7 @@ class Session:
             )
 
             skill_descs = build_skill_descriptions(
-                resolved, global_skills=global_skills or None,
-                working_dir=working_dir,
+                resolved, working_dir=working_dir,
             )
             role_prompt = build_prompt(
                 resolved["slug"],
@@ -423,7 +418,6 @@ class Session:
             agent_id = f"agent_{uuid.uuid4().hex[:12]}"
             skills_dir, roles_dir = stage_role(
                 self._session_dir(), resolved,
-                global_skills=global_skills or None,
                 working_dir=working_dir,
             )
             workspace = create_agent_workspace(

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -14,7 +14,6 @@ from strawpot.delegation import (
     PolicyDenied,
     _agent_status,
     _build_delegatable_roles,
-    _check_inherit_global_skills,
     _check_policy,
     _collect_transitive_skills,
     _find_skill,
@@ -29,7 +28,6 @@ from strawpot.delegation import (
     _validate_output,
     collect_skill_env,
     create_agent_workspace,
-    discover_global_skills,
     handle_delegate,
     stage_role,
     validate_skill_env,
@@ -93,7 +91,7 @@ def _write_skill(base, slug, body="Skill body.", deps=None, env=None):
 
 def _write_role(base, slug, body="Role body.", description="test",
                 skill_deps=None, role_deps=None,
-                inherit_global_skills=None, default_agent=None):
+                default_agent=None):
     """Write a ROLE.md file.
 
     Args:
@@ -103,14 +101,12 @@ def _write_role(base, slug, body="Role body.", description="test",
         description: Role description.
         skill_deps: Optional list of skill dependency slugs.
         role_deps: Optional list of role dependency slugs.
-        inherit_global_skills: Optional bool for metadata.strawpot.inherit_global_skills.
         default_agent: Optional string for metadata.strawpot.default_agent.
     """
     d = os.path.join(base, "roles", slug)
     os.makedirs(d, exist_ok=True)
     has_strawpot = (
         skill_deps or role_deps
-        or inherit_global_skills is not None
         or default_agent is not None
     )
     if has_strawpot:
@@ -125,9 +121,6 @@ def _write_role(base, slug, body="Role body.", description="test",
                 strawpot_lines.append("      roles:")
                 for r in role_deps:
                     strawpot_lines.append(f'        - "{r}"')
-        if inherit_global_skills is not None:
-            val = "true" if inherit_global_skills else "false"
-            strawpot_lines.append(f"    inherit_global_skills: {val}")
         if default_agent is not None:
             strawpot_lines.append(f"    default_agent: {default_agent}")
         strawpot_yaml = "\n".join(strawpot_lines)
@@ -1772,301 +1765,21 @@ class TestMemoryIntegration:
 
 
 # ---------------------------------------------------------------------------
-# _check_inherit_global_skills
+# stage_role builtins
 # ---------------------------------------------------------------------------
 
 
-class TestCheckInheritGlobalSkills:
-    def test_default_false(self, tmp_path):
-        """Default is False when field is not present."""
-        d = _write_role(str(tmp_path), "basic")
-        assert _check_inherit_global_skills(d) is False
-
-    def test_explicit_true(self, tmp_path):
-        """Explicit True is respected."""
-        d = _write_role(str(tmp_path), "yes", inherit_global_skills=True)
-        assert _check_inherit_global_skills(d) is True
-
-    def test_explicit_false(self, tmp_path):
-        """Explicit False opts out of global skills."""
-        d = _write_role(str(tmp_path), "no", inherit_global_skills=False)
-        assert _check_inherit_global_skills(d) is False
-
-    def test_missing_role_md(self, tmp_path):
-        """Missing ROLE.md defaults to False."""
-        d = str(tmp_path / "roles" / "missing")
-        os.makedirs(d, exist_ok=True)
-        assert _check_inherit_global_skills(d) is False
-
-
-# ---------------------------------------------------------------------------
-# discover_global_skills
-# ---------------------------------------------------------------------------
-
-
-def _write_global_skill(global_dir, slug, version, description="test"):
-    """Create a global skill directory with SKILL.md."""
-    d = os.path.join(global_dir, "skills", f"{slug}-{version}")
-    os.makedirs(d, exist_ok=True)
-    with open(os.path.join(d, "SKILL.md"), "w") as f:
-        f.write(
-            f"---\nname: {slug}\ndescription: {description}\n---\n"
-            f"# {slug}\n\nSkill body.\n"
-        )
-    return d
-
-
-class TestDiscoverGlobalSkills:
-    def test_default_no_global_skills(self, tmp_path, monkeypatch):
-        """Roles without inherit_global_skills do not get global skills."""
-        global_dir = str(tmp_path / "global")
-        monkeypatch.setenv("STRAWPOT_HOME", global_dir)
-        _write_global_skill(global_dir, "linter", "1.0.0")
-
-        role_path = _write_role(str(tmp_path), "worker")
-        resolved = {
-            "slug": "worker", "kind": "role", "version": "1.0.0",
-            "path": role_path, "source": "local", "dependencies": [],
-        }
-
-        assert discover_global_skills(role_path) == []
-
-    def test_discovers_global_skills(self, tmp_path, monkeypatch):
-        """Finds skills in ~/.strawpot/skills/."""
-        global_dir = str(tmp_path / "global")
-        monkeypatch.setenv("STRAWPOT_HOME", global_dir)
-        _write_global_skill(global_dir, "linter", "1.0.0", "Checks code quality")
-
-        role_path = _write_role(str(tmp_path), "worker",
-                               inherit_global_skills=True)
-        resolved = {
-            "slug": "worker", "kind": "role", "version": "1.0.0",
-            "path": role_path, "source": "local", "dependencies": [],
-        }
-
-        result = discover_global_skills(role_path)
-        assert len(result) == 1
-        assert result[0][0] == "linter"
-        assert result[0][1] == "Checks code quality"
-
-    def test_skips_excluded_slugs(self, tmp_path, monkeypatch):
-        """Skills in exclude_slugs are skipped."""
-        global_dir = str(tmp_path / "global")
-        monkeypatch.setenv("STRAWPOT_HOME", global_dir)
-        _write_global_skill(global_dir, "linter", "1.0.0")
-        _write_global_skill(global_dir, "formatter", "1.0.0", "Formats code")
-
-        role_path = _write_role(str(tmp_path), "worker",
-                               inherit_global_skills=True)
-
-        result = discover_global_skills(role_path, exclude_slugs={"linter"})
-        assert len(result) == 1
-        assert result[0][0] == "formatter"
-
-    def test_discovers_unversioned_skills(self, tmp_path, monkeypatch):
-        """Finds skills installed as plain slug directories (no version)."""
-        global_dir = str(tmp_path / "global")
-        monkeypatch.setenv("STRAWPOT_HOME", global_dir)
-        d = os.path.join(global_dir, "skills", "denden")
-        os.makedirs(d, exist_ok=True)
-        with open(os.path.join(d, "SKILL.md"), "w") as f:
-            f.write("---\nname: denden\ndescription: Agent comms\n---\n# denden\n")
-
-        role_path = _write_role(str(tmp_path), "worker",
-                               inherit_global_skills=True)
-        resolved = {
-            "slug": "worker", "kind": "role", "version": "1.0.0",
-            "path": role_path, "source": "local", "dependencies": [],
-        }
-
-        result = discover_global_skills(role_path)
-        assert len(result) == 1
-        assert result[0][0] == "denden"
-        assert result[0][1] == "Agent comms"
-
-    def test_empty_when_no_dir(self, tmp_path, monkeypatch):
-        """Returns empty when ~/.strawpot/skills/ doesn't exist."""
-        monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "nonexistent"))
-        role_path = _write_role(str(tmp_path), "worker",
-                               inherit_global_skills=True)
-        resolved = {
-            "slug": "worker", "kind": "role", "version": "1.0.0",
-            "path": role_path, "source": "local", "dependencies": [],
-        }
-
-        assert discover_global_skills(role_path) == []
-
-    def test_respects_inherit_false(self, tmp_path, monkeypatch):
-        """Returns empty when role opts out via inherit_global_skills: false."""
-        global_dir = str(tmp_path / "global")
-        monkeypatch.setenv("STRAWPOT_HOME", global_dir)
-        _write_global_skill(global_dir, "linter", "1.0.0")
-
-        role_path = _write_role(
-            str(tmp_path), "minimal", inherit_global_skills=False
-        )
-        resolved = {
-            "slug": "minimal", "kind": "role", "version": "1.0.0",
-            "path": role_path, "source": "local", "dependencies": [],
-        }
-
-        assert discover_global_skills(role_path) == []
-
-    def test_invalid_dir_names_skipped(self, tmp_path, monkeypatch):
-        """Directories not matching slug-version pattern are skipped."""
-        global_dir = str(tmp_path / "global")
-        monkeypatch.setenv("STRAWPOT_HOME", global_dir)
-        skills_dir = os.path.join(global_dir, "skills")
-        os.makedirs(skills_dir, exist_ok=True)
-
-        # Invalid names
-        os.makedirs(os.path.join(skills_dir, "not_a_skill"))
-        os.makedirs(os.path.join(skills_dir, ".DS_Store"))
-
-        # Valid name
-        _write_global_skill(global_dir, "linter", "1.0.0", "Checks code")
-
-        role_path = _write_role(str(tmp_path), "worker",
-                               inherit_global_skills=True)
-        resolved = {
-            "slug": "worker", "kind": "role", "version": "1.0.0",
-            "path": role_path, "source": "local", "dependencies": [],
-        }
-
-        result = discover_global_skills(role_path)
-        assert len(result) == 1
-        assert result[0][0] == "linter"
-
-    def test_multiple_skills_sorted(self, tmp_path, monkeypatch):
-        """Multiple global skills are returned in sorted order."""
-        global_dir = str(tmp_path / "global")
-        monkeypatch.setenv("STRAWPOT_HOME", global_dir)
-        _write_global_skill(global_dir, "z-tool", "1.0.0", "Z tool")
-        _write_global_skill(global_dir, "a-tool", "1.0.0", "A tool")
-
-        role_path = _write_role(str(tmp_path), "worker",
-                               inherit_global_skills=True)
-        resolved = {
-            "slug": "worker", "kind": "role", "version": "1.0.0",
-            "path": role_path, "source": "local", "dependencies": [],
-        }
-
-        result = discover_global_skills(role_path)
-        assert len(result) == 2
-        assert result[0][0] == "a-tool"
-        assert result[1][0] == "z-tool"
-
-    def test_raises_on_name_mismatch(self, tmp_path, monkeypatch):
-        """Raises ValueError when global skill name != directory slug."""
-        global_dir = str(tmp_path / "global")
-        monkeypatch.setenv("STRAWPOT_HOME", global_dir)
-
-        # Create global skill with mismatched name
-        d = os.path.join(global_dir, "skills", "linter-1.0.0")
-        os.makedirs(d, exist_ok=True)
-        with open(os.path.join(d, "SKILL.md"), "w") as f:
-            f.write("---\nname: wrong-name\ndescription: test\n---\nBody.\n")
-
-        role_path = _write_role(str(tmp_path), "worker",
-                               inherit_global_skills=True)
-        resolved = {
-            "slug": "worker", "kind": "role", "version": "1.0.0",
-            "path": role_path, "source": "local", "dependencies": [],
-        }
-
-        with pytest.raises(ValueError, match="does not match"):
-            discover_global_skills(role_path)
-
-
-# ---------------------------------------------------------------------------
-# stage_role with global_skills
-# ---------------------------------------------------------------------------
-
-
-class TestStageRoleGlobalSkills:
-    def test_stages_global_skills(self, tmp_path):
-        """Global skills are symlinked into skills_dir."""
-        registry = str(tmp_path / "registry")
-        role_path = _write_role(registry, "worker")
-        global_skill = _write_global_skill(
-            str(tmp_path / "global"), "linter", "1.0.0"
-        )
-
-        resolved = {
-            "slug": "worker", "kind": "role", "version": "1.0.0",
-            "path": role_path, "source": "local", "dependencies": [],
-        }
-
-        session = str(tmp_path / "session")
-        skills_dir, _ = stage_role(
-            session, resolved,
-            global_skills=[("linter", "Checks code", global_skill)],
-        )
-
-        staged = os.path.join(skills_dir, "linter")
-        assert os.path.islink(staged)
-        assert os.readlink(staged) == global_skill
-
-    def test_global_skill_skipped_if_dep_exists(self, tmp_path):
-        """Dependency-resolved skill takes precedence over global."""
-        registry = str(tmp_path / "registry")
-        dep_skill = _write_skill(registry, "linter")
-        role_path = _write_role(registry, "worker", skill_deps=["linter"])
-        global_skill = _write_global_skill(
-            str(tmp_path / "global"), "linter", "1.0.0"
-        )
-
-        resolved = {
-            "slug": "worker", "kind": "role", "version": "1.0.0",
-            "path": role_path, "source": "local",
-            "dependencies": [
-                {"slug": "linter", "kind": "skill", "version": "1.0.0",
-                 "path": dep_skill, "source": "local"},
-            ],
-        }
-
-        session = str(tmp_path / "session")
-        skills_dir, _ = stage_role(
-            session, resolved,
-            global_skills=[("linter", "Checks code", global_skill)],
-        )
-
-        staged = os.path.join(skills_dir, "linter")
-        assert os.path.islink(staged)
-        # Should point to dep path, not global
-        assert os.readlink(staged) == dep_skill
-
-    def test_no_global_skills_when_none(self, tmp_path, monkeypatch):
-        """Passing None for global_skills stages only denden."""
-        registry = str(tmp_path / "registry")
-        role_path = _write_role(registry, "worker")
-        # Ensure no denden in STRAWPOT_HOME so nothing is staged
-        monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "empty_home"))
-
-        resolved = {
-            "slug": "worker", "kind": "role", "version": "1.0.0",
-            "path": role_path, "source": "local", "dependencies": [],
-        }
-
-        session = str(tmp_path / "session")
-        skills_dir, _ = stage_role(session, resolved, global_skills=None)
-
-        # skills dir exists but is empty (no denden installed globally)
-        assert os.path.isdir(skills_dir)
-        assert os.listdir(skills_dir) == []
-
+class TestStageRoleBuiltins:
     def test_denden_always_staged(self, tmp_path, monkeypatch):
-        """Denden is staged even without inherit_global_skills or explicit dep."""
+        """Denden is staged even without explicit dep."""
         global_dir = str(tmp_path / "global")
         monkeypatch.setenv("STRAWPOT_HOME", global_dir)
-        # Install denden globally (plain slug dir, no version)
         denden_path = os.path.join(global_dir, "skills", "denden")
         os.makedirs(denden_path, exist_ok=True)
         with open(os.path.join(denden_path, "SKILL.md"), "w") as f:
             f.write("---\nname: denden\ndescription: Agent comms\n---\n# denden\n")
 
         registry = str(tmp_path / "registry")
-        # Role does NOT set inherit_global_skills
         role_path = _write_role(registry, "worker")
 
         resolved = {
@@ -2075,7 +1788,7 @@ class TestStageRoleGlobalSkills:
         }
 
         session = str(tmp_path / "session")
-        skills_dir, _ = stage_role(session, resolved, global_skills=None)
+        skills_dir, _ = stage_role(session, resolved)
 
         staged = os.path.join(skills_dir, "denden")
         assert os.path.islink(staged)
@@ -2104,7 +1817,7 @@ class TestStageRoleGlobalSkills:
         }
 
         session = str(tmp_path / "session")
-        skills_dir, _ = stage_role(session, resolved, global_skills=None)
+        skills_dir, _ = stage_role(session, resolved)
 
         staged = os.path.join(skills_dir, "denden")
         assert os.path.islink(staged)
@@ -2230,7 +1943,7 @@ class TestEnsureStagedLocal:
 
         session = str(tmp_path / "session")
         skills_dir, _ = stage_role(
-            session, resolved, global_skills=None, working_dir=str(project),
+            session, resolved, working_dir=str(project),
         )
 
         staged = os.path.join(skills_dir, "denden")
@@ -2258,7 +1971,7 @@ class TestEnsureStagedLocal:
 
         session = str(tmp_path / "session")
         skills_dir, _ = stage_role(
-            session, resolved, global_skills=None, working_dir=str(project),
+            session, resolved, working_dir=str(project),
         )
 
         staged = os.path.join(skills_dir, "denden")
@@ -2289,7 +2002,7 @@ class TestEnsureStagedLocal:
 
         session = str(tmp_path / "session")
         _, roles_dir = stage_role(
-            session, resolved, global_skills=None, working_dir=str(project),
+            session, resolved, working_dir=str(project),
         )
 
         staged_slugs = os.listdir(roles_dir)
@@ -2352,22 +2065,12 @@ class TestMergeEnvEntry:
 
 
 class TestCollectSkillEnv:
-    def test_merges_deps_and_global(self, tmp_path):
+    def test_collects_from_deps(self, tmp_path):
         base = str(tmp_path)
 
-        # Skill dep with env
         skill_a = _write_skill(
             base, "skill-a",
             env={"TOKEN_A": {"required": True, "description": "A"}},
-        )
-
-        # Global skill with env
-        global_dir = tmp_path / "global_skills" / "skill-g"
-        global_dir.mkdir(parents=True)
-        (global_dir / "SKILL.md").write_text(
-            "---\nname: skill-g\ndescription: global\n"
-            "metadata:\n  strawpot:\n    env:\n      TOKEN_G:\n"
-            "        required: true\n        description: G\n---\nbody\n"
         )
 
         role_path = _write_role(base, "my-role", skill_deps=["skill-a"])
@@ -2380,12 +2083,8 @@ class TestCollectSkillEnv:
             ],
         }
 
-        result = collect_skill_env(
-            resolved,
-            global_skills=[("skill-g", "global", str(global_dir))],
-        )
+        result = collect_skill_env(resolved)
         assert "TOKEN_A" in result
-        assert "TOKEN_G" in result
 
     def test_required_wins_across_skills(self, tmp_path):
         base = str(tmp_path)
@@ -2561,28 +2260,6 @@ class TestCollectSkillEnv:
         assert result["TOKEN_A"]["_source_skill"] == "skill-a"
         assert result["TOKEN_B"]["_source_skill"] == "skill-b"
 
-    def test_source_skill_global(self, tmp_path):
-        """Global skills also get _source_skill tracked."""
-        base = str(tmp_path)
-        global_dir = tmp_path / "global_skills" / "skill-g"
-        global_dir.mkdir(parents=True)
-        (global_dir / "SKILL.md").write_text(
-            "---\nname: skill-g\ndescription: global\n"
-            "metadata:\n  strawpot:\n    env:\n      TOKEN_G:\n"
-            "        required: true\n        description: G\n---\nbody\n"
-        )
-        role_path = _write_role(base, "my-role")
-        resolved = {
-            "slug": "my-role",
-            "kind": "role",
-            "path": role_path,
-            "dependencies": [],
-        }
-        result = collect_skill_env(
-            resolved,
-            global_skills=[("skill-g", "global", str(global_dir))],
-        )
-        assert result["TOKEN_G"]["_source_skill"] == "skill-g"
 
 
 # ---------------------------------------------------------------------------
@@ -2881,15 +2558,6 @@ class TestCollectSavedEnv:
         }
         saved = _collect_saved_env(config, resolved)
         assert saved == {"TOKEN": "abc"}
-
-    def test_collects_from_global_skills(self):
-        config = StrawPotConfig(skills={"global_skill": {"KEY": "val"}})
-        resolved = {"slug": "my-role", "path": "/tmp", "dependencies": []}
-        saved = _collect_saved_env(
-            config, resolved,
-            global_skills=[("global_skill", "desc", "/tmp/g")],
-        )
-        assert saved == {"KEY": "val"}
 
     def test_ignores_unknown_slugs(self):
         config = StrawPotConfig(skills={})

--- a/cli/tests/test_session.py
+++ b/cli/tests/test_session.py
@@ -1681,67 +1681,6 @@ class TestNoninteractiveMode:
         mock_stop.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
-# Global skills integration
-# ---------------------------------------------------------------------------
-
-
-class TestGlobalSkills:
-    @patch("strawpot.session.discover_global_skills")
-    @patch("strawpot.session.DenDenServer")
-    def test_orchestrator_gets_global_skills(
-        self, mock_server_cls, mock_discover, tmp_path
-    ):
-        """Orchestrator prompt includes global skills when discovered."""
-        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
-        mock_discover.return_value = [
-            ("linter", "Checks code quality", "/global/skills/linter-1.0.0"),
-        ]
-        isolator = _mock_isolator()
-        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
-        runtime = _mock_runtime()
-        session = _make_session(
-            tmp_path, isolator=isolator, runtime=runtime, task="do stuff"
-        )
-
-        session.start(str(tmp_path))
-
-        # Verify discover_global_skills was called
-        mock_discover.assert_called_once()
-        # Verify the prompt passed to spawn contains Skills section
-        spawn_kwargs = runtime.spawn.call_args.kwargs
-        assert "## Skills" in spawn_kwargs["role_prompt"]
-        assert "**linter**" in spawn_kwargs["role_prompt"]
-
-    @patch("strawpot.delegation._append_builtins")
-    @patch("strawpot.session.discover_global_skills")
-    @patch("strawpot.session.DenDenServer")
-    def test_orchestrator_builtins_when_no_global_skills(
-        self, mock_server_cls, mock_discover, mock_builtins, tmp_path
-    ):
-        """Built-in skills still appear even when global discover returns empty."""
-        mock_server_cls.return_value.bound_addr = "127.0.0.1:9700"
-        mock_discover.return_value = []
-
-        def fake_builtins(skills, _working_dir):
-            skills.append(("denden", "Agent communication"))
-            skills.append(("strawpot-session-recap", "Session recap"))
-
-        mock_builtins.side_effect = fake_builtins
-        isolator = _mock_isolator()
-        isolator.create.return_value = IsolatedEnv(path=str(tmp_path))
-        runtime = _mock_runtime()
-        session = _make_session(
-            tmp_path, isolator=isolator, runtime=runtime, task="do stuff"
-        )
-
-        session.start(str(tmp_path))
-
-        spawn_kwargs = runtime.spawn.call_args.kwargs
-        assert "## Skills" in spawn_kwargs["role_prompt"]
-        assert "**denden**" in spawn_kwargs["role_prompt"]
-        assert "**strawpot-session-recap**" in spawn_kwargs["role_prompt"]
-
 
 # ---------------------------------------------------------------------------
 # Max delegations per session

--- a/designs/DESIGN.md
+++ b/designs/DESIGN.md
@@ -1682,14 +1682,11 @@ alive.
     after wait in the delegation flow
 20. `config.py` — add `memory` and `memory_config` fields
 
-### Phase 4 — Global Skills (complete)
+### Phase 4 — Global Skills (removed)
 
-21. `delegation.py` + `context.py` — discover global skills from
-    `~/.strawpot/skills/`, stage alongside dependency-resolved skills,
-    add "Available Skills" summary section to prompt (slug + description;
-    agents read `skills/<name>/SKILL.md` for full body). Respect
-    `metadata.strawpot.inherit_global_skills` in ROLE.md (default `false`)
-    to allow roles to opt in to global skills.
+21. ~~Global skill discovery via `inherit_global_skills`~~ — removed.
+    Built-in skill injection (`_append_builtins`) and wildcard
+    dependencies (`skills: ["*"]`) cover the same use cases.
 
 ### Phase 5 — Web GUI (complete)
 
@@ -1961,47 +1958,11 @@ Python package itself is auto-installed by StrawPot on first use when
 
 ---
 
-## Global Skills
+## ~~Global Skills~~ (removed)
 
-When delegating, strawpot discovers globally installed skills and makes them
-available to agents alongside dependency-resolved skills. This lets users
-install utility skills once (e.g. `strawpot install skill my-linter`) and
-have them available to all roles without explicit dependency declarations.
-
-### Discovery
-
-Scan `~/.strawpot/skills/` for installed skill directories using strawhub's
-`parse_dir_name()`. Only global-scope skills are discovered — project-local
-skills (`.strawpot/skills/`) are not included (those are already handled by
-the dependency resolver).
-
-### Staging
-
-During `stage_role()`, symlink each discovered global skill into the
-role's skills directory alongside dependency-resolved skills. If a global
-skill slug already exists (added by the dependency resolver), skip it —
-dependency-resolved versions take precedence.
-
-### Prompt — "Available Skills" Section
-
-`build_prompt()` adds an **Available Skills** summary section listing each
-global skill's slug and one-line description. This appears after the role
-body and before the Delegation section. Agents can read
-`skills/<name>/SKILL.md` for the full body when they need details.
-
-### Opt-In via `inherit_global_skills`
-
-Roles can opt in to receiving global skills by setting
-`metadata.strawpot.inherit_global_skills: true` in their ROLE.md
-frontmatter. When omitted, the default is `false` (global skills are
-not inherited). This keeps roles minimal by default while allowing
-roles that need broader capabilities to inherit all globally installed
-skills.
-
-### Denden Communication
-
-Already covered: the Delegation and Requester sections in `context.py`
-include denden communication instructions when delegatable roles are
-present. No additional changes needed.
-
+The `inherit_global_skills` opt-in mechanism has been removed. Built-in
+skill injection (`_append_builtins`) ensures `denden` and
+`strawpot-session-recap` are always available. Wildcard dependencies
+(`skills: ["*"]`) cover the "include everything" use case by scanning
+both project-local and global skill directories via `_discover_all_skills()`.
 

--- a/docs/concepts/delegation.mdx
+++ b/docs/concepts/delegation.mdx
@@ -106,10 +106,6 @@ The resolved directory structure looks like:
     └── implementer/ROLE.md
 ```
 
-## Global Skills
-
-Roles can opt in to loading global skills from `~/.strawpot/skills/` by setting `metadata.strawpot.inherit_global_skills: true` in their ROLE.md frontmatter. By default, global skills are **not** inherited. When enabled, they are included alongside the role's declared dependencies, giving agents access to user-wide skill configurations.
-
 ## Memory Context
 
 If a memory provider is configured, StrawPot retrieves context before spawning each sub-agent:


### PR DESCRIPTION
## Summary

- Remove `discover_global_skills()`, `_check_inherit_global_skills()`, and `global_skills` parameter from `build_skill_descriptions()`, `collect_skill_env()`, `_collect_saved_env()`, `stage_role()`
- Remove global skills discovery and passing from `handle_delegate()`, `Session.start()`, and CLI env validation
- Remove ~560 lines of related tests (4 test classes + helpers)
- Update docs and DESIGN.md to reflect removal

Built-in skill injection (`_append_builtins`) ensures denden and strawpot-session-recap are always available. Wildcard dependencies (`skills: ["*"]`) cover the "include everything" use case via `_discover_all_skills()`. The `inherit_global_skills` opt-in mechanism is redundant.

## Test plan

- [x] All 128 delegation tests pass
- [x] All 84 session tests pass
- [x] Wildcard skill support (`_discover_all_skills`) is independent and unaffected
- [ ] Manual: verify delegation works without global skills in a live session

🤖 Generated with [Claude Code](https://claude.com/claude-code)