### PR TITLE
Add WebSocket log streaming and ask_user design

### DIFF
--- a/designs/integration/DESIGN.md
+++ b/designs/integration/DESIGN.md
@@ -282,7 +282,7 @@ its own `(platform_id, thread_id) → conversation_id` mapping locally.
 | PUT | `/api/integrations/:name/config` | Save config values |
 | POST | `/api/integrations/:name/start` | Start the adapter process |
 | POST | `/api/integrations/:name/stop` | Stop the adapter process |
-| GET | `/api/integrations/:name/logs` | SSE: stream adapter log output |
+| WS | `/api/integrations/:name/logs/ws` | WebSocket: stream adapter log output |
 | POST | `/api/integrations/install` | Install from Strawhub |
 | DELETE | `/api/integrations/:name` | Stop + uninstall |
 
@@ -483,6 +483,51 @@ app.run_polling()
 
 ---
 
+## ask_user Handling for Chat-Originated Sessions
+
+When a chat adapter submits a task to imu, the resulting session may
+trigger an `ask_user` event — the agent needs human input to proceed.
+In the GUI this opens a prompt dialog, but chat-originated sessions have
+no GUI user watching. Three approaches, in order of complexity:
+
+### Option 1: Route ask_user back through chat (long-term goal)
+
+The adapter subscribes to the session WebSocket. When it receives an
+`ask_user` event, it forwards the question to the chat user and relays
+their reply back via a new API endpoint (e.g.,
+`POST /api/sessions/{run_id}/reply`). This gives the best UX — the user
+stays in their chat app for the full interaction.
+
+**Requires:** A reply API endpoint, adapter awareness of ask_user events,
+and per-platform UX for prompting the user (inline message + wait for
+reply).
+
+### Option 2: GUI-only prompt
+
+ask_user events appear only in the GUI. The chat user gets a message
+like "Action needed — check the StrawPot GUI to respond." Works but
+breaks the "stay in chat" experience.
+
+### Option 3: Disable ask_user for chat sessions (initial approach)
+
+Sessions launched from chat adapters run with `ask_user` disabled —
+agents must proceed without human input or fail gracefully. This is the
+simplest starting point and avoids building reply infrastructure before
+validating the chat workflow.
+
+**How:** The adapter passes a flag (e.g., `"interactive": false`) when
+submitting a task. The session launcher propagates this to the agent
+config, which suppresses ask_user tool availability.
+
+### Phased approach
+
+Start with **Option 3** — disable ask_user for chat-originated sessions.
+This unblocks the full chat integration flow without additional API work.
+Move to **Option 1** when chat usage matures and users need interactive
+workflows from chat.
+
+---
+
 ## Not Planned
 
 | Feature | Reason |
@@ -502,10 +547,10 @@ discovers, configures, and manages them. Full feature without registry.
 
 | # | Item | Status |
 |---|------|--------|
-| 1 | Database: `integrations` + `integration_config` tables | Planned |
-| 2 | Backend: integration CRUD API (list, detail, config, uninstall) | Planned |
-| 3 | Backend: lifecycle management (start, stop, status, health check) | Planned |
-| 4 | Backend: adapter log streaming (SSE) | Planned |
+| 1 | Database: `integrations` + `integration_config` tables | Done |
+| 2 | Backend: integration CRUD API (list, detail, config, uninstall) | Done |
+| 3 | Backend: lifecycle management (start, stop, status, auto-start) | Done |
+| 4 | Backend: adapter log streaming (WebSocket) | Done |
 | 5 | Frontend: Integrations page (list, configure, start/stop, logs) | Planned |
 | 6 | Reference adapter: Telegram (bot token + long polling) | Planned |
 | 7 | Reference adapter: Slack (Socket Mode + Events API) | Planned |

--- a/gui/src/strawpot_gui/routers/integrations.py
+++ b/gui/src/strawpot_gui/routers/integrations.py
@@ -1,5 +1,6 @@
-"""Integration management endpoints — list, detail, config CRUD, lifecycle."""
+"""Integration management endpoints — list, detail, config CRUD, lifecycle, logs."""
 
+import asyncio
 import logging
 import os
 import shlex
@@ -9,11 +10,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
+from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from strawpot.config import get_strawpot_home
 from strawpot.context import parse_frontmatter
 
 from strawpot_gui.db import get_db_conn
+from strawpot_gui.routers.logs import read_log_delta, read_log_tail
+from strawpot_gui.sse import watch_dir
 
 logger = logging.getLogger(__name__)
 
@@ -482,3 +486,125 @@ def auto_start_integrations(db_path: str) -> None:
                 (proc.pid, now, name),
             )
         logger.info("Auto-started integration '%s' (pid %d)", name, proc.pid)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket: integration log streaming
+# ---------------------------------------------------------------------------
+
+
+@router.websocket("/{name}/logs/ws")
+async def integration_logs_ws(websocket: WebSocket, name: str) -> None:
+    """Stream integration adapter logs over WebSocket.
+
+    Protocol (server → client):
+      {"type": "log_snapshot", "lines": [...], "offset": N}
+      {"type": "log_delta",    "lines": [...], "offset": N}
+      {"type": "log_done"}  — integration stopped, stream ends
+      {"type": "error", "message": "..."}
+    """
+    home = get_strawpot_home()
+    integration_dir = home / "integrations" / name
+    manifest_path = integration_dir / MANIFEST
+    if not manifest_path.is_file():
+        await websocket.accept()
+        await websocket.send_json({"type": "error", "message": f"Integration not found: {name}"})
+        await websocket.close(code=4004)
+        return
+
+    log_path = str(integration_dir / ".log")
+
+    await websocket.accept()
+
+    # Send initial snapshot
+    lines, offset = read_log_tail(log_path)
+    await websocket.send_json({
+        "type": "log_snapshot",
+        "lines": lines,
+        "offset": offset,
+    })
+
+    # Check if integration is currently running
+    db_path: str = websocket.app.state.db_path
+    from strawpot_gui.db import get_db
+    with get_db(db_path) as conn:
+        db_state = _get_db_state(conn, name)
+
+    is_running = (
+        db_state is not None
+        and db_state["status"] == "running"
+        and db_state["pid"]
+        and _is_process_alive(db_state["pid"])
+    )
+
+    if not is_running:
+        await websocket.send_json({"type": "log_done"})
+        await websocket.close()
+        return
+
+    # Watch for log changes
+    stop = asyncio.Event()
+
+    async def log_watcher() -> None:
+        nonlocal offset
+        try:
+            async for changed_files in watch_dir(str(integration_dir), stop):
+                if not changed_files:
+                    # Timeout — check if still running
+                    with get_db(db_path) as conn:
+                        state = _get_db_state(conn, name)
+                    alive = (
+                        state is not None
+                        and state["status"] == "running"
+                        and state["pid"]
+                        and _is_process_alive(state["pid"])
+                    )
+                    if not alive:
+                        # Final read
+                        new_lines, offset = read_log_delta(log_path, offset)
+                        if new_lines:
+                            await websocket.send_json({
+                                "type": "log_delta",
+                                "lines": new_lines,
+                                "offset": offset,
+                            })
+                        await websocket.send_json({"type": "log_done"})
+                        return
+                    continue
+
+                if any(f.endswith(".log") for f in changed_files):
+                    new_lines, offset = read_log_delta(log_path, offset)
+                    if new_lines:
+                        await websocket.send_json({
+                            "type": "log_delta",
+                            "lines": new_lines,
+                            "offset": offset,
+                        })
+        except asyncio.CancelledError:
+            pass
+
+    async def receiver() -> None:
+        """Drain client messages (keep connection alive)."""
+        try:
+            while True:
+                await websocket.receive_text()
+        except WebSocketDisconnect:
+            stop.set()
+
+    watcher_task = asyncio.create_task(log_watcher())
+    receiver_task = asyncio.create_task(receiver())
+
+    try:
+        await asyncio.wait(
+            {watcher_task, receiver_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+    finally:
+        stop.set()
+        for task in [watcher_task, receiver_task]:
+            task.cancel()
+        await asyncio.gather(watcher_task, receiver_task, return_exceptions=True)
+        try:
+            await websocket.close()
+        except Exception:
+            pass

--- a/gui/tests/test_integrations_api.py
+++ b/gui/tests/test_integrations_api.py
@@ -289,3 +289,48 @@ class TestOrphanedIntegrations:
             ).fetchone()
         assert row["status"] == "stopped"
         assert row["pid"] is None
+
+
+class TestIntegrationLogs:
+    def test_logs_ws_not_found(self, client, home):
+        """WebSocket for nonexistent integration returns error and closes."""
+        with client.websocket_connect("/api/integrations/nonexistent/logs/ws") as ws:
+            msg = ws.receive_json()
+            assert msg["type"] == "error"
+            assert "not found" in msg["message"]
+
+    def test_logs_ws_stopped_sends_done(self, client, home):
+        """Stopped integration sends snapshot then done."""
+        integration_dir = _create_integration(home, "telegram")
+        (integration_dir / ".log").write_text("line1\nline2\n")
+        with client.websocket_connect("/api/integrations/telegram/logs/ws") as ws:
+            msg = ws.receive_json()
+            assert msg["type"] == "log_snapshot"
+            assert "line1" in msg["lines"]
+            assert "line2" in msg["lines"]
+            msg = ws.receive_json()
+            assert msg["type"] == "log_done"
+
+    def test_logs_ws_empty_log(self, client, home):
+        """No log file yet — snapshot has empty lines, then done."""
+        _create_integration(home, "telegram")
+        with client.websocket_connect("/api/integrations/telegram/logs/ws") as ws:
+            msg = ws.receive_json()
+            assert msg["type"] == "log_snapshot"
+            assert msg["lines"] == []
+            msg = ws.receive_json()
+            assert msg["type"] == "log_done"
+
+    def test_logs_ws_snapshot_includes_existing_content(self, client, home):
+        """Snapshot includes existing log content."""
+        integration_dir = _create_integration(home, "telegram")
+        (integration_dir / ".log").write_text(
+            "line1\nline2\nline3\nline4\nline5\n"
+        )
+        with client.websocket_connect("/api/integrations/telegram/logs/ws") as ws:
+            msg = ws.receive_json()
+            assert msg["type"] == "log_snapshot"
+            assert len(msg["lines"]) == 5
+            assert msg["lines"][0] == "line1"
+            assert msg["lines"][4] == "line5"
+            assert msg["offset"] > 0


### PR DESCRIPTION
## Summary
- **WebSocket log streaming** for integration adapters — `/{name}/logs/ws` endpoint with snapshot → delta → done protocol, file watching via `watch_dir`, and process liveness checks
- **ask_user handling** section added to integration DESIGN.md — three options with phased approach (Option 3: disable for chat sessions initially, Option 1: route through chat long-term)
- **DESIGN.md status updates** — steps 1-4 marked Done, log endpoint updated from SSE to WebSocket
- 4 new WebSocket log tests (not found, stopped sends done, empty log, snapshot content)

## Test plan
- [x] All 27 integration API tests pass
- [ ] Manual: connect to WebSocket while adapter is running, verify snapshot + delta streaming
- [ ] Manual: verify `log_done` sent when adapter stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)