### PR TITLE
Add reference Telegram adapter

### DIFF
--- a/designs/integration/DESIGN.md
+++ b/designs/integration/DESIGN.md
@@ -133,6 +133,9 @@ metadata:
   strawpot:
     entry_point: python adapter.py
     auto_start: false
+    install:
+      macos: pip install -r requirements.txt
+      linux: pip install -r requirements.txt
     config:
       bot_token:
         type: secret
@@ -167,7 +170,9 @@ replied back in the chat.
 | `metadata.strawpot.config` | No | Schema for user-facing config (type, required, secret, default, description). Values are passed as env vars at start. |
 | `metadata.strawpot.health_check` | No | Endpoint + interval for liveness checks |
 
-Unlike agents/skills/memory, integrations do **not** use `env`, `install`,
+| `metadata.strawpot.install` | No | OS-keyed install commands (same convention as agents). Run by `strawhub install` in Phase 3. |
+
+Unlike agents/skills/memory, integrations do **not** use `env`,
 `tools`, `params`, or `dependencies`. Those exist for CLI-resolved resources
 that need pre-launch validation. Integrations are standalone processes
 managed by the GUI — the adapter handles its own environment and setup.

--- a/integrations/telegram/INTEGRATION.md
+++ b/integrations/telegram/INTEGRATION.md
@@ -1,0 +1,64 @@
+---
+name: telegram
+description: Telegram bot adapter for StrawPot conversations
+metadata:
+  strawpot:
+    entry_point: python adapter.py
+    auto_start: false
+    install:
+      macos: pip install -r requirements.txt
+      linux: pip install -r requirements.txt
+    config:
+      bot_token:
+        type: secret
+        required: true
+        description: Telegram bot API token from @BotFather
+---
+
+# Telegram Adapter
+
+Connects a Telegram bot to StrawPot via imu. Messages sent to the bot
+become tasks in imu conversations; session outputs are replied back in
+the chat.
+
+## Setup
+
+1. Create a bot via [@BotFather](https://t.me/BotFather) on Telegram
+2. Copy the bot token
+3. Install this integration and its dependencies:
+   ```bash
+   cp -r integrations/telegram ~/.strawpot/integrations/telegram
+   cd ~/.strawpot/integrations/telegram && pip install -r requirements.txt
+   ```
+4. In the StrawPot GUI, go to **Integrations** → **telegram** → **Configure**
+5. Paste the bot token and click Save
+6. Click **Start**
+
+> **Future:** `strawhub install integration telegram` will handle step 3
+> automatically, including running the `install` command from the manifest.
+
+## How it works
+
+- Each Telegram chat (DM or group) maps to a separate imu conversation
+- Messages are submitted as tasks to imu via the StrawPot REST API
+- The adapter monitors the session via WebSocket and replies with the
+  summary when done
+- Use `/new` to start a fresh conversation (clears the chat→conversation
+  mapping)
+- Use `/start` to see a welcome message
+
+## Conversation mapping
+
+The adapter stores `chat_id → conversation_id` in a local SQLite
+database (`.adapter.db` in the integration directory). This is adapter
+state only — the StrawPot GUI sees normal imu conversations.
+
+## Group chats
+
+In group chats, the bot responds to:
+- Direct replies to the bot's messages
+- Messages that mention the bot by name
+- All `/new` and `/start` commands
+
+To add the bot to a group, disable "Group Privacy" in BotFather settings
+or use the bot in reply-only mode.

--- a/integrations/telegram/adapter.py
+++ b/integrations/telegram/adapter.py
@@ -1,0 +1,303 @@
+"""Telegram adapter for StrawPot — relays messages to/from imu."""
+
+import asyncio
+import json
+import logging
+import os
+import signal
+import sqlite3
+import sys
+from pathlib import Path
+
+import httpx
+import websockets
+from telegram import Update
+from telegram.constants import ChatAction, ParseMode
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    MessageHandler,
+    filters,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stdout,
+)
+logger = logging.getLogger("strawpot.telegram")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+API_URL = os.environ.get("STRAWPOT_API_URL", "http://127.0.0.1:52532")
+BOT_TOKEN = os.environ.get("STRAWPOT_BOT_TOKEN", "")
+# Max chars per Telegram message (leave room for formatting)
+TG_MAX_LEN = 4000
+# How often to poll for session status if WebSocket fails (seconds)
+POLL_INTERVAL = 3
+
+if not BOT_TOKEN:
+    logger.error("STRAWPOT_BOT_TOKEN is not set")
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Local database: chat_id → conversation_id mapping
+# ---------------------------------------------------------------------------
+
+_DB_PATH = Path(__file__).parent / ".adapter.db"
+
+
+def _init_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(_DB_PATH))
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS chat_conversations (
+            chat_id   TEXT PRIMARY KEY,
+            conv_id   INTEGER NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+db = _init_db()
+
+
+def get_conv_id(chat_id: str) -> int | None:
+    row = db.execute(
+        "SELECT conv_id FROM chat_conversations WHERE chat_id = ?",
+        (chat_id,),
+    ).fetchone()
+    return row[0] if row else None
+
+
+def set_conv_id(chat_id: str, conv_id: int) -> None:
+    db.execute(
+        "INSERT OR REPLACE INTO chat_conversations (chat_id, conv_id) VALUES (?, ?)",
+        (chat_id, conv_id),
+    )
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# StrawPot API helpers
+# ---------------------------------------------------------------------------
+
+
+async def create_conversation(client: httpx.AsyncClient) -> int:
+    """Create a new imu conversation and return its ID."""
+    resp = await client.post(f"{API_URL}/api/imu/conversations")
+    resp.raise_for_status()
+    return resp.json()["id"]
+
+
+async def get_or_create_conversation(
+    client: httpx.AsyncClient, chat_id: str
+) -> int:
+    """Get existing conversation for this chat, or create a new one."""
+    conv_id = get_conv_id(chat_id)
+    if conv_id is not None:
+        return conv_id
+    conv_id = await create_conversation(client)
+    set_conv_id(chat_id, conv_id)
+    logger.info("Created conversation %d for chat %s", conv_id, chat_id)
+    return conv_id
+
+
+async def submit_task(
+    client: httpx.AsyncClient, conv_id: int, text: str
+) -> dict:
+    """Submit a task to a conversation. Returns the response dict."""
+    resp = await client.post(
+        f"{API_URL}/api/conversations/{conv_id}/tasks",
+        json={"task": text},
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+async def get_session_summary(
+    client: httpx.AsyncClient, conv_id: int, run_id: str
+) -> str:
+    """Fetch the session summary from the conversation."""
+    resp = await client.get(f"{API_URL}/api/conversations/{conv_id}")
+    resp.raise_for_status()
+    for session in resp.json().get("sessions", []):
+        if session["run_id"] == run_id:
+            return session.get("summary") or f"Session {session['status']}."
+    return "Session completed."
+
+
+# ---------------------------------------------------------------------------
+# Session monitoring
+# ---------------------------------------------------------------------------
+
+
+async def wait_for_session_ws(run_id: str) -> None:
+    """Wait for a session to complete via WebSocket."""
+    ws_url = API_URL.replace("http://", "ws://").replace("https://", "wss://")
+    uri = f"{ws_url}/ws/sessions/{run_id}"
+    try:
+        async with websockets.connect(uri) as ws:
+            # Send init to start receiving events
+            await ws.send(json.dumps({"type": "init", "trace_offset": 0}))
+            async for raw in ws:
+                msg = json.loads(raw)
+                if msg.get("type") == "stream_complete":
+                    return
+                if msg.get("type") == "error":
+                    logger.warning("WS error: %s", msg.get("message"))
+                    return
+    except Exception as exc:
+        logger.warning("WebSocket monitoring failed: %s — falling back to polling", exc)
+        await wait_for_session_poll(run_id)
+
+
+async def wait_for_session_poll(run_id: str) -> None:
+    """Fallback: poll session status until terminal."""
+    terminal = {"completed", "failed", "stopped"}
+    async with httpx.AsyncClient() as client:
+        while True:
+            await asyncio.sleep(POLL_INTERVAL)
+            try:
+                resp = await client.get(f"{API_URL}/api/sessions/{run_id}")
+                resp.raise_for_status()
+                if resp.json().get("status") in terminal:
+                    return
+            except Exception as exc:
+                logger.warning("Poll error: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Message formatting
+# ---------------------------------------------------------------------------
+
+
+def chunk_message(text: str) -> list[str]:
+    """Split text into chunks that fit Telegram's message limit."""
+    if len(text) <= TG_MAX_LEN:
+        return [text]
+    chunks = []
+    while text:
+        if len(text) <= TG_MAX_LEN:
+            chunks.append(text)
+            break
+        # Try to break at a newline
+        cut = text.rfind("\n", 0, TG_MAX_LEN)
+        if cut < TG_MAX_LEN // 2:
+            cut = TG_MAX_LEN
+        chunks.append(text[:cut])
+        text = text[cut:].lstrip("\n")
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Telegram handlers
+# ---------------------------------------------------------------------------
+
+
+async def cmd_start(update: Update, context) -> None:
+    """Handle /start — welcome message."""
+    await update.message.reply_text(
+        "Hi! I'm your StrawPot assistant.\n\n"
+        "Send me a message and I'll route it through imu.\n"
+        "Use /new to start a fresh conversation."
+    )
+
+
+async def cmd_new(update: Update, context) -> None:
+    """Handle /new — start a fresh conversation."""
+    chat_id = str(update.effective_chat.id)
+    async with httpx.AsyncClient() as client:
+        conv_id = await create_conversation(client)
+    set_conv_id(chat_id, conv_id)
+    logger.info("New conversation %d for chat %s", conv_id, chat_id)
+    await update.message.reply_text("New conversation started.")
+
+
+async def handle_message(update: Update, context) -> None:
+    """Handle incoming text message — submit as task to imu."""
+    chat_id = str(update.effective_chat.id)
+    text = update.message.text
+    if not text:
+        return
+
+    logger.info("Message from chat %s: %s", chat_id, text[:100])
+
+    # Show typing indicator
+    await update.effective_chat.send_action(ChatAction.TYPING)
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        conv_id = await get_or_create_conversation(client, chat_id)
+
+        try:
+            result = await submit_task(client, conv_id, text)
+        except httpx.HTTPStatusError as exc:
+            logger.error("Task submission failed: %s", exc)
+            await update.message.reply_text(
+                "Failed to submit task. Is StrawPot GUI running?"
+            )
+            return
+
+        if result.get("queued"):
+            await update.message.reply_text(
+                "Queued — will run after the current session finishes."
+            )
+            return
+
+        run_id = result.get("run_id")
+        if not run_id:
+            await update.message.reply_text("Task submitted.")
+            return
+
+        # Acknowledge
+        ack = await update.message.reply_text("On it...")
+
+    # Wait for session to complete
+    await wait_for_session_ws(run_id)
+
+    # Fetch and send the summary
+    async with httpx.AsyncClient(timeout=30) as client:
+        summary = await get_session_summary(client, conv_id, run_id)
+
+    # Delete the "On it..." message
+    try:
+        await ack.delete()
+    except Exception:
+        pass
+
+    for chunk in chunk_message(summary):
+        await update.message.reply_text(chunk)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    logger.info("Starting Telegram adapter")
+    logger.info("API URL: %s", API_URL)
+
+    app = Application.builder().token(BOT_TOKEN).build()
+    app.add_handler(CommandHandler("start", cmd_start))
+    app.add_handler(CommandHandler("new", cmd_new))
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
+
+    # Graceful shutdown on SIGTERM (sent by StrawPot GUI)
+    def handle_sigterm(signum, frame):
+        logger.info("Received SIGTERM, shutting down...")
+        app.stop_running()
+
+    signal.signal(signal.SIGTERM, handle_sigterm)
+
+    logger.info("Bot is running — polling for updates")
+    app.run_polling(drop_pending_updates=True)
+    logger.info("Bot stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/telegram/requirements.txt
+++ b/integrations/telegram/requirements.txt
@@ -1,0 +1,3 @@
+python-telegram-bot>=21.0,<22
+httpx>=0.27,<1
+websockets>=13.0,<14


### PR DESCRIPTION
## Summary
- **Reference Telegram adapter** (`integrations/telegram/`) — standalone process that relays messages to imu via REST API
  - WebSocket session monitoring with polling fallback
  - Local SQLite mapping of `chat_id → conversation_id`
  - Chunked replies for Telegram's 4096 char limit
  - `/new` (fresh conversation) and `/start` (welcome) commands
  - Graceful SIGTERM shutdown
- **`metadata.strawpot.install`** field added to integration manifest convention (OS-keyed, same pattern as agents) — for future `strawhub install` support
- Updated DESIGN.md manifest example and frontmatter fields table

## Test plan
- [ ] Manual: copy to `~/.strawpot/integrations/telegram/`, install deps, configure bot token, start from GUI
- [ ] Manual: send message to bot, verify imu conversation created and reply received
- [ ] Manual: `/new` resets conversation, `/start` shows welcome
- [ ] Manual: verify graceful shutdown on Stop from GUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)