### PR TITLE
Add conversation cross-links (DESIGN item 10)

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -193,21 +193,32 @@ export interface ConversationSession {
   chat_messages?: ChatMessage[];
 }
 
+export interface ConversationLink {
+  id: number;
+  project_id: number;
+  title: string | null;
+  project_name: string;
+}
+
 export interface Conversation {
   id: number;
   project_id: number;
   title: string | null;
+  parent_conversation_id: number | null;
   created_at: string;
   updated_at: string | null;
   pending_task: string | null;
   sessions: ConversationSession[];
   has_more: boolean;
+  parent: ConversationLink | null;
+  children: ConversationLink[];
 }
 
 export interface ConversationListItem {
   id: number;
   project_id: number;
   title: string | null;
+  parent_conversation_id: number | null;
   created_at: string;
   updated_at: string | null;
   session_count: number;
@@ -232,6 +243,7 @@ export interface ImuConversation {
   updated_at: string | null;
   session_count: number;
   active_session_count: number;
+  spawned_count: number;
 }
 
 export interface Schedule {

--- a/gui/frontend/src/hooks/mutations/use-conversations.ts
+++ b/gui/frontend/src/hooks/mutations/use-conversations.ts
@@ -7,6 +7,7 @@ import type { InfiniteData } from "@tanstack/react-query";
 interface CreateConversationBody {
   project_id: number;
   title?: string;
+  parent_conversation_id?: number;
 }
 
 interface SubmitTaskBody {

--- a/gui/frontend/src/pages/ConversationView.tsx
+++ b/gui/frontend/src/pages/ConversationView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useConversationInfinite } from "@/hooks/queries/use-conversations";
 import { useSubmitConversationTask, useRenameConversation, useCancelPendingTask } from "@/hooks/mutations/use-conversations";
@@ -33,7 +33,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { api } from "@/api/client";
 import { queryKeys } from "@/lib/query-keys";
-import { AlertCircle, CheckCircle2, CornerDownLeft, ExternalLink, Loader2, MessageSquare, Paperclip, Settings, Square, Upload, X, XCircle } from "lucide-react";
+import { AlertCircle, ArrowUpRight, BotMessageSquare, CheckCircle2, CornerDownLeft, ExternalLink, Loader2, MessageSquare, Paperclip, Settings, Square, Upload, X, XCircle } from "lucide-react";
 import type { AskUserPending, ChatMessage, ConversationSession, ProjectFile } from "@/api/types";
 import MarkdownContent from "@/components/MarkdownContent";
 
@@ -392,6 +392,39 @@ export default function ConversationView() {
           </span>
         )}
       </div>
+
+      {/* Cross-link: parent conversation */}
+      {conversation?.parent && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/50 rounded px-3 py-1.5 mb-3">
+          <BotMessageSquare className="h-3.5 w-3.5 shrink-0" />
+          <span>Spawned from</span>
+          <Link
+            to={`/imu/${conversation.parent.id}`}
+            className="text-primary hover:underline inline-flex items-center gap-1"
+          >
+            {conversation.parent.title || `imu conversation #${conversation.parent.id}`}
+            <ArrowUpRight className="h-3 w-3" />
+          </Link>
+        </div>
+      )}
+
+      {/* Cross-link: child conversations spawned from this one */}
+      {conversation?.children && conversation.children.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground bg-muted/50 rounded px-3 py-1.5 mb-3">
+          <ExternalLink className="h-3.5 w-3.5 shrink-0" />
+          <span>Delegated to:</span>
+          {conversation.children.map((child) => (
+            <Link
+              key={child.id}
+              to={`/projects/${child.project_id}/conversations/${child.id}`}
+              className="text-primary hover:underline inline-flex items-center gap-1"
+            >
+              {child.project_name}: {child.title || `#${child.id}`}
+              <ArrowUpRight className="h-3 w-3" />
+            </Link>
+          ))}
+        </div>
+      )}
 
       {/* Message list — scrolls within this container */}
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">

--- a/gui/frontend/src/pages/ImuPage.tsx
+++ b/gui/frontend/src/pages/ImuPage.tsx
@@ -1053,6 +1053,11 @@ function ImuHome() {
                         </td>
                         <td className="px-4 py-2 text-muted-foreground">
                           {conv.session_count}
+                          {conv.spawned_count > 0 && (
+                            <span className="ml-1.5 text-xs text-primary" title={`${conv.spawned_count} delegated conversation${conv.spawned_count !== 1 ? "s" : ""}`}>
+                              +{conv.spawned_count}
+                            </span>
+                          )}
                         </td>
                         <td className="px-4 py-2 text-muted-foreground">
                           {conv.updated_at

--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS conversations (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     project_id  INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
     title       TEXT,
+    parent_conversation_id INTEGER REFERENCES conversations(id) ON DELETE SET NULL,
     created_at  TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at  TEXT
 );
@@ -258,6 +259,20 @@ def _migrate(conn: sqlite3.Connection) -> None:
             PRAGMA foreign_keys=ON;
         """)
 
+    # Add parent_conversation_id column to conversations (added 2026-03-15)
+    try:
+        conn.execute(
+            "ALTER TABLE conversations "
+            "ADD COLUMN parent_conversation_id INTEGER REFERENCES conversations(id) ON DELETE SET NULL"
+        )
+    except sqlite3.OperationalError:
+        pass  # Column already exists
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_conversations_parent "
+        "ON conversations(parent_conversation_id)"
+    )
+
     # Migrate conversations table to AUTOINCREMENT to prevent rowid reuse
     # after deletion (added 2026-03-13).
     # IMPORTANT: foreign_keys must be OFF during the table swap, otherwise
@@ -274,14 +289,16 @@ def _migrate(conn: sqlite3.Connection) -> None:
                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
                 project_id  INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
                 title       TEXT,
+                parent_conversation_id INTEGER REFERENCES conversations(id) ON DELETE SET NULL,
                 created_at  TEXT NOT NULL DEFAULT (datetime('now')),
                 updated_at  TEXT,
                 pending_task TEXT
             );
-            INSERT INTO conversations_new SELECT id, project_id, title, created_at, updated_at, pending_task FROM conversations;
+            INSERT INTO conversations_new SELECT id, project_id, title, parent_conversation_id, created_at, updated_at, pending_task FROM conversations;
             DROP TABLE conversations;
             ALTER TABLE conversations_new RENAME TO conversations;
             CREATE INDEX IF NOT EXISTS idx_conversations_project ON conversations(project_id, created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_conversations_parent ON conversations(parent_conversation_id);
             PRAGMA foreign_keys=ON;
         """)
 

--- a/gui/src/strawpot_gui/routers/conversations.py
+++ b/gui/src/strawpot_gui/routers/conversations.py
@@ -23,6 +23,7 @@ router = APIRouter(prefix="/api", tags=["conversations"])
 class ConversationCreate(BaseModel):
     project_id: int
     title: str | None = None
+    parent_conversation_id: int | None = None
 
 
 class ConversationTask(BaseModel):
@@ -302,14 +303,23 @@ def create_conversation(body: ConversationCreate, conn=Depends(get_db_conn)):
     if not project:
         raise HTTPException(404, "Project not found")
 
+    if body.parent_conversation_id is not None:
+        parent = conn.execute(
+            "SELECT id FROM conversations WHERE id = ?",
+            (body.parent_conversation_id,),
+        ).fetchone()
+        if not parent:
+            raise HTTPException(422, "Parent conversation not found")
+
     now = datetime.now(timezone.utc).isoformat()
     cur = conn.execute(
-        "INSERT INTO conversations (project_id, title, created_at) VALUES (?, ?, ?)",
-        (body.project_id, body.title, now),
+        "INSERT INTO conversations (project_id, title, parent_conversation_id, created_at) VALUES (?, ?, ?, ?)",
+        (body.project_id, body.title, body.parent_conversation_id, now),
     )
     conv_id = cur.lastrowid
     row = conn.execute(
-        "SELECT id, project_id, title, created_at, updated_at FROM conversations WHERE id = ?",
+        "SELECT id, project_id, title, parent_conversation_id, created_at, updated_at "
+        "FROM conversations WHERE id = ?",
         (conv_id,),
     ).fetchone()
     return dict(row)
@@ -324,7 +334,7 @@ def get_conversation(
 ):
     """Get a conversation with its paginated sessions (newest page first)."""
     row = conn.execute(
-        "SELECT id, project_id, title, created_at, updated_at, pending_task "
+        "SELECT id, project_id, title, parent_conversation_id, created_at, updated_at, pending_task "
         "FROM conversations WHERE id = ?",
         (conversation_id,),
     ).fetchone()
@@ -373,6 +383,32 @@ def get_conversation(
             d["chat_messages"] = _read_chat_messages(s["session_dir"])
         result["sessions"].append(d)
     result["has_more"] = has_more
+
+    # Parent conversation info
+    if row["parent_conversation_id"]:
+        parent = conn.execute(
+            "SELECT c.id, c.project_id, c.title, p.display_name AS project_name "
+            "FROM conversations c JOIN projects p ON p.id = c.project_id "
+            "WHERE c.id = ?",
+            (row["parent_conversation_id"],),
+        ).fetchone()
+        if parent:
+            result["parent"] = dict(parent)
+        else:
+            result["parent"] = None
+    else:
+        result["parent"] = None
+
+    # Child conversations spawned from this one
+    children = conn.execute(
+        "SELECT c.id, c.project_id, c.title, p.display_name AS project_name "
+        "FROM conversations c JOIN projects p ON p.id = c.project_id "
+        "WHERE c.parent_conversation_id = ? "
+        "ORDER BY c.created_at",
+        (conversation_id,),
+    ).fetchall()
+    result["children"] = [dict(c) for c in children]
+
     return result
 
 
@@ -397,7 +433,8 @@ def list_project_conversations(
 
     offset = (page - 1) * per_page
     rows = conn.execute(
-        """SELECT c.id, c.project_id, c.title, c.created_at, c.updated_at,
+        """SELECT c.id, c.project_id, c.title, c.parent_conversation_id,
+                  c.created_at, c.updated_at,
                   COUNT(s.run_id) AS session_count,
                   MAX(s.started_at) AS last_activity
            FROM conversations c

--- a/gui/src/strawpot_gui/routers/imu.py
+++ b/gui/src/strawpot_gui/routers/imu.py
@@ -20,7 +20,9 @@ def list_imu_conversations(
     rows = conn.execute(
         """SELECT c.id, c.title, c.created_at, c.updated_at,
                   COUNT(s.run_id) AS session_count,
-                  COUNT(CASE WHEN s.status IN ('running', 'starting') THEN 1 END) AS active_session_count
+                  COUNT(CASE WHEN s.status IN ('running', 'starting') THEN 1 END) AS active_session_count,
+                  (SELECT COUNT(*) FROM conversations c2
+                   WHERE c2.parent_conversation_id = c.id) AS spawned_count
            FROM conversations c
            LEFT JOIN sessions s ON s.conversation_id = c.id
            WHERE c.project_id = ?

--- a/gui/tests/test_conversations.py
+++ b/gui/tests/test_conversations.py
@@ -1166,3 +1166,139 @@ class TestChatMessagePersistence:
         assert len(data["sessions"]) == 2
         assert data["sessions"][0]["chat_messages"][0]["text"] == "Question 0"
         assert data["sessions"][1]["chat_messages"][0]["text"] == "Question 1"
+
+
+class TestConversationCrossLinks:
+    """Tests for parent/child conversation linking."""
+
+    def test_create_with_parent_conversation_id(self, client, tmp_path):
+        """Create a conversation with a parent link."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+
+        # Create parent (imu) conversation
+        parent = client.post("/api/imu/conversations").json()
+
+        # Create child with parent_conversation_id
+        resp = client.post("/api/conversations", json={
+            "project_id": pid,
+            "title": "Fix bug",
+            "parent_conversation_id": parent["id"],
+        })
+        assert resp.status_code == 201
+        assert resp.json()["parent_conversation_id"] == parent["id"]
+
+    def test_get_conversation_includes_parent(self, client, tmp_path):
+        """GET conversation returns parent info."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+
+        parent = client.post("/api/imu/conversations").json()
+        child = client.post("/api/conversations", json={
+            "project_id": pid,
+            "parent_conversation_id": parent["id"],
+        }).json()
+
+        data = client.get(f"/api/conversations/{child['id']}").json()
+        assert data["parent"] is not None
+        assert data["parent"]["id"] == parent["id"]
+        assert data["parent"]["project_name"] == "Bot Imu"
+
+    def test_get_conversation_includes_children(self, client, tmp_path):
+        """GET parent conversation returns children."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+
+        parent = client.post("/api/imu/conversations").json()
+        child = client.post("/api/conversations", json={
+            "project_id": pid,
+            "title": "Delegated work",
+            "parent_conversation_id": parent["id"],
+        }).json()
+
+        data = client.get(f"/api/conversations/{parent['id']}").json()
+        assert len(data["children"]) == 1
+        assert data["children"][0]["id"] == child["id"]
+        assert data["children"][0]["title"] == "Delegated work"
+
+    def test_no_parent_returns_null(self, client, tmp_path):
+        """Conversation without parent has parent=null and children=[]."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+
+        data = client.get(f"/api/conversations/{conv['id']}").json()
+        assert data["parent"] is None
+        assert data["children"] == []
+
+    def test_invalid_parent_returns_422(self, client, tmp_path):
+        """Creating with nonexistent parent returns 422."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+
+        resp = client.post("/api/conversations", json={
+            "project_id": pid,
+            "parent_conversation_id": 99999,
+        })
+        assert resp.status_code == 422
+
+    def test_parent_deleted_sets_null(self, client, tmp_path, app):
+        """Deleting parent sets child's parent_conversation_id to NULL."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+
+        parent = client.post("/api/imu/conversations").json()
+        child = client.post("/api/conversations", json={
+            "project_id": pid,
+            "parent_conversation_id": parent["id"],
+        }).json()
+
+        # Delete parent
+        client.delete(f"/api/conversations/{parent['id']}")
+
+        # Child's parent should be null
+        data = client.get(f"/api/conversations/{child['id']}").json()
+        assert data["parent_conversation_id"] is None
+        assert data["parent"] is None
+
+    def test_list_project_conversations_includes_parent_id(self, client, tmp_path):
+        """Project conversation list includes parent_conversation_id."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+
+        parent = client.post("/api/imu/conversations").json()
+        client.post("/api/conversations", json={
+            "project_id": pid,
+            "parent_conversation_id": parent["id"],
+        })
+
+        items = client.get(f"/api/projects/{pid}/conversations").json()["items"]
+        assert len(items) == 1
+        assert items[0]["parent_conversation_id"] == parent["id"]
+
+    def test_imu_list_includes_spawned_count(self, client, tmp_path):
+        """Imu conversation list includes spawned_count."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+
+        parent = client.post("/api/imu/conversations").json()
+        client.post("/api/conversations", json={
+            "project_id": pid,
+            "parent_conversation_id": parent["id"],
+        })
+        client.post("/api/conversations", json={
+            "project_id": pid,
+            "parent_conversation_id": parent["id"],
+        })
+
+        items = client.get("/api/imu/conversations").json()
+        conv = next(c for c in items if c["id"] == parent["id"])
+        assert conv["spawned_count"] == 2


### PR DESCRIPTION
## Summary
- Adds `parent_conversation_id` FK to conversations table for linking imu conversations to the project conversations they spawn
- Backend: DB migration (ALTER TABLE + index), API create/get/list support with parent info and children list
- Frontend: cross-link banners in ConversationView (parent → imu, children → project), spawned count badge in ImuPage
- 8 new tests covering create with parent, get parent/children info, invalid parent 422, ON DELETE SET NULL, and list endpoints

## Test plan
- [x] All 403 GUI tests pass
- [x] Fresh database initializes correctly (column + index created)
- [x] Existing database migrates correctly (ALTER TABLE then CREATE INDEX)
- [ ] Manual: verify cross-link banners render in ConversationView
- [ ] Manual: verify spawned count badge in ImuPage

🤖 Generated with [Claude Code](https://claude.com/claude-code)