### PR TITLE
Add integrations concept page and fill docs gaps

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,6 +58,7 @@
           "strawhub/concepts/roles",
           "strawhub/concepts/agents",
           "strawhub/concepts/memories",
+          "strawhub/concepts/integrations",
           "strawhub/concepts/dependencies",
           "strawhub/cli/commands",
           "strawhub/publishing/guide",

--- a/docs/strawhub/api/reference.mdx
+++ b/docs/strawhub/api/reference.mdx
@@ -218,6 +218,51 @@ DELETE /api/v1/memories/:slug
 
 ---
 
+## Integrations
+
+### List Integrations
+
+```
+GET /api/v1/integrations?limit=50&sort=updated
+```
+
+Same parameters and response shape as List Skills.
+
+### Get Integration Detail
+
+```
+GET /api/v1/integrations/:slug
+```
+
+### Get Integration File
+
+```
+GET /api/v1/integrations/:slug/file?path=INTEGRATION.md
+```
+
+Returns raw file content. `path` defaults to `INTEGRATION.md`.
+
+### Publish Integration
+
+<Note>Requires authentication.</Note>
+
+```
+POST /api/v1/integrations
+Content-Type: multipart/form-data
+```
+
+Same payload as Publish Skill (without `dependencies`). Must include an `INTEGRATION.md` file. Max 100 files, 10 MB each, 50 MB total. Supports binary files.
+
+### Delete Integration
+
+<Note>Requires admin role.</Note>
+
+```
+DELETE /api/v1/integrations/:slug
+```
+
+---
+
 ## Search
 
 ```
@@ -227,7 +272,7 @@ GET /api/v1/search?q=review&kind=all&limit=20
 | Param | Description | Default |
 |-------|-------------|---------|
 | `q` | Search query (required) | — |
-| `kind` | `all`, `skill`, `role`, `agent`, or `memory` | `all` |
+| `kind` | `all`, `skill`, `role`, `agent`, `memory`, or `integration` | `all` |
 | `limit` | Results (1-100) | `20` |
 
 Uses hybrid ranking: vector similarity + lexical matching + popularity boost.
@@ -244,7 +289,7 @@ Uses hybrid ranking: vector similarity + lexical matching + popularity boost.
 POST /api/v1/stars/toggle
 Content-Type: application/json
 
-{ "slug": "git-workflow", "kind": "skill" }  // kind: skill | role | agent | memory
+{ "slug": "git-workflow", "kind": "skill" }  // kind: skill | role | agent | memory | integration
 ```
 
 Returns `{ "starred": true }` or `{ "starred": false }`.

--- a/docs/strawhub/cli/commands.mdx
+++ b/docs/strawhub/cli/commands.mdx
@@ -52,7 +52,7 @@ strawhub install role implementer --global           # global install
 strawhub install skill code-review --save            # save to project file
 strawhub install skill code-review --update          # update to latest
 strawhub install memory dial --global                # memory provider
-strawhub install integration telegram --global       # chat adapter
+strawhub install integration telegram               # chat adapter (always global)
 ```
 
 ### `uninstall`
@@ -63,7 +63,7 @@ Remove a package and clean up orphaned dependencies.
 strawhub uninstall skill <slug> [--version <ver>] [--global] [--save]
 strawhub uninstall role <slug> [--version <ver>] [--global] [--save]
 strawhub uninstall memory <slug> [--version <ver>] [--global] [--save]
-strawhub uninstall integration <slug> [--global]
+strawhub uninstall integration <slug> [--version <ver>]
 ```
 
 ### `update`
@@ -74,6 +74,7 @@ Update packages to their latest versions.
 strawhub update skill <slug> [--global] [--save] [--skip-tools] [--yes]
 strawhub update role <slug> [--global] [--save] [--skip-tools] [--yes]
 strawhub update memory <slug> [--global] [--save]
+strawhub update integration <slug>
 strawhub update --all [--global] [--save] [--skip-tools] [--yes]
 ```
 
@@ -113,6 +114,7 @@ Show package details.
 strawhub info skill <slug> [--file PATH] [--json]
 strawhub info role <slug> [--file PATH] [--json]
 strawhub info memory <slug> [--file PATH] [--json]
+strawhub info integration <slug> [--file PATH] [--json]
 ```
 
 ### `list`

--- a/docs/strawhub/concepts/agents.mdx
+++ b/docs/strawhub/concepts/agents.mdx
@@ -309,15 +309,16 @@ metadata:
 A StrawPot agent wrapper for the my-ai CLI tool.
 ```
 
-## Skills vs Roles vs Agents vs Memories
+## Skills vs Roles vs Agents vs Memories vs Integrations
 
-| | Skills | Roles | Agents | Memories |
-|---|--------|-------|--------|----------|
-| **Purpose** | Reusable instructions | Agent behavior definition | CLI wrapper for an AI tool | Persistent knowledge bank |
-| **File** | `SKILL.md` | `ROLE.md` | `AGENT.md` | `MEMORY.md` |
-| **Can depend on** | Other skills | Skills and roles | System tools | None |
-| **Default agent** | No | Yes | N/A (is the agent) | No |
-| **Env vars** | Yes | No | Yes | No |
-| **Params** | No | No | Yes | No |
-| **Binary files** | No | No | Yes | Yes |
-| **Namespace** | Separate | Separate | Separate | Separate |
+| | Skills | Roles | Agents | Memories | Integrations |
+|---|--------|-------|--------|----------|--------------|
+| **Purpose** | Reusable instructions | Agent behavior definition | CLI wrapper for an AI tool | Persistent knowledge bank | Chat platform adapter |
+| **File** | `SKILL.md` | `ROLE.md` | `AGENT.md` | `MEMORY.md` | `INTEGRATION.md` |
+| **Can depend on** | Other skills | Skills and roles | System tools | None | None |
+| **Default agent** | No | Yes | N/A (is the agent) | No | No |
+| **Env vars** | Yes | No | Yes | No | Yes |
+| **Params** | No | No | Yes | No | No |
+| **Binary files** | No | No | Yes | Yes | Yes |
+| **Scope** | Local or global | Local or global | Local or global | Local or global | Global only |
+| **Namespace** | Separate | Separate | Separate | Separate | Separate |

--- a/docs/strawhub/concepts/integrations.mdx
+++ b/docs/strawhub/concepts/integrations.mdx
@@ -1,0 +1,101 @@
+---
+title: Integrations
+description: Chat platform adapters for StrawPot
+---
+
+An integration is an adapter package that connects StrawPot to an external messaging platform (e.g., Telegram, Slack, Discord). Integrations relay messages between a chat platform and StrawPot via imu, and are managed from the GUI.
+
+## Format
+
+Every integration is a directory containing an `INTEGRATION.md` file with YAML frontmatter and a markdown body:
+
+```yaml
+---
+name: telegram
+description: "Telegram bot adapter for StrawPot"
+metadata:
+  strawpot:
+    entry_point: python adapter.py
+    auto_start: false
+    install:
+      macos: pip install -r requirements.txt
+      linux: pip install -r requirements.txt
+    env:
+      STRAWPOT_BOT_TOKEN:
+        required: true
+        description: Bot API token
+      STRAWPOT_API_URL:
+        required: false
+        description: StrawPot API URL (auto-set by GUI)
+    health_check:
+      endpoint: http://localhost:${port}/health
+      interval_seconds: 30
+---
+
+# Telegram Adapter
+
+Connects a Telegram bot to StrawPot via imu.
+```
+
+### Required Fields
+
+| Field | Description |
+|-------|-------------|
+| `name` | Integration slug (unique identifier) |
+| `description` | One-line summary |
+| `metadata.strawpot.entry_point` | Command to launch the adapter process |
+
+### Optional Fields
+
+| Field | Description |
+|-------|-------------|
+| `metadata.strawpot.auto_start` | Start on GUI launch (default: `false`) |
+| `metadata.strawpot.install` | OS-keyed install commands (run by `strawhub install`) |
+| `metadata.strawpot.env` | Required environment variables |
+| `metadata.strawpot.health_check` | Liveness probe endpoint and interval |
+
+## Scope
+
+Integrations are **always global** — they install to `~/.strawpot/integrations/` (or `$STRAWPOT_HOME/integrations/`). The `--global` flag is not needed or accepted.
+
+```
+~/.strawpot/integrations/
+└── telegram/
+    ├── INTEGRATION.md
+    ├── adapter.py
+    ├── requirements.txt
+    └── .version
+```
+
+## Lifecycle
+
+Integrations are managed through the StrawPot GUI:
+
+1. **Install** — `strawhub install integration telegram` downloads the package globally
+2. **Configure** — Set environment variables (e.g., bot token) in the GUI settings
+3. **Start/Stop** — The GUI launches the `entry_point` command and manages the process
+4. **Health Check** — If configured, the GUI periodically pings the health endpoint
+
+## Dependencies
+
+Integrations are standalone — they have no transitive dependencies on skills, roles, or other packages.
+
+## Supporting Files
+
+An integration directory can contain additional files alongside `INTEGRATION.md`:
+
+- Python scripts, config files, binaries
+- Any file type is allowed (including binaries)
+- Max 100 files, 10 MB each, 50 MB total
+
+## Skills vs Roles vs Agents vs Memories vs Integrations
+
+| | Skills | Roles | Agents | Memories | Integrations |
+|---|--------|-------|--------|----------|--------------|
+| **Purpose** | Reusable instructions | Agent behavior definition | CLI wrapper for an AI tool | Persistent knowledge bank | Chat platform adapter |
+| **File** | `SKILL.md` | `ROLE.md` | `AGENT.md` | `MEMORY.md` | `INTEGRATION.md` |
+| **Can depend on** | Other skills | Skills and roles | System tools | None | None |
+| **Entry point** | None | None | `bin` (compiled) | None | `entry_point` (shell command) |
+| **Managed by** | CLI (session) | CLI (session) | CLI (session) | CLI (session) | GUI (lifecycle) |
+| **Scope** | Local or global | Local or global | Local or global | Local or global | Global only |
+| **Namespace** | Separate | Separate | Separate | Separate | Separate |

--- a/docs/strawhub/concepts/memories.mdx
+++ b/docs/strawhub/concepts/memories.mdx
@@ -19,12 +19,13 @@ A memory directory can contain additional files alongside `MEMORY.md`:
 - Any file type is allowed (including binaries)
 - Max 100 files, 10 MB each, 50 MB total
 
-## Skills vs Roles vs Agents vs Memories
+## Skills vs Roles vs Agents vs Memories vs Integrations
 
-| | Skills | Roles | Agents | Memories |
-|---|--------|-------|--------|----------|
-| **Purpose** | Reusable instructions | Agent behavior definition | CLI wrapper for an AI tool | Persistent knowledge bank |
-| **File** | `SKILL.md` | `ROLE.md` | `AGENT.md` | `MEMORY.md` |
-| **Can depend on** | Other skills | Skills and roles | System tools | None |
-| **Binary files** | No | No | Yes | Yes |
-| **Namespace** | Separate | Separate | Separate | Separate |
+| | Skills | Roles | Agents | Memories | Integrations |
+|---|--------|-------|--------|----------|--------------|
+| **Purpose** | Reusable instructions | Agent behavior definition | CLI wrapper for an AI tool | Persistent knowledge bank | Chat platform adapter |
+| **File** | `SKILL.md` | `ROLE.md` | `AGENT.md` | `MEMORY.md` | `INTEGRATION.md` |
+| **Can depend on** | Other skills | Skills and roles | System tools | None | None |
+| **Binary files** | No | No | Yes | Yes | Yes |
+| **Scope** | Local or global | Local or global | Local or global | Local or global | Global only |
+| **Namespace** | Separate | Separate | Separate | Separate | Separate |

--- a/docs/strawhub/quickstart.mdx
+++ b/docs/strawhub/quickstart.mdx
@@ -35,6 +35,14 @@ strawhub install memory dial
 
 Memory providers are installed to `.strawpot/memory/` and supply agents with context from past sessions.
 
+## Install an Integration
+
+```bash
+strawhub install integration telegram
+```
+
+Integrations are always installed globally to `~/.strawpot/integrations/`. They connect StrawPot to chat platforms and are managed from the GUI.
+
 ## Search the Registry
 
 ```bash
@@ -75,7 +83,7 @@ strawhub init
 
 ## Authentication
 
-To publish skills, roles, and memories, you need an API token:
+To publish skills, roles, memories, and integrations, you need an API token:
 
 1. Sign in at [strawhub.dev](https://strawhub.dev) with GitHub
 2. Go to **Settings > API Tokens** and create a token
@@ -100,5 +108,6 @@ strawpot search "testing"
 - [Skills](/strawhub/concepts/skills) — Understand how skills work
 - [Roles](/strawhub/concepts/roles) — Understand how roles work
 - [Memories](/strawhub/concepts/memories) — Understand how memory providers work
+- [Integrations](/strawhub/concepts/integrations) — Understand how integrations work
 - [CLI Reference](/strawhub/cli/commands) — All available commands
-- [Publishing](/strawhub/publishing/guide) — Publish your own skills, roles, and memories
+- [Publishing](/strawhub/publishing/guide) — Publish your own skills, roles, memories, and integrations


### PR DESCRIPTION
## Summary
- Add **concepts/integrations.mdx** — dedicated concept page with format, scope, lifecycle, and comparison table
- Add integration API endpoints to **api/reference.mdx** (list, detail, file, publish, delete)
- Add "Install an Integration" section to **quickstart.mdx**
- Fix **cli/commands.mdx**: remove `--global` from integration install example, add `update integration` and `info integration`
- Update comparison tables in **agents.mdx** and **memories.mdx** with Integrations column and Scope row
- Add `strawhub/concepts/integrations` to **docs.json** navigation

## Test plan
- [ ] Verify Mintlify renders the new integrations concept page
- [ ] Verify navigation includes the new page between Memories and Dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)