### PR TITLE
Fix integration update failure and show version in list

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -290,6 +290,7 @@ export interface ScheduleRunList {
 
 export interface Integration {
   name: string;
+  version: string | null;
   description: string;
   entry_point: string;
   auto_start: boolean;

--- a/gui/frontend/src/pages/Integrations.tsx
+++ b/gui/frontend/src/pages/Integrations.tsx
@@ -84,6 +84,7 @@ export default function Integrations() {
           <TableHeader>
             <TableRow>
               <TableHead>Name</TableHead>
+              <TableHead>Version</TableHead>
               <TableHead>Description</TableHead>
               <TableHead>Status</TableHead>
             </TableRow>
@@ -99,6 +100,9 @@ export default function Integrations() {
                 }}
               >
                 <TableCell className="font-medium">{integration.name}</TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {integration.version ? `v${integration.version}` : "\u2014"}
+                </TableCell>
                 <TableCell className="max-w-[300px] truncate text-sm text-muted-foreground">
                   {integration.description || "\u2014"}
                 </TableCell>

--- a/gui/src/strawpot_gui/routers/integrations.py
+++ b/gui/src/strawpot_gui/routers/integrations.py
@@ -39,6 +39,17 @@ def parse_integration_manifest(manifest_path: Path) -> tuple[dict, str]:
     return parsed.get("frontmatter", {}), parsed.get("body", "")
 
 
+def _read_version(resource_dir: Path) -> str | None:
+    """Read version from .version file."""
+    version_file = resource_dir / ".version"
+    if version_file.is_file():
+        try:
+            return version_file.read_text(encoding="utf-8").strip() or None
+        except OSError:
+            pass
+    return None
+
+
 def scan_integrations(base_dir: Path) -> list[dict]:
     """Scan ``base_dir/integrations/*/INTEGRATION.md`` for installed integrations."""
     scan_path = base_dir / "integrations"
@@ -58,6 +69,7 @@ def scan_integrations(base_dir: Path) -> list[dict]:
         strawpot_meta = fm.get("metadata", {}).get("strawpot", {})
         items.append({
             "name": fm.get("name", entry.name),
+            "version": _read_version(entry),
             "description": fm.get("description", ""),
             "entry_point": strawpot_meta.get("entry_point", ""),
             "env_schema": strawpot_meta.get("env", {}),
@@ -257,16 +269,32 @@ def _stop_if_running(conn, name: str) -> bool:
     db_state = _get_db_state(conn, name)
     if not db_state or db_state["status"] != "running" or not db_state["pid"]:
         return False
-    if _is_process_alive(db_state["pid"]):
+    pid = db_state["pid"]
+    if _is_process_alive(pid):
         try:
-            os.kill(db_state["pid"], signal.SIGTERM)
+            os.kill(pid, signal.SIGTERM)
         except (ProcessLookupError, OSError):
             pass
+        # Wait for the process to actually exit before proceeding
+        import time
+        for _ in range(50):  # up to 5 seconds
+            if not _is_process_alive(pid):
+                break
+            time.sleep(0.1)
+        else:
+            logger.warning(
+                "Integration '%s' (pid %s) did not exit after SIGTERM, sending SIGKILL",
+                name, pid,
+            )
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
     conn.execute(
         "UPDATE integrations SET status = 'stopped', pid = NULL WHERE name = ?",
         (name,),
     )
-    logger.info("Stopped integration '%s' (pid %s) before mutation", name, db_state["pid"])
+    logger.info("Stopped integration '%s' (pid %s) before mutation", name, pid)
     return True
 
 


### PR DESCRIPTION
## Summary
- **Fix update always failing on first try**: `_stop_if_running` sent SIGTERM but didn't wait for the process to exit — the strawhub update then ran while the old process still held file locks. Now polls for up to 5s, then sends SIGKILL as fallback.
- **Show version in integration list**: Read `.version` file (same pattern as skills/roles in registry.py) and add a Version column to the table.

## Test plan
- [ ] Update a running integration — should succeed on first try
- [ ] Verify version column shows `v1.0.0` (or similar) for installed integrations
- [ ] Verify `—` is shown for integrations without a `.version` file
- [ ] Confirm SIGKILL fallback works if an adapter ignores SIGTERM (edge case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)