### PR TITLE
Add integration_notifications table (DESIGN item 14)

### DIFF
--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -87,6 +87,19 @@ CREATE TABLE IF NOT EXISTS integration_config (
     value            TEXT,
     PRIMARY KEY (integration_name, key)
 );
+
+CREATE TABLE IF NOT EXISTS integration_notifications (
+    id               INTEGER PRIMARY KEY,
+    integration_name TEXT NOT NULL REFERENCES integrations(name) ON DELETE CASCADE,
+    chat_id          TEXT,
+    message          TEXT NOT NULL,
+    created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    delivered_at     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_integration_notifications_pending
+    ON integration_notifications(integration_name, delivered_at)
+    WHERE delivered_at IS NULL;
 """
 
 
@@ -301,6 +314,21 @@ def _migrate(conn: sqlite3.Connection) -> None:
             CREATE INDEX IF NOT EXISTS idx_conversations_parent ON conversations(parent_conversation_id);
             PRAGMA foreign_keys=ON;
         """)
+
+    # Add integration_notifications table (added 2026-03-16)
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS integration_notifications (
+            id               INTEGER PRIMARY KEY,
+            integration_name TEXT NOT NULL REFERENCES integrations(name) ON DELETE CASCADE,
+            chat_id          TEXT,
+            message          TEXT NOT NULL,
+            created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+            delivered_at     TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_integration_notifications_pending
+            ON integration_notifications(integration_name, delivered_at)
+            WHERE delivered_at IS NULL;
+    """)
 
 
 @contextmanager


### PR DESCRIPTION
## Summary
- Adds `integration_notifications` table to both the base schema (new installs) and `_migrate()` (existing installs)
- Columns: `id`, `integration_name`, `chat_id`, `message`, `created_at`, `delivered_at`
- Partial index on pending notifications (`WHERE delivered_at IS NULL`) for efficient adapter polling
- Foundation for items #16-#18 (notify/poll/ack endpoints)

## Test plan
- [x] All 45 existing integration tests pass
- [ ] Fresh DB init creates the table with correct columns and index
- [ ] Existing DB upgrade via `_migrate()` creates the table without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)