### PR TITLE
Add notification API and scheduled_tasks conversation_id (DESIGN items 15-18)

### DIFF
--- a/designs/integration/DESIGN.md
+++ b/designs/integration/DESIGN.md
@@ -997,14 +997,14 @@ posting results back to Telegram groups, Slack channels, etc.
 
 | # | Item | Status |
 |---|------|--------|
-| 14 | Database: `integration_notifications` table | Not started |
-| 15 | Database: `conversation_id` column on `scheduled_tasks` | Not started |
-| 16 | Backend: `POST /api/integrations/:name/notify` endpoint | Not started |
-| 17 | Backend: `GET /api/integrations/:name/notifications` polling endpoint | Not started |
-| 18 | Backend: `POST /api/integrations/:name/notifications/:id/ack` endpoint | Not started |
+| 14 | Database: `integration_notifications` table | Done |
+| 15 | Database: `conversation_id` column on `scheduled_tasks` | Done |
+| 16 | Backend: `POST /api/integrations/:name/notify` endpoint | Done |
+| 17 | Backend: `GET /api/integrations/:name/notifications` polling endpoint | Done |
+| 18 | Backend: `POST /api/integrations/:name/notifications/:id/ack` endpoint | Done |
 | 19 | Scheduler: submit to conversation API when `conversation_id` is set | Not started |
 | 20 | Scheduler: enforce `role=imu` for `project_id=0` schedules | Not started |
 | 21 | Skill: `notify-integration` for agent use | Not started |
-| 22 | Reference adapters: add conversation poller to Telegram/Slack/Discord | Not started |
+| 22 | Reference adapters: add conversation poller to Telegram/Slack/Discord | Done |
 | 23 | Reference adapters: add notification poller to Telegram/Slack/Discord | Not started |
 | 24 | Frontend: schedule UI — conversation targeting + skill selection | Not started |

--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -68,7 +68,8 @@ CREATE TABLE IF NOT EXISTS scheduled_tasks (
     last_run_at     TEXT,
     next_run_at     TEXT,
     last_error      TEXT,
-    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    conversation_id INTEGER REFERENCES conversations(id) ON DELETE SET NULL
 );
 
 CREATE TABLE IF NOT EXISTS integrations (
@@ -259,13 +260,14 @@ def _migrate(conn: sqlite3.Connection) -> None:
                 last_run_at     TEXT,
                 next_run_at     TEXT,
                 last_error      TEXT,
-                created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+                created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+                conversation_id INTEGER REFERENCES conversations(id) ON DELETE SET NULL
             );
             INSERT INTO scheduled_tasks_new
                 SELECT id, name, project_id, role, task, cron_expr,
                        schedule_type, run_at, enabled, system_prompt,
                        skip_if_running, last_run_at, next_run_at,
-                       last_error, created_at
+                       last_error, created_at, NULL
                 FROM scheduled_tasks;
             DROP TABLE scheduled_tasks;
             ALTER TABLE scheduled_tasks_new RENAME TO scheduled_tasks;
@@ -314,6 +316,15 @@ def _migrate(conn: sqlite3.Connection) -> None:
             CREATE INDEX IF NOT EXISTS idx_conversations_parent ON conversations(parent_conversation_id);
             PRAGMA foreign_keys=ON;
         """)
+
+    # Add conversation_id column to scheduled_tasks (added 2026-03-16)
+    try:
+        conn.execute(
+            "ALTER TABLE scheduled_tasks "
+            "ADD COLUMN conversation_id INTEGER REFERENCES conversations(id) ON DELETE SET NULL"
+        )
+    except sqlite3.OperationalError:
+        pass  # Column already exists
 
     # Add integration_notifications table (added 2026-03-16)
     conn.executescript("""

--- a/gui/src/strawpot_gui/routers/integrations.py
+++ b/gui/src/strawpot_gui/routers/integrations.py
@@ -287,6 +287,52 @@ def notify_integration(
     return {"id": notification_id, "integration_name": name, "status": "pending"}
 
 
+@router.get("/{name}/notifications")
+def list_notifications(name: str, conn=Depends(get_db_conn)):
+    """Return pending (undelivered) notifications for an integration.
+
+    Adapters poll this endpoint to discover messages they need to deliver.
+    """
+    home = get_strawpot_home()
+    manifest_path = home / "integrations" / name / MANIFEST
+    if not manifest_path.is_file():
+        raise HTTPException(404, f"Integration not found: {name}")
+
+    rows = conn.execute(
+        "SELECT id, chat_id, message, created_at "
+        "FROM integration_notifications "
+        "WHERE integration_name = ? AND delivered_at IS NULL "
+        "ORDER BY id",
+        (name,),
+    ).fetchall()
+
+    return [dict(r) for r in rows]
+
+
+@router.post("/{name}/notifications/{notification_id}/ack")
+def ack_notification(
+    name: str, notification_id: int, conn=Depends(get_db_conn)
+):
+    """Mark a notification as delivered.
+
+    Adapters call this after successfully sending the message to the platform.
+    """
+    row = conn.execute(
+        "SELECT id FROM integration_notifications "
+        "WHERE id = ? AND integration_name = ?",
+        (notification_id, name),
+    ).fetchone()
+    if row is None:
+        raise HTTPException(404, "Notification not found")
+
+    conn.execute(
+        "UPDATE integration_notifications SET delivered_at = datetime('now') "
+        "WHERE id = ?",
+        (notification_id,),
+    )
+    return {"ok": True}
+
+
 # ---------------------------------------------------------------------------
 # Install / Uninstall via Strawhub
 # ---------------------------------------------------------------------------

--- a/gui/tests/test_integrations_api.py
+++ b/gui/tests/test_integrations_api.py
@@ -661,6 +661,111 @@ class TestNotify:
         assert r1.json()["id"] != r2.json()["id"]
 
 
+class TestListNotifications:
+    def test_list_pending(self, client, home):
+        _create_integration(home, "telegram")
+        client.post(
+            "/api/integrations/telegram/notify",
+            json={"message": "Hello"},
+        )
+        client.post(
+            "/api/integrations/telegram/notify",
+            json={"message": "World", "chat_id": "99"},
+        )
+        resp = client.get("/api/integrations/telegram/notifications")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["message"] == "Hello"
+        assert data[0]["chat_id"] is None
+        assert data[1]["message"] == "World"
+        assert data[1]["chat_id"] == "99"
+
+    def test_list_empty(self, client, home):
+        _create_integration(home, "telegram")
+        resp = client.get("/api/integrations/telegram/notifications")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_excludes_delivered(self, client, home):
+        """Notifications marked as delivered are not returned."""
+        _create_integration(home, "telegram")
+        r = client.post(
+            "/api/integrations/telegram/notify",
+            json={"message": "Delivered one"},
+        )
+        nid = r.json()["id"]
+        # Manually mark as delivered
+        from strawpot_gui.db import get_db
+        db_path = client.app.state.db_path
+        with get_db(db_path) as conn:
+            conn.execute(
+                "UPDATE integration_notifications SET delivered_at = datetime('now') "
+                "WHERE id = ?",
+                (nid,),
+            )
+        resp = client.get("/api/integrations/telegram/notifications")
+        assert resp.json() == []
+
+    def test_list_not_found(self, client, home):
+        resp = client.get("/api/integrations/nonexistent/notifications")
+        assert resp.status_code == 404
+
+    def test_list_ordered_by_id(self, client, home):
+        _create_integration(home, "telegram")
+        client.post("/api/integrations/telegram/notify", json={"message": "A"})
+        client.post("/api/integrations/telegram/notify", json={"message": "B"})
+        client.post("/api/integrations/telegram/notify", json={"message": "C"})
+        data = client.get("/api/integrations/telegram/notifications").json()
+        assert [n["message"] for n in data] == ["A", "B", "C"]
+        assert data[0]["id"] < data[1]["id"] < data[2]["id"]
+
+
+class TestAckNotification:
+    def test_ack_marks_delivered(self, client, home):
+        _create_integration(home, "telegram")
+        r = client.post(
+            "/api/integrations/telegram/notify",
+            json={"message": "To deliver"},
+        )
+        nid = r.json()["id"]
+        resp = client.post(f"/api/integrations/telegram/notifications/{nid}/ack")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        # Should no longer appear in pending list
+        pending = client.get("/api/integrations/telegram/notifications").json()
+        assert len(pending) == 0
+
+    def test_ack_not_found(self, client, home):
+        _create_integration(home, "telegram")
+        resp = client.post("/api/integrations/telegram/notifications/999/ack")
+        assert resp.status_code == 404
+
+    def test_ack_wrong_integration(self, client, home):
+        """ACK with mismatched integration name returns 404."""
+        _create_integration(home, "telegram")
+        _create_integration(home, "slack")
+        r = client.post(
+            "/api/integrations/telegram/notify",
+            json={"message": "For telegram"},
+        )
+        nid = r.json()["id"]
+        resp = client.post(f"/api/integrations/slack/notifications/{nid}/ack")
+        assert resp.status_code == 404
+
+    def test_ack_idempotent(self, client, home):
+        """ACKing an already-delivered notification succeeds."""
+        _create_integration(home, "telegram")
+        r = client.post(
+            "/api/integrations/telegram/notify",
+            json={"message": "Double ack"},
+        )
+        nid = r.json()["id"]
+        client.post(f"/api/integrations/telegram/notifications/{nid}/ack")
+        resp = client.post(f"/api/integrations/telegram/notifications/{nid}/ack")
+        assert resp.status_code == 200
+
+
 class TestManifestParsing:
     def test_scan_skips_dir_without_manifest(self, client, home):
         """Directories without INTEGRATION.md are silently skipped."""

--- a/gui/tests/test_integrations_db.py
+++ b/gui/tests/test_integrations_db.py
@@ -71,3 +71,48 @@ class TestIntegrationTables:
                 ("telegram",),
             ).fetchone()
         assert count["cnt"] == 0
+
+
+class TestScheduledTasksConversationId:
+    """Verify conversation_id column on scheduled_tasks."""
+
+    def test_conversation_id_column_exists(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        init_db(db_path)
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO projects (id, display_name, working_dir) "
+                "VALUES (1, 'test', '/tmp/test')"
+            )
+            conn.execute(
+                "INSERT INTO conversations (id, project_id) VALUES (10, 1)"
+            )
+            conn.execute(
+                "INSERT INTO scheduled_tasks (name, project_id, task, conversation_id) "
+                "VALUES (?, 1, 'do stuff', ?)",
+                ("test-schedule", 10),
+            )
+            row = conn.execute(
+                "SELECT conversation_id FROM scheduled_tasks WHERE name = ?",
+                ("test-schedule",),
+            ).fetchone()
+        assert row["conversation_id"] == 10
+
+    def test_conversation_id_nullable(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        init_db(db_path)
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO projects (id, display_name, working_dir) "
+                "VALUES (1, 'test', '/tmp/test')"
+            )
+            conn.execute(
+                "INSERT INTO scheduled_tasks (name, project_id, task) "
+                "VALUES (?, 1, 'do stuff')",
+                ("test-schedule",),
+            )
+            row = conn.execute(
+                "SELECT conversation_id FROM scheduled_tasks WHERE name = ?",
+                ("test-schedule",),
+            ).fetchone()
+        assert row["conversation_id"] is None


### PR DESCRIPTION
## Summary
- `POST /api/integrations/{name}/notify` — agents/skills push notifications to adapters
- `GET /api/integrations/{name}/notifications` — adapters poll for pending (undelivered) notifications
- `POST /api/integrations/{name}/notifications/{id}/ack` — adapters mark notifications as delivered
- `conversation_id` column on `scheduled_tasks` (schema + migration + table rebuild path)
- DESIGN.md: mark items 14-18 and 22 as Done

## Test plan
- [x] 65 integration tests pass (15 new: 6 notify, 5 list, 4 ack)
- [x] 15 scheduler tests pass (no regressions from conversation_id column)
- [x] DB tests: cascade delete, conversation_id exists/nullable

🤖 Generated with [Claude Code](https://claude.com/claude-code)