### PR TITLE
Add scheduler conversation targeting + imu role enforcement

### DIFF
--- a/designs/integration/DESIGN.md
+++ b/designs/integration/DESIGN.md
@@ -936,6 +936,116 @@ runtime behavior, not a declared capability.
 
 ---
 
+## Conversation Source Tracking
+
+Conversations created by adapters, the scheduler, or the GUI are
+visually indistinguishable. Adding a `source` column to conversations
+lets the GUI show platform icons and labels so users can see where a
+conversation originated.
+
+### Database Changes
+
+```sql
+ALTER TABLE conversations ADD COLUMN source TEXT;       -- NULL=gui, "telegram", "slack", "scheduler", etc.
+ALTER TABLE conversations ADD COLUMN source_meta TEXT;   -- JSON, platform-specific context
+```
+
+`source` is a short slug used for icon selection. `source_meta` is
+freeform JSON carrying platform-specific details the GUI can display.
+
+| source | source_meta example | GUI display |
+|--------|-------------------|-------------|
+| `NULL` | — | (no badge — default GUI conversation) |
+| `"telegram"` | `{"chat_id": "-100123", "chat_title": "Engineering"}` | Telegram icon + "Engineering" |
+| `"slack"` | `{"channel_id": "C0123", "channel_name": "#ops", "thread_ts": "1234.5678"}` | Slack icon + "#ops" |
+| `"discord"` | `{"channel_id": "98765", "guild_name": "My Server"}` | Discord icon + "My Server" |
+| `"scheduler"` | `{"schedule_id": 7, "schedule_name": "daily-report"}` | Clock icon + "daily-report" |
+
+### Who Sets It
+
+- **Adapters** pass `source` and `source_meta` when creating
+  conversations via `POST /api/imu/conversations`. The adapter knows
+  its own name and the platform context (chat title, channel name).
+- **Scheduler** sets `source: "scheduler"` when creating a new
+  conversation for a schedule (conversation targeting).
+- **GUI** leaves `source` as NULL (the default).
+
+### API Changes
+
+`POST /api/imu/conversations` accepts two new optional fields:
+
+```json
+{
+  "source": "telegram",
+  "source_meta": {"chat_id": "-100123", "chat_title": "Engineering"}
+}
+```
+
+`GET /api/conversations/:id` and list endpoints include `source` and
+`source_meta` in their response.
+
+### Frontend Display
+
+- **Conversation list:** Small platform icon next to the title.
+  Telegram paper plane, Slack hash, Discord controller, clock for
+  scheduler. No icon when `source` is NULL.
+- **Conversation header:** Subtitle line: "via Telegram / Engineering"
+  or "via Slack / #ops". Derived from `source` + `source_meta`.
+- **imu conversations page:** Source badge in the table row, making it
+  easy to see which conversations came from which platform.
+
+### Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Two columns (`source` + `source_meta`) instead of one | `source` is a fixed enum for icon/badge logic. `source_meta` is freeform JSON for display labels. Keeps queries simple while allowing platform-specific detail. |
+| `source_meta` is JSON TEXT, not separate columns | Each platform has different context. A rigid schema would require migrations for every new platform. JSON is read-only display data — never queried. |
+| Set at conversation creation, immutable | A conversation's origin doesn't change. Even if multiple sources submit tasks to it later, it was *started* from one place. |
+| NULL means GUI | Most conversations are GUI-originated. NULL as default avoids backfilling existing data. |
+
+### Lifecycle: Deletion and Orphaning
+
+`source` is a display hint, not a foreign key. No cascade behavior
+is needed — conversations and integrations are independent resources
+that reference each other loosely.
+
+**Conversation deleted, adapter still running:**
+
+The adapter's local mapping (`chat_id → conversation_id`) now points
+to a stale ID. When the adapter next submits a task, the API returns
+404. The adapter handles this by creating a new conversation and
+updating its local mapping. This is adapter-side logic — no GUI
+changes needed. Adapters should treat 404 on task submission as
+"conversation gone, create a new one."
+
+**Adapter uninstalled, conversations remain:**
+
+Conversations with `source="telegram"` are preserved as historical
+records. The GUI shows a dimmed or generic icon when the referenced
+integration is not installed. Conversations remain fully functional —
+browsable, searchable, and can receive tasks from the GUI or other
+sources. `source_meta` retains its value (chat title, channel name)
+for display context even after the adapter is gone.
+
+**Adapter reinstalled:**
+
+The adapter creates new conversations by default. However, its
+persistent mapping in `STRAWPOT_DATA_DIR` (which survives reinstalls)
+may still reference old conversation IDs. If those conversations
+exist, the adapter reconnects to them naturally. If they were deleted,
+the adapter gets 404 and creates new ones (see above).
+
+**Summary:**
+
+| Scenario | Conversation | Adapter |
+|----------|-------------|---------|
+| Conversation deleted | Gone | Gets 404, creates new conversation |
+| Adapter uninstalled | Preserved, dimmed icon | Gone |
+| Adapter reinstalled | Old ones preserved | Reconnects via persisted mapping or creates new |
+| Both deleted | Nothing to clean up | Nothing to clean up |
+
+---
+
 ## Not Planned
 
 | Feature | Reason |
@@ -1002,9 +1112,25 @@ posting results back to Telegram groups, Slack channels, etc.
 | 16 | Backend: `POST /api/integrations/:name/notify` endpoint | Done |
 | 17 | Backend: `GET /api/integrations/:name/notifications` polling endpoint | Done |
 | 18 | Backend: `POST /api/integrations/:name/notifications/:id/ack` endpoint | Done |
-| 19 | Scheduler: submit to conversation API when `conversation_id` is set | Not started |
-| 20 | Scheduler: enforce `role=imu` for `project_id=0` schedules | Not started |
+| 19 | Scheduler: submit to conversation API when `conversation_id` is set | Done |
+| 20 | Scheduler: enforce `role=imu` for `project_id=0` schedules | Done |
 | 21 | Skill: `notify-integration` for agent use | Not started |
 | 22 | Reference adapters: add conversation poller to Telegram/Slack/Discord | Done |
 | 23 | Reference adapters: add notification poller to Telegram/Slack/Discord | Not started |
 | 24 | Frontend: schedule UI — conversation targeting + skill selection | Not started |
+
+**Phase 5 — Conversation source tracking**
+
+Visual indicators showing where a conversation originated (Telegram,
+Slack, scheduler, etc.). Platform icons and labels in the conversation
+list and header.
+
+| # | Item | Status |
+|---|------|--------|
+| 25 | Database: `source` + `source_meta` columns on `conversations` | Not started |
+| 26 | Backend: accept `source`/`source_meta` in `POST /api/imu/conversations` | Not started |
+| 27 | Backend: include `source`/`source_meta` in conversation list/detail responses | Not started |
+| 28 | Backend: scheduler sets `source="scheduler"` when creating conversations | Not started |
+| 29 | Frontend: platform icon badges in conversation list | Not started |
+| 30 | Frontend: "via Platform / label" subtitle in conversation header | Not started |
+| 31 | Reference adapters: pass `source`/`source_meta` when creating conversations | Not started |

--- a/gui/src/strawpot_gui/scheduler.py
+++ b/gui/src/strawpot_gui/scheduler.py
@@ -120,14 +120,53 @@ class Scheduler:
         """Fire a single scheduled task."""
         schedule_id = schedule["id"]
         name = schedule["name"]
+        project_id = schedule["project_id"]
+
+        # #20 — enforce imu role for project 0 (strawpot-internal)
+        role = schedule["role"] or ("imu" if project_id == 0 else None)
+
+        task = schedule["task"]
+        conversation_id = schedule.get("conversation_id")
+
+        # #19 — conversation targeting: build context from prior turns
+        kwargs: dict = {}
+        if conversation_id:
+            from strawpot_gui.routers.conversations import (
+                _build_conversation_context,
+                _write_conversation_history,
+            )
+
+            conv = conn.execute(
+                "SELECT id, project_id FROM conversations WHERE id = ?",
+                (conversation_id,),
+            ).fetchone()
+            if conv:
+                project_row = conn.execute(
+                    "SELECT working_dir FROM projects WHERE id = ?",
+                    (project_id,),
+                ).fetchone()
+                hist_path = None
+                if project_row and project_row["working_dir"]:
+                    hist_path = _write_conversation_history(
+                        conn, conversation_id, project_row["working_dir"]
+                    )
+                context = _build_conversation_context(
+                    conn, conversation_id, history_path=hist_path
+                )
+                if context:
+                    kwargs["user_task"] = task
+                    task = f"{context}\n\n---\n\n{task}"
+                kwargs["conversation_id"] = conversation_id
+
         try:
             run_id = self._launch_fn(
                 conn,
-                schedule["project_id"],
-                schedule["task"],
-                role=schedule["role"],
+                project_id,
+                task,
+                role=role,
                 system_prompt=schedule["system_prompt"],
                 schedule_id=schedule_id,
+                **kwargs,
             )
             if schedule.get("schedule_type") == "one_time":
                 # One-time: auto-disable after firing

--- a/gui/tests/test_scheduler.py
+++ b/gui/tests/test_scheduler.py
@@ -42,14 +42,15 @@ def _insert_schedule(db_path, project_id, **kwargs):
         "enabled": 1,
         "skip_if_running": 1,
         "next_run_at": None,
+        "conversation_id": None,
     }
     defaults.update(kwargs)
     with get_db(db_path) as conn:
         cursor = conn.execute(
             """INSERT INTO scheduled_tasks
                (name, project_id, task, cron_expr, schedule_type, run_at,
-                enabled, skip_if_running, next_run_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                enabled, skip_if_running, next_run_at, conversation_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 defaults["name"],
                 defaults["project_id"],
@@ -60,6 +61,7 @@ def _insert_schedule(db_path, project_id, **kwargs):
                 defaults["enabled"],
                 defaults["skip_if_running"],
                 defaults["next_run_at"],
+                defaults["conversation_id"],
             ),
         )
         return cursor.lastrowid
@@ -320,3 +322,140 @@ class TestOneTimeScheduleFire:
             ).fetchone()
         # next_run_at should be unchanged (not cleared or advanced)
         assert row["next_run_at"] == past
+
+
+# ---------------------------------------------------------------------------
+# #20 — imu role enforcement for project_id == 0
+# ---------------------------------------------------------------------------
+
+
+class TestImuRoleEnforcement:
+    def test_imu_role_for_project_zero(self, db_path):
+        """Schedules with project_id=0 and no explicit role get role='imu'."""
+        # Insert project 0 (strawpot-internal)
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO projects (id, display_name, working_dir) "
+                "VALUES (0, 'strawpot', '/tmp/strawpot')"
+            )
+        sid = _insert_schedule(db_path, 0, next_run_at="2000-01-01T00:00:00+00:00")
+
+        launch_fn = MagicMock(return_value="run-imu")
+        scheduler = Scheduler(db_path, launch_fn)
+        scheduler._check_and_fire()
+
+        assert launch_fn.called
+        assert launch_fn.call_args[1]["role"] == "imu"
+
+    def test_explicit_role_preserved_for_project_zero(self, db_path):
+        """An explicit role on a project-0 schedule is kept (not overridden)."""
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO projects (id, display_name, working_dir) "
+                "VALUES (0, 'strawpot', '/tmp/strawpot')"
+            )
+        # Manually set role via direct SQL since _insert_schedule doesn't set role
+        sid = _insert_schedule(db_path, 0, next_run_at="2000-01-01T00:00:00+00:00")
+        with get_db(db_path) as conn:
+            conn.execute(
+                "UPDATE scheduled_tasks SET role = 'custom' WHERE id = ?", (sid,)
+            )
+
+        launch_fn = MagicMock(return_value="run-custom")
+        scheduler = Scheduler(db_path, launch_fn)
+        scheduler._check_and_fire()
+
+        assert launch_fn.called
+        assert launch_fn.call_args[1]["role"] == "custom"
+
+    def test_no_imu_for_regular_project(self, db_path, project_id):
+        """Non-zero project_id without explicit role keeps role=None."""
+        past = "2000-01-01T00:00:00+00:00"
+        _insert_schedule(db_path, project_id, next_run_at=past)
+
+        launch_fn = MagicMock(return_value="run-123")
+        scheduler = Scheduler(db_path, launch_fn)
+        scheduler._check_and_fire()
+
+        assert launch_fn.called
+        assert launch_fn.call_args[1]["role"] is None
+
+
+# ---------------------------------------------------------------------------
+# #19 — conversation targeting
+# ---------------------------------------------------------------------------
+
+
+class TestConversationTargeting:
+    def _setup_conversation(self, db_path, project_id):
+        """Create a conversation and return its id."""
+        with get_db(db_path) as conn:
+            cursor = conn.execute(
+                "INSERT INTO conversations (project_id) VALUES (?)",
+                (project_id,),
+            )
+            return cursor.lastrowid
+
+    def test_passes_conversation_id_to_launch(self, db_path, project_id):
+        """When conversation_id is set, it's forwarded to launch_fn."""
+        conv_id = self._setup_conversation(db_path, project_id)
+        past = "2000-01-01T00:00:00+00:00"
+        _insert_schedule(
+            db_path, project_id,
+            next_run_at=past,
+            conversation_id=conv_id,
+        )
+
+        launch_fn = MagicMock(return_value="run-conv")
+        scheduler = Scheduler(db_path, launch_fn)
+        scheduler._check_and_fire()
+
+        assert launch_fn.called
+        assert launch_fn.call_args[1]["conversation_id"] == conv_id
+
+    def test_no_conversation_id_by_default(self, db_path, project_id):
+        """Without conversation_id, launch_fn is called without it."""
+        past = "2000-01-01T00:00:00+00:00"
+        _insert_schedule(db_path, project_id, next_run_at=past)
+
+        launch_fn = MagicMock(return_value="run-plain")
+        scheduler = Scheduler(db_path, launch_fn)
+        scheduler._check_and_fire()
+
+        assert launch_fn.called
+        assert "conversation_id" not in launch_fn.call_args[1]
+
+    def test_conversation_context_prepended(self, db_path, project_id):
+        """When conversation has prior sessions, context is prepended to task."""
+        conv_id = self._setup_conversation(db_path, project_id)
+        past = "2000-01-01T00:00:00+00:00"
+
+        # Add a completed session to the conversation
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO sessions "
+                "(run_id, project_id, conversation_id, status, role, runtime, "
+                " isolation, started_at, session_dir, task, summary, exit_code) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                ("run-prior", project_id, conv_id, "completed",
+                 "test", "test", "none", "2025-01-01T00:00:00", "/tmp",
+                 "earlier task", "did stuff", 0),
+            )
+
+        _insert_schedule(
+            db_path, project_id,
+            next_run_at=past,
+            conversation_id=conv_id,
+        )
+
+        launch_fn = MagicMock(return_value="run-ctx")
+        scheduler = Scheduler(db_path, launch_fn)
+        scheduler._check_and_fire()
+
+        assert launch_fn.called
+        # Task should have context prepended
+        task_arg = launch_fn.call_args[0][2]
+        assert "Prior Conversation" in task_arg
+        assert "run tests" in task_arg
+        # user_task should be the original task
+        assert launch_fn.call_args[1]["user_task"] == "run tests"


### PR DESCRIPTION
## Summary
- **#19**: Scheduler `_fire()` now builds conversation context and passes `conversation_id` to `launch_fn` when a schedule targets a conversation. Reuses `_build_conversation_context` and `_write_conversation_history` from conversations router.
- **#20**: Scheduler enforces `role=imu` for `project_id=0` schedules (matching conversations router behavior). Explicit roles are preserved.
- **Phase 5 design**: Adds "Conversation Source Tracking" section — `source` + `source_meta` columns on conversations for platform icon badges and labels, with lifecycle/orphaning semantics (#25-#31).

## Test plan
- [x] 3 new tests for imu role enforcement (project 0 gets imu, explicit role preserved, regular projects unaffected)
- [x] 3 new tests for conversation targeting (conversation_id forwarded, not present by default, context prepended with prior sessions)
- [x] All 443 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)