### PR TITLE
Replace pending_task with FIFO conversation task queue

### DIFF
--- a/designs/integration/DESIGN.md
+++ b/designs/integration/DESIGN.md
@@ -1129,7 +1129,23 @@ posting results back to Telegram groups, Slack channels, etc.
 | 23 | Reference adapters: add notification poller to Telegram/Slack/Discord | Done |
 | 24 | Frontend: schedule UI — conversation targeting + Imu project support | Done |
 
-**Phase 5 — Conversation source tracking**
+**Phase 5 — Task queue with source tracking**
+
+Replace `pending_task` string concatenation with a proper task queue.
+Each submitted task is a separate record with source attribution, drained
+one at a time (FIFO). Fixes task merging, parameter loss on drain,
+scheduler concurrency, and enables per-source response routing.
+
+| # | Item | Status |
+|---|------|--------|
+| 25 | Database: `conversation_task_queue` table | Done |
+| 26 | Backend: task submission inserts into queue (atomic, no TOCTOU) | Done |
+| 27 | Backend: drain mechanism pops one task at a time (preserves all parameters) | Done |
+| 28 | Backend: scheduler queues when active session on conversation | Done |
+| 29 | Backend: individual + bulk task cancellation endpoints | Done |
+| 30 | Frontend: render `queued_tasks` with source badges + per-task cancel | Done |
+
+**Phase 6 — Conversation source tracking**
 
 Visual indicators showing where a conversation originated (Telegram,
 Slack, scheduler, etc.). Platform icons and labels in the conversation
@@ -1137,10 +1153,10 @@ list and header.
 
 | # | Item | Status |
 |---|------|--------|
-| 25 | Database: `source` + `source_meta` columns on `conversations` | Not started |
-| 26 | Backend: accept `source`/`source_meta` in `POST /api/imu/conversations` | Not started |
-| 27 | Backend: include `source`/`source_meta` in conversation list/detail responses | Not started |
-| 28 | Backend: scheduler sets `source="scheduler"` when creating conversations | Not started |
-| 29 | Frontend: platform icon badges in conversation list | Not started |
-| 30 | Frontend: "via Platform / label" subtitle in conversation header | Not started |
-| 31 | Reference adapters: pass `source`/`source_meta` when creating conversations | Not started |
+| 31 | Database: `source` + `source_meta` columns on `conversations` | Not started |
+| 32 | Backend: accept `source`/`source_meta` in `POST /api/imu/conversations` | Not started |
+| 33 | Backend: include `source`/`source_meta` in conversation list/detail responses | Not started |
+| 34 | Backend: scheduler sets `source="scheduler"` when creating conversations | Not started |
+| 35 | Frontend: platform icon badges in conversation list | Not started |
+| 36 | Frontend: "via Platform / label" subtitle in conversation header | Not started |
+| 37 | Reference adapters: pass `source`/`source_meta` when creating conversations | Not started |

--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -200,6 +200,14 @@ export interface ConversationLink {
   project_name: string;
 }
 
+export interface QueuedTask {
+  id: number;
+  task: string;
+  source: string;
+  source_id: string | null;
+  created_at: string;
+}
+
 export interface Conversation {
   id: number;
   project_id: number;
@@ -208,6 +216,7 @@ export interface Conversation {
   created_at: string;
   updated_at: string | null;
   pending_task: string | null;
+  queued_tasks: QueuedTask[];
   sessions: ConversationSession[];
   has_more: boolean;
   parent: ConversationLink | null;

--- a/gui/frontend/src/hooks/mutations/use-conversations.ts
+++ b/gui/frontend/src/hooks/mutations/use-conversations.ts
@@ -47,18 +47,26 @@ export function useSubmitConversationTask(conversationId: number) {
       ),
     onSuccess: (data, variables) => {
       if (data.queued) {
-        // Optimistically append to pending_task in the infinite query cache
+        // Optimistically append to queued_tasks in the infinite query cache
         qc.setQueryData<InfiniteData<Conversation>>(
           queryKeys.conversations.detail(conversationId),
           (old) => {
             if (!old) return old;
             const pages = old.pages.map((page, i) => {
               if (i !== old.pages.length - 1) return page;
-              const existing = page.pending_task || "";
-              const newPending = existing
-                ? `${existing}\n\n${variables.task}`
-                : variables.task;
-              return { ...page, pending_task: newPending };
+              const newTask = {
+                id: -Date.now(), // temporary ID until refetch
+                task: variables.task,
+                source: "user",
+                source_id: null,
+                created_at: new Date().toISOString(),
+              };
+              const queued = [...(page.queued_tasks ?? []), newTask];
+              return {
+                ...page,
+                queued_tasks: queued,
+                pending_task: queued.map((q) => q.task).join("\n\n") || null,
+              };
             });
             return { ...old, pages };
           },
@@ -90,6 +98,19 @@ export function useCancelPendingTask(conversationId: number) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () => api.delete(`/conversations/${conversationId}/pending_task`),
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: queryKeys.conversations.detail(conversationId),
+      });
+    },
+  });
+}
+
+export function useCancelQueuedTask(conversationId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (taskId: number) =>
+      api.delete(`/conversations/${conversationId}/queued_tasks/${taskId}`),
     onSuccess: () => {
       qc.invalidateQueries({
         queryKey: queryKeys.conversations.detail(conversationId),

--- a/gui/frontend/src/pages/ConversationView.tsx
+++ b/gui/frontend/src/pages/ConversationView.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { useConversationInfinite } from "@/hooks/queries/use-conversations";
-import { useSubmitConversationTask, useRenameConversation, useCancelPendingTask } from "@/hooks/mutations/use-conversations";
+import { useSubmitConversationTask, useRenameConversation, useCancelPendingTask, useCancelQueuedTask } from "@/hooks/mutations/use-conversations";
 import { useStopSession } from "@/hooks/mutations/use-sessions";
 import { useSessionWS } from "@/hooks/useSessionWS";
 import { useProjectResources } from "@/hooks/queries/use-project-resources";
@@ -195,6 +195,7 @@ export default function ConversationView() {
   const submit = useSubmitConversationTask(cid);
   const stop = useStopSession();
   const cancelPending = useCancelPendingTask(cid);
+  const cancelTask = useCancelQueuedTask(cid);
   const rename = useRenameConversation(pid);
   const { pendingAskUsers, chatMessages, respond } = useSessionWS(
     lastSession?.run_id ?? "",
@@ -471,33 +472,50 @@ export default function ConversationView() {
       </div>
 
       {/* Pending (queued) task indicator */}
-      {conversation?.pending_task && (() => {
-        const queuedTasks = conversation.pending_task.split("\n\n").filter(Boolean);
+      {conversation?.queued_tasks && conversation.queued_tasks.length > 0 && (() => {
+        const tasks = conversation.queued_tasks;
         return (
           <div className="flex-shrink-0 border-t border-border bg-background px-4 py-2">
             <div className="mx-auto max-w-2xl space-y-1.5">
-              {queuedTasks.map((qt, i) => (
-                <div key={i} className="flex items-center gap-2 rounded-lg border border-dashed border-primary/40 bg-primary/5 px-3 py-2">
+              {tasks.map((qt, i) => (
+                <div key={qt.id} className="flex items-center gap-2 rounded-lg border border-dashed border-primary/40 bg-primary/5 px-3 py-2">
                   <Loader2 className="h-3.5 w-3.5 animate-spin text-primary flex-shrink-0" />
+                  {qt.source !== "user" && (
+                    <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-muted text-muted-foreground flex-shrink-0">
+                      {qt.source}
+                    </span>
+                  )}
                   <span className="text-xs text-muted-foreground flex-1 truncate">
-                    Queued{queuedTasks.length > 1 ? ` (${i + 1}/${queuedTasks.length})` : ""}:{" "}
-                    <span className="text-foreground">{qt.split("\n")[0]}</span>
+                    Queued{tasks.length > 1 ? ` (${i + 1}/${tasks.length})` : ""}:{" "}
+                    <span className="text-foreground">{qt.task.split("\n")[0]}</span>
                   </span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="flex-shrink-0 text-muted-foreground hover:text-destructive"
+                    onClick={() => cancelTask.mutate(qt.id)}
+                    disabled={cancelTask.isPending}
+                  >
+                    <X />
+                  </Button>
                 </div>
               ))}
-              <div className="flex justify-end">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="h-6 px-2 text-xs text-muted-foreground hover:text-destructive"
-                  onClick={() => cancelPending.mutate()}
-                  disabled={cancelPending.isPending}
-                >
-                  <X className="h-3 w-3 mr-1" />
-                  Cancel all
-                </Button>
-              </div>
+              {tasks.length > 1 && (
+                <div className="flex justify-end">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs text-muted-foreground hover:text-destructive"
+                    onClick={() => cancelPending.mutate()}
+                    disabled={cancelPending.isPending}
+                  >
+                    <X className="h-3 w-3 mr-1" />
+                    Cancel all
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
         );

--- a/gui/frontend/src/pages/ImuPage.tsx
+++ b/gui/frontend/src/pages/ImuPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { useConversationInfinite, useImuConversations } from "@/hooks/queries/use-conversations";
-import { useCreateImuConversation, useDeleteImuConversation, useRenameImuConversation, useSubmitConversationTask, useCancelPendingTask } from "@/hooks/mutations/use-conversations";
+import { useCreateImuConversation, useDeleteImuConversation, useRenameImuConversation, useSubmitConversationTask, useCancelPendingTask, useCancelQueuedTask } from "@/hooks/mutations/use-conversations";
 import { useStopSession } from "@/hooks/mutations/use-sessions";
 import { useProjectSessions } from "@/hooks/queries/use-sessions";
 import { useSessionWS } from "@/hooks/useSessionWS";
@@ -237,6 +237,7 @@ function ImuConversationView({ cid }: { cid: number }) {
   const submit = useSubmitConversationTask(cid);
   const stop = useStopSession();
   const cancelPending = useCancelPendingTask(cid);
+  const cancelTask = useCancelQueuedTask(cid);
   const rename = useRenameImuConversation();
   const { pendingAskUsers, chatMessages, respond } = useSessionWS(
     lastSession?.run_id ?? "",
@@ -470,33 +471,50 @@ function ImuConversationView({ cid }: { cid: number }) {
       </div>
 
       {/* Pending (queued) task indicator */}
-      {conversation?.pending_task && (() => {
-        const queuedTasks = conversation.pending_task.split("\n\n").filter(Boolean);
+      {conversation?.queued_tasks && conversation.queued_tasks.length > 0 && (() => {
+        const tasks = conversation.queued_tasks;
         return (
           <div className="flex-shrink-0 border-t border-border bg-background px-4 py-2">
             <div className="mx-auto max-w-2xl space-y-1.5">
-              {queuedTasks.map((qt, i) => (
-                <div key={i} className="flex items-center gap-2 rounded-lg border border-dashed border-primary/40 bg-primary/5 px-3 py-2">
+              {tasks.map((qt, i) => (
+                <div key={qt.id} className="flex items-center gap-2 rounded-lg border border-dashed border-primary/40 bg-primary/5 px-3 py-2">
                   <Loader2 className="h-3.5 w-3.5 animate-spin text-primary flex-shrink-0" />
+                  {qt.source !== "user" && (
+                    <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-muted text-muted-foreground flex-shrink-0">
+                      {qt.source}
+                    </span>
+                  )}
                   <span className="text-xs text-muted-foreground flex-1 truncate">
-                    Queued{queuedTasks.length > 1 ? ` (${i + 1}/${queuedTasks.length})` : ""}:{" "}
-                    <span className="text-foreground">{qt.split("\n")[0]}</span>
+                    Queued{tasks.length > 1 ? ` (${i + 1}/${tasks.length})` : ""}:{" "}
+                    <span className="text-foreground">{qt.task.split("\n")[0]}</span>
                   </span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="flex-shrink-0 text-muted-foreground hover:text-destructive"
+                    onClick={() => cancelTask.mutate(qt.id)}
+                    disabled={cancelTask.isPending}
+                  >
+                    <X />
+                  </Button>
                 </div>
               ))}
-              <div className="flex justify-end">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="h-6 px-2 text-xs text-muted-foreground hover:text-destructive"
-                  onClick={() => cancelPending.mutate()}
-                  disabled={cancelPending.isPending}
-                >
-                  <X className="h-3 w-3 mr-1" />
-                  Cancel all
-                </Button>
-              </div>
+              {tasks.length > 1 && (
+                <div className="flex justify-end">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs text-muted-foreground hover:text-destructive"
+                    onClick={() => cancelPending.mutate()}
+                    disabled={cancelPending.isPending}
+                  >
+                    <X className="h-3 w-3 mr-1" />
+                    Cancel all
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
         );

--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -341,6 +341,48 @@ def _migrate(conn: sqlite3.Connection) -> None:
             WHERE delivered_at IS NULL;
     """)
 
+    # Add conversation_task_queue table (added 2026-03-16)
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS conversation_task_queue (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            conversation_id INTEGER NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+            task            TEXT NOT NULL,
+            source          TEXT NOT NULL DEFAULT 'user',
+            source_id       TEXT,
+            role            TEXT,
+            context_files   TEXT,
+            interactive     INTEGER NOT NULL DEFAULT 0,
+            system_prompt   TEXT,
+            runtime         TEXT,
+            memory          TEXT,
+            max_num_delegations  INTEGER,
+            cache_delegations    INTEGER,
+            cache_max_entries    INTEGER,
+            cache_ttl_seconds    INTEGER,
+            created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_task_queue_conversation
+            ON conversation_task_queue(conversation_id, id ASC);
+    """)
+
+    # Migrate existing pending_task data into conversation_task_queue
+    pending_rows = conn.execute(
+        "SELECT id, pending_task FROM conversations WHERE pending_task IS NOT NULL"
+    ).fetchall()
+    for row in pending_rows:
+        for chunk in row["pending_task"].split("\n\n"):
+            chunk = chunk.strip()
+            if chunk:
+                conn.execute(
+                    "INSERT INTO conversation_task_queue (conversation_id, task, source) "
+                    "VALUES (?, ?, 'user')",
+                    (row["id"], chunk),
+                )
+        conn.execute(
+            "UPDATE conversations SET pending_task = NULL WHERE id = ?",
+            (row["id"],),
+        )
+
 
 @contextmanager
 def get_db(db_path: str):

--- a/gui/src/strawpot_gui/routers/conversations.py
+++ b/gui/src/strawpot_gui/routers/conversations.py
@@ -38,6 +38,8 @@ class ConversationTask(BaseModel):
     cache_delegations: bool | None = None
     cache_max_entries: int | None = None
     cache_ttl_seconds: int | None = None
+    source: str = "user"
+    source_id: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -384,6 +386,18 @@ def get_conversation(
         result["sessions"].append(d)
     result["has_more"] = has_more
 
+    # Queued tasks from the task queue table
+    queued_rows = conn.execute(
+        "SELECT id, task, source, source_id, created_at "
+        "FROM conversation_task_queue WHERE conversation_id = ? ORDER BY id ASC",
+        (conversation_id,),
+    ).fetchall()
+    result["queued_tasks"] = [dict(q) for q in queued_rows]
+    # Backward compat: synthesize pending_task string from queue
+    result["pending_task"] = (
+        "\n\n".join(q["task"] for q in queued_rows) or None
+    )
+
     # Parent conversation info
     if row["parent_conversation_id"]:
         parent = conn.execute(
@@ -487,13 +501,29 @@ def submit_task(
     ).fetchone()
 
     if active:
-        # Queue the task — concatenate with existing pending_task
-        existing = conv["pending_task"] or ""
-        new_pending = f"{existing}\n\n{body.task}".strip() if existing else body.task
+        # Queue the task as a separate row in conversation_task_queue
         now = datetime.now(timezone.utc).isoformat()
         conn.execute(
-            "UPDATE conversations SET pending_task = ?, updated_at = ? WHERE id = ?",
-            (new_pending, now, conversation_id),
+            """INSERT INTO conversation_task_queue
+               (conversation_id, task, source, source_id, role, context_files,
+                interactive, system_prompt, runtime, memory,
+                max_num_delegations, cache_delegations, cache_max_entries,
+                cache_ttl_seconds)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                conversation_id, body.task, body.source, body.source_id,
+                body.role,
+                json.dumps(body.context_files) if body.context_files else None,
+                1 if body.interactive else 0,
+                body.system_prompt, body.runtime, body.memory,
+                body.max_num_delegations,
+                1 if body.cache_delegations else None,
+                body.cache_max_entries, body.cache_ttl_seconds,
+            ),
+        )
+        conn.execute(
+            "UPDATE conversations SET updated_at = ? WHERE id = ?",
+            (now, conversation_id),
         )
         return JSONResponse(
             status_code=202,
@@ -565,12 +595,6 @@ def _launch_conversation_task(conn, conv, body: ConversationTask):
             (now, conversation_id),
         )
 
-    # Clear pending_task since we just launched
-    conn.execute(
-        "UPDATE conversations SET pending_task = NULL WHERE id = ?",
-        (conversation_id,),
-    )
-
     return JSONResponse(
         status_code=201,
         content={"run_id": run_id, "conversation_id": conversation_id},
@@ -621,13 +645,24 @@ def delete_conversation(conversation_id: int, conn=Depends(get_db_conn)):
 
 @router.delete("/conversations/{conversation_id}/pending_task", status_code=204)
 def cancel_pending_task(conversation_id: int, conn=Depends(get_db_conn)):
-    """Cancel the queued pending task for a conversation."""
+    """Cancel all queued tasks for a conversation."""
     row = conn.execute(
         "SELECT id FROM conversations WHERE id = ?", (conversation_id,)
     ).fetchone()
     if not row:
         raise HTTPException(404, "Conversation not found")
     conn.execute(
-        "UPDATE conversations SET pending_task = NULL WHERE id = ?",
+        "DELETE FROM conversation_task_queue WHERE conversation_id = ?",
         (conversation_id,),
     )
+
+
+@router.delete("/conversations/{conversation_id}/queued_tasks/{task_id}", status_code=204)
+def cancel_queued_task(conversation_id: int, task_id: int, conn=Depends(get_db_conn)):
+    """Cancel a single queued task."""
+    deleted = conn.execute(
+        "DELETE FROM conversation_task_queue WHERE id = ? AND conversation_id = ?",
+        (task_id, conversation_id),
+    ).rowcount
+    if not deleted:
+        raise HTTPException(404, "Queued task not found")

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -27,32 +27,63 @@ _logger = _logging.getLogger(__name__)
 
 
 def _drain_pending_task(conn, conversation_id: int | None) -> None:
-    """If the conversation has a queued pending_task, launch it now."""
+    """If the conversation has queued tasks, launch the next one (FIFO)."""
     if not conversation_id:
         return
-    conv = conn.execute(
-        "SELECT id, project_id, title, pending_task FROM conversations WHERE id = ?",
+
+    # Only drain if no session is currently active for this conversation
+    active = conn.execute(
+        "SELECT 1 FROM sessions "
+        "WHERE conversation_id = ? AND status IN ('starting', 'running') LIMIT 1",
         (conversation_id,),
     ).fetchone()
-    if not conv or not conv["pending_task"]:
+    if active:
         return
 
-    pending = conv["pending_task"]
-    # Clear pending_task first to avoid re-entry
-    conn.execute(
-        "UPDATE conversations SET pending_task = NULL WHERE id = ?",
+    # Pop the oldest queued task
+    queued = conn.execute(
+        "SELECT * FROM conversation_task_queue "
+        "WHERE conversation_id = ? ORDER BY id ASC LIMIT 1",
         (conversation_id,),
-    )
+    ).fetchone()
+    if not queued:
+        return
+
+    # Delete from queue before launching (prevents re-entry)
+    conn.execute("DELETE FROM conversation_task_queue WHERE id = ?", (queued["id"],))
+
+    conv = conn.execute(
+        "SELECT id, project_id, title FROM conversations WHERE id = ?",
+        (conversation_id,),
+    ).fetchone()
+    if not conv:
+        return
+
+    import json as _json
 
     from strawpot_gui.routers.conversations import ConversationTask, _launch_conversation_task
 
     try:
-        body = ConversationTask(task=pending)
+        body = ConversationTask(
+            task=queued["task"],
+            role=queued["role"],
+            context_files=_json.loads(queued["context_files"]) if queued["context_files"] else None,
+            interactive=bool(queued["interactive"]),
+            system_prompt=queued["system_prompt"],
+            runtime=queued["runtime"],
+            memory=queued["memory"],
+            max_num_delegations=queued["max_num_delegations"],
+            cache_delegations=bool(queued["cache_delegations"]) if queued["cache_delegations"] is not None else None,
+            cache_max_entries=queued["cache_max_entries"],
+            cache_ttl_seconds=queued["cache_ttl_seconds"],
+            source=queued["source"],
+            source_id=queued["source_id"],
+        )
         _launch_conversation_task(conn, conv, body)
-        _logger.info("Auto-submitted pending task for conversation %d", conversation_id)
+        _logger.info("Drained queued task %d for conversation %d", queued["id"], conversation_id)
     except Exception:
         _logger.exception(
-            "Failed to auto-submit pending task for conversation %d", conversation_id
+            "Failed to drain queued task %d for conversation %d", queued["id"], conversation_id
         )
 
 

--- a/gui/src/strawpot_gui/scheduler.py
+++ b/gui/src/strawpot_gui/scheduler.py
@@ -128,6 +128,29 @@ class Scheduler:
         task = schedule["task"]
         conversation_id = schedule.get("conversation_id")
 
+        # For conversation-bound schedules, check for active sessions first.
+        # If one is running, queue the task instead of launching directly.
+        if conversation_id:
+            active = conn.execute(
+                "SELECT 1 FROM sessions "
+                "WHERE conversation_id = ? AND status IN ('starting', 'running') LIMIT 1",
+                (conversation_id,),
+            ).fetchone()
+            if active:
+                conn.execute(
+                    """INSERT INTO conversation_task_queue
+                       (conversation_id, task, source, source_id, role, system_prompt)
+                       VALUES (?, ?, 'scheduler', ?, ?, ?)""",
+                    (conversation_id, task, str(schedule_id), role,
+                     schedule["system_prompt"]),
+                )
+                logger.info(
+                    "Schedule '%s' queued (active session on conversation %d)",
+                    name, conversation_id,
+                )
+                self._advance_schedule(conn, schedule, now)
+                return
+
         # #19 — conversation targeting: build context from prior turns
         kwargs: dict = {}
         if conversation_id:
@@ -168,27 +191,10 @@ class Scheduler:
                 schedule_id=schedule_id,
                 **kwargs,
             )
-            if schedule.get("schedule_type") == "one_time":
-                # One-time: auto-disable after firing
-                conn.execute(
-                    "UPDATE scheduled_tasks "
-                    "SET last_run_at = ?, next_run_at = NULL, "
-                    "    enabled = 0, last_error = NULL "
-                    "WHERE id = ?",
-                    (now.isoformat(), schedule_id),
-                )
-                next_run = None
-            else:
-                next_run = _next_run(schedule["cron_expr"], now)
-                conn.execute(
-                    "UPDATE scheduled_tasks "
-                    "SET last_run_at = ?, next_run_at = ?, last_error = NULL "
-                    "WHERE id = ?",
-                    (now.isoformat(), next_run, schedule_id),
-                )
+            self._advance_schedule(conn, schedule, now)
             logger.info(
-                "Schedule '%s' fired session %s, next run: %s",
-                name, run_id, next_run,
+                "Schedule '%s' fired session %s",
+                name, run_id,
             )
         except Exception as exc:
             conn.execute(
@@ -196,6 +202,27 @@ class Scheduler:
                 (str(exc), schedule_id),
             )
             logger.warning("Schedule '%s' failed: %s", name, exc)
+
+    @staticmethod
+    def _advance_schedule(conn, schedule: dict, now: datetime) -> None:
+        """Update last_run_at, next_run_at, and clear last_error."""
+        schedule_id = schedule["id"]
+        if schedule.get("schedule_type") == "one_time":
+            conn.execute(
+                "UPDATE scheduled_tasks "
+                "SET last_run_at = ?, next_run_at = NULL, "
+                "    enabled = 0, last_error = NULL "
+                "WHERE id = ?",
+                (now.isoformat(), schedule_id),
+            )
+        else:
+            next_run = _next_run(schedule["cron_expr"], now)
+            conn.execute(
+                "UPDATE scheduled_tasks "
+                "SET last_run_at = ?, next_run_at = ?, last_error = NULL "
+                "WHERE id = ?",
+                (now.isoformat(), next_run, schedule_id),
+            )
 
 
 def _next_run(cron_expr: str, after: datetime) -> str | None:

--- a/gui/tests/test_conversations.py
+++ b/gui/tests/test_conversations.py
@@ -898,7 +898,7 @@ class TestMessageQueuing:
         assert data["pending_task"] is None
 
     def test_auto_submit_drains_pending_on_completion(self, client, tmp_path, app):
-        """When a session completes and pending_task exists, a new session is launched."""
+        """When a session completes and a task is queued, a new session is launched."""
         d = tmp_path / "proj"
         d.mkdir()
         pid = _register_project(client, d)
@@ -912,12 +912,15 @@ class TestMessageQueuing:
         # Queue a second task
         _submit_task(client, cid, task="Auto-submit me")
 
-        # Verify pending_task is set
+        # Verify task is in the queue table
         with get_db(app.state.db_path) as conn:
-            row = conn.execute(
-                "SELECT pending_task FROM conversations WHERE id = ?", (cid,)
-            ).fetchone()
-        assert row["pending_task"] == "Auto-submit me"
+            queued = conn.execute(
+                "SELECT task, source FROM conversation_task_queue WHERE conversation_id = ?",
+                (cid,),
+            ).fetchall()
+        assert len(queued) == 1
+        assert queued[0]["task"] == "Auto-submit me"
+        assert queued[0]["source"] == "user"
 
         # Simulate session completion by calling _drain_pending_task
         from strawpot_gui.routers.sessions import _drain_pending_task
@@ -934,12 +937,13 @@ class TestMessageQueuing:
                 )
                 _drain_pending_task(conn, cid)
 
-        # pending_task should be cleared
+        # Queue should be empty after drain
         with get_db(app.state.db_path) as conn:
-            row = conn.execute(
-                "SELECT pending_task FROM conversations WHERE id = ?", (cid,)
-            ).fetchone()
-        assert row["pending_task"] is None
+            remaining = conn.execute(
+                "SELECT id FROM conversation_task_queue WHERE conversation_id = ?",
+                (cid,),
+            ).fetchall()
+        assert len(remaining) == 0
 
         # A new session should have been created
         with get_db(app.state.db_path) as conn:


### PR DESCRIPTION
## Summary
- Replace `pending_task` TEXT column with `conversation_task_queue` table — each submitted task is a separate row with source attribution (`user`, `scheduler`, etc.) and full parameter preservation
- Drain mechanism pops one task at a time (FIFO) with active-session guard preventing simultaneous launches
- Scheduler queues tasks when a session is already running on the conversation instead of launching concurrently
- Frontend (ConversationView + ImuPage) renders `queued_tasks` with source badges and per-task cancel buttons
- DESIGN.md updated with new Phase 5 (items 25-30)

## Test plan
- [x] All 444 existing tests pass
- [x] Frontend type-check clean
- [ ] Submit multiple tasks while session running → verify separate queue rows, not merged
- [ ] First session completes → only first queued task drains (FIFO)
- [ ] Cancel individual task via X button
- [ ] Cancel all tasks when multiple queued
- [ ] Scheduler with conversation_id queues when session active
- [ ] Verify ImuPage queued task rendering with cancel buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)