### PR TITLE
Add integration prompts to Imu onboarding

### DIFF
--- a/gui/frontend/src/pages/ImuPage.tsx
+++ b/gui/frontend/src/pages/ImuPage.tsx
@@ -151,6 +151,13 @@ const IMU_SUGGESTED_PROMPTS = [
       { label: "Register my project", text: "Register my project at ~/path/to/repo" },
     ],
   },
+  {
+    group: "Integrations",
+    prompts: [
+      { label: "How to integrate with Telegram?", text: "How to integrate with Telegram?" },
+      { label: "How to integrate with Slack or Discord?", text: "How to integrate with Slack or Discord?" },
+    ],
+  },
 ];
 
 function ImuOnboarding({ onSelectPrompt }: { onSelectPrompt: (text: string) => void }) {


### PR DESCRIPTION
## Summary
- Add "Integrations" group to Imu conversation onboarding prompts
- Includes "How to integrate with Telegram?" and "How to integrate with Slack or Discord?"

## Test plan
- [ ] Start a new Imu conversation → verify Integrations group appears below existing prompts
- [ ] Click each prompt → verify it submits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)