### PR TITLE
Add tests for /via/ middleware and conversation task queue

### DIFF
--- a/gui/tests/test_task_queue.py
+++ b/gui/tests/test_task_queue.py
@@ -1,0 +1,262 @@
+"""Tests for the conversation task queue and drain mechanism."""
+
+import uuid
+from unittest.mock import patch
+
+from test_sessions_sync import _register_project
+
+from strawpot_gui.db import get_db
+
+
+def _create_conversation(client, project_id):
+    resp = client.post("/api/conversations", json={"project_id": project_id})
+    assert resp.status_code == 201
+    return resp.json()
+
+
+def _submit_task(client, conversation_id, task="Do something", **kwargs):
+    body = {"task": task, **kwargs}
+    with patch("strawpot_gui.routers.sessions.shutil.which", return_value="/usr/bin/strawpot"), \
+         patch("strawpot_gui.routers.sessions.subprocess.Popen"), \
+         patch("strawpot_gui.routers.sessions.load_config") as mock_config:
+        from strawpot.config import StrawPotConfig
+        mock_config.return_value = StrawPotConfig()
+        return client.post(f"/api/conversations/{conversation_id}/tasks", json=body)
+
+
+class TestTaskQueueInsert:
+    """Tasks insert into conversation_task_queue as separate rows."""
+
+    def test_queued_task_stored_individually(self, client, tmp_path, app):
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        _submit_task(client, cid, task="First")
+        _submit_task(client, cid, task="Second")
+        _submit_task(client, cid, task="Third")
+
+        with get_db(app.state.db_path) as conn:
+            rows = conn.execute(
+                "SELECT task FROM conversation_task_queue WHERE conversation_id = ? ORDER BY id",
+                (cid,),
+            ).fetchall()
+        assert len(rows) == 2  # First launched, Second+Third queued
+        assert rows[0]["task"] == "Second"
+        assert rows[1]["task"] == "Third"
+
+    def test_queued_tasks_in_detail_response(self, client, tmp_path):
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        _submit_task(client, cid, task="Running")
+        _submit_task(client, cid, task="Queued A")
+        _submit_task(client, cid, task="Queued B")
+
+        data = client.get(f"/api/conversations/{cid}").json()
+        tasks = data.get("queued_tasks", [])
+        assert len(tasks) == 2
+        assert tasks[0]["task"] == "Queued A"
+        assert tasks[1]["task"] == "Queued B"
+        assert all("id" in t for t in tasks)
+        assert all("created_at" in t for t in tasks)
+
+    def test_pending_task_backward_compat(self, client, tmp_path):
+        """pending_task field joins queued tasks for backward compatibility."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        _submit_task(client, cid, task="Running")
+        _submit_task(client, cid, task="Task A")
+        _submit_task(client, cid, task="Task B")
+
+        data = client.get(f"/api/conversations/{cid}").json()
+        assert "Task A" in data["pending_task"]
+        assert "Task B" in data["pending_task"]
+
+    def test_queue_preserves_source(self, client, tmp_path, app):
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        _submit_task(client, cid, task="First")
+        _submit_task(client, cid, task="Queued")
+
+        with get_db(app.state.db_path) as conn:
+            row = conn.execute(
+                "SELECT source FROM conversation_task_queue WHERE conversation_id = ?",
+                (cid,),
+            ).fetchone()
+        assert row["source"] == "user"
+
+
+class TestDrainActiveSessionGuard:
+    """Drain skips if a session is still active."""
+
+    def test_drain_skips_when_session_active(self, client, tmp_path, app):
+        """If a session is starting/running, drain does nothing."""
+        from strawpot_gui.routers.sessions import _drain_pending_task
+
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        # Launch first task (creates a session with status='starting')
+        _submit_task(client, cid, task="Running task")
+        # Queue a second
+        _submit_task(client, cid, task="Queued task")
+
+        # Try to drain — should skip because session is still active
+        with get_db(app.state.db_path) as conn:
+            _drain_pending_task(conn, cid)
+            # Queue should still have the task
+            remaining = conn.execute(
+                "SELECT id FROM conversation_task_queue WHERE conversation_id = ?",
+                (cid,),
+            ).fetchall()
+        assert len(remaining) == 1
+
+    def test_drain_pops_after_session_completes(self, client, tmp_path, app):
+        """After session completes, drain pops the next task."""
+        from strawpot_gui.routers.sessions import _drain_pending_task
+
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        resp = _submit_task(client, cid, task="First")
+        run_id = resp.json()["run_id"]
+        _submit_task(client, cid, task="Second")
+
+        # Mark first session as completed
+        with patch("strawpot_gui.routers.sessions.shutil.which", return_value="/usr/bin/strawpot"), \
+             patch("strawpot_gui.routers.sessions.subprocess.Popen"), \
+             patch("strawpot_gui.routers.sessions.load_config") as mock_config:
+            from strawpot.config import StrawPotConfig
+            mock_config.return_value = StrawPotConfig()
+            with get_db(app.state.db_path) as conn:
+                conn.execute(
+                    "UPDATE sessions SET status = 'completed' WHERE run_id = ?",
+                    (run_id,),
+                )
+                _drain_pending_task(conn, cid)
+
+        # Queue should be empty and a new session should exist
+        with get_db(app.state.db_path) as conn:
+            remaining = conn.execute(
+                "SELECT id FROM conversation_task_queue WHERE conversation_id = ?",
+                (cid,),
+            ).fetchall()
+            sessions = conn.execute(
+                "SELECT run_id FROM sessions WHERE conversation_id = ?",
+                (cid,),
+            ).fetchall()
+        assert len(remaining) == 0
+        assert len(sessions) == 2
+
+    def test_drain_fifo_order(self, client, tmp_path, app):
+        """Tasks drain in FIFO order (oldest first)."""
+        from strawpot_gui.routers.sessions import _drain_pending_task
+
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        resp = _submit_task(client, cid, task="First")
+        run_id = resp.json()["run_id"]
+        _submit_task(client, cid, task="Alpha")
+        _submit_task(client, cid, task="Beta")
+
+        # Complete first, drain once
+        with patch("strawpot_gui.routers.sessions.shutil.which", return_value="/usr/bin/strawpot"), \
+             patch("strawpot_gui.routers.sessions.subprocess.Popen") as mock_popen, \
+             patch("strawpot_gui.routers.sessions.load_config") as mock_config:
+            from strawpot.config import StrawPotConfig
+            mock_config.return_value = StrawPotConfig()
+            with get_db(app.state.db_path) as conn:
+                conn.execute(
+                    "UPDATE sessions SET status = 'completed' WHERE run_id = ?",
+                    (run_id,),
+                )
+                _drain_pending_task(conn, cid)
+
+        # Only Alpha should have drained, Beta still queued
+        with get_db(app.state.db_path) as conn:
+            remaining = conn.execute(
+                "SELECT task FROM conversation_task_queue WHERE conversation_id = ? ORDER BY id",
+                (cid,),
+            ).fetchall()
+        assert len(remaining) == 1
+        assert remaining[0]["task"] == "Beta"
+
+
+class TestCancelQueuedTask:
+    """Individual and bulk queue cancellation."""
+
+    def test_cancel_individual_task(self, client, tmp_path, app):
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        _submit_task(client, cid, task="Running")
+        _submit_task(client, cid, task="Cancel me")
+        _submit_task(client, cid, task="Keep me")
+
+        # Get task IDs
+        data = client.get(f"/api/conversations/{cid}").json()
+        tasks = data["queued_tasks"]
+        cancel_id = tasks[0]["id"]
+
+        resp = client.delete(f"/api/conversations/{cid}/queued_tasks/{cancel_id}")
+        assert resp.status_code == 204
+
+        # Only "Keep me" remains
+        data = client.get(f"/api/conversations/{cid}").json()
+        assert len(data["queued_tasks"]) == 1
+        assert data["queued_tasks"][0]["task"] == "Keep me"
+
+    def test_cancel_all_clears_queue(self, client, tmp_path):
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        _submit_task(client, cid, task="Running")
+        _submit_task(client, cid, task="A")
+        _submit_task(client, cid, task="B")
+
+        resp = client.delete(f"/api/conversations/{cid}/pending_task")
+        assert resp.status_code == 204
+
+        data = client.get(f"/api/conversations/{cid}").json()
+        assert data["pending_task"] is None
+        assert data.get("queued_tasks", []) == []
+
+    def test_cancel_nonexistent_task_returns_404(self, client, tmp_path):
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        resp = client.delete(f"/api/conversations/{cid}/queued_tasks/99999")
+        assert resp.status_code == 404

--- a/gui/tests/test_via_middleware.py
+++ b/gui/tests/test_via_middleware.py
@@ -1,0 +1,105 @@
+"""Tests for the /via/{name} integration source middleware."""
+
+
+class TestViaMiddleware:
+    """Tests for IntegrationSourceMiddleware in app.py."""
+
+    def test_via_rewrites_path(self, client):
+        """/via/telegram/api/health → /api/health"""
+        resp = client.get("/via/telegram/api/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_via_injects_source_header(self, client):
+        """/via/telegram creates imu conversation with source=telegram."""
+        resp = client.post("/via/telegram/api/imu/conversations")
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["source"] == "telegram"
+
+    def test_via_with_different_names(self, client):
+        """Different integration names are extracted correctly."""
+        for name in ("slack", "discord", "custom-bot"):
+            resp = client.post(f"/via/{name}/api/imu/conversations")
+            assert resp.status_code == 201
+            assert resp.json()["source"] == name
+
+    def test_via_strips_prefix_completely(self, client, tmp_path):
+        """Nested API paths work after prefix stripping."""
+        resp = client.get("/via/telegram/api/imu/conversations")
+        assert resp.status_code == 200
+
+    def test_non_via_path_unaffected(self, client):
+        """Regular paths are not modified."""
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_via_with_empty_rest(self, client):
+        """/via/telegram with no trailing path resolves to /."""
+        resp = client.get("/via/telegram")
+        # Should not 500 — resolves to root (SPA fallback or 404 depending on setup)
+        assert resp.status_code != 500
+
+    def test_body_source_overrides_via_header(self, client):
+        """Explicit source in request body takes precedence over /via/ header."""
+        resp = client.post(
+            "/via/telegram/api/imu/conversations",
+            json={"source": "slack", "source_meta": "override"},
+        )
+        assert resp.status_code == 201
+        # Body source wins over header
+        assert resp.json()["source"] == "slack"
+
+
+class TestConversationSourceTracking:
+    """Tests for source/source_meta on conversations."""
+
+    def test_imu_conversation_source_defaults_to_null(self, client):
+        """Without /via/ prefix, source is null."""
+        resp = client.post("/api/imu/conversations")
+        data = resp.json()
+        assert data.get("source") is None
+        assert data.get("source_meta") is None
+
+    def test_imu_conversation_with_explicit_source(self, client):
+        """POST body can set source and source_meta."""
+        resp = client.post("/api/imu/conversations", json={
+            "source": "scheduler",
+            "source_meta": '{"schedule_id": 7}',
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["source"] == "scheduler"
+        assert data["source_meta"] == '{"schedule_id": 7}'
+
+    def test_imu_list_includes_source(self, client):
+        """List endpoint includes source fields."""
+        client.post("/via/telegram/api/imu/conversations")
+        client.post("/api/imu/conversations")
+
+        items = client.get("/api/imu/conversations").json()
+        sources = [c.get("source") for c in items]
+        assert "telegram" in sources
+        assert None in sources
+
+    def test_conversation_detail_includes_source(self, client):
+        """GET conversation detail includes source/source_meta."""
+        resp = client.post("/via/slack/api/imu/conversations")
+        conv_id = resp.json()["id"]
+
+        detail = client.get(f"/api/conversations/{conv_id}").json()
+        assert detail["source"] == "slack"
+
+    def test_project_conversation_with_source(self, client, tmp_path):
+        """Project conversations also support source tracking."""
+        from test_sessions_sync import _register_project
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+
+        resp = client.post("/via/discord/api/conversations", json={
+            "project_id": pid,
+        })
+        assert resp.status_code == 201
+        assert resp.json()["source"] == "discord"


### PR DESCRIPTION
## Summary
- Adds 12 tests for the `/via/{name}` ASGI middleware (path rewriting, source header injection, conversation source tracking)
- Adds 10 tests for the conversation task queue (insert, drain active-session guard, FIFO ordering, individual/bulk cancel)
- Addresses critical coverage gap: `/via/` middleware previously had zero tests

## Test plan
- [x] All 22 new tests pass locally (`pytest tests/test_via_middleware.py tests/test_task_queue.py -v`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)