### PR TITLE
Default conversation mode to auto

### DIFF
--- a/gui/frontend/src/pages/ConversationView.tsx
+++ b/gui/frontend/src/pages/ConversationView.tsx
@@ -156,7 +156,7 @@ export default function ConversationView() {
   const [advCacheDelegations, setAdvCacheDelegations] = useState("");
   const [advCacheMaxEntries, setAdvCacheMaxEntries] = useState("");
   const [advCacheTtl, setAdvCacheTtl] = useState("");
-  const [interactive, setInteractive] = useState(true);
+  const [interactive, setInteractive] = useState(false);
   const [askUserResponse, setAskUserResponse] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);

--- a/gui/frontend/src/pages/ImuPage.tsx
+++ b/gui/frontend/src/pages/ImuPage.tsx
@@ -196,7 +196,7 @@ function ImuOnboarding({ onSelectPrompt }: { onSelectPrompt: (text: string) => v
 
 function ImuConversationView({ cid }: { cid: number }) {
   const [task, setTask] = useState("");
-  const [interactive, setInteractive] = useState(true);
+  const [interactive, setInteractive] = useState(false);
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);


### PR DESCRIPTION
## Summary
- Change default conversation mode from Interactive to Auto in both project and IMU conversation views
- LaunchDialog already defaulted to Auto — this makes all entry points consistent

## Test plan
- [ ] Open a project conversation — verify toggle shows "Auto" by default
- [ ] Open an IMU conversation — verify toggle shows "Auto" by default
- [ ] Toggle to Interactive and submit a task — verify interactive mode still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)