### PR TITLE
Fix integration log clear and session delete invalidation

### DIFF
--- a/gui/frontend/src/hooks/mutations/use-sessions.ts
+++ b/gui/frontend/src/hooks/mutations/use-sessions.ts
@@ -42,6 +42,7 @@ export function useDeleteSession() {
     mutationFn: (runId: string) => api.delete(`/sessions/${runId}`),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["sessions"] });
+      qc.invalidateQueries({ queryKey: ["conversations"] });
     },
   });
 }

--- a/gui/frontend/src/hooks/useIntegrationLogWS.ts
+++ b/gui/frontend/src/hooks/useIntegrationLogWS.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "@/api/client";
 
 export interface IntegrationLogState {
   lines: string[];
@@ -77,7 +78,12 @@ export function useIntegrationLogWS(name: string | null): IntegrationLogState {
     };
   }, [connect]);
 
-  const clearLines = useCallback(() => setLines([]), []);
+  const clearLines = useCallback(() => {
+    if (name) {
+      api.delete(`/integrations/${name}/logs`).catch(() => {});
+    }
+    setLines([]);
+  }, [name]);
 
   return { lines, done, connected, clearLines };
 }

--- a/gui/src/strawpot_gui/routers/integrations.py
+++ b/gui/src/strawpot_gui/routers/integrations.py
@@ -752,6 +752,21 @@ def stop_all_integrations(db_path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Log management
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/{name}/logs")
+def clear_integration_logs(name: str):
+    """Truncate the integration adapter log file."""
+    home = get_strawpot_home()
+    log_path = home / "integrations" / name / ".log"
+    if log_path.is_file():
+        log_path.write_text("")
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
 # WebSocket: integration log streaming
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `DELETE /api/integrations/{name}/logs` endpoint to truncate the on-disk log file — the clear button was only clearing in-memory state, so logs reappeared on reopen
- Wire the frontend `clearLines` to call the new endpoint
- Invalidate `["conversations"]` queries on session delete so the conversation view updates

## Test plan
- [ ] Open integration logs, click Clear, close and reopen — logs should stay cleared
- [ ] Delete a session from the Imu conversation view — it should disappear from the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)