### PR TITLE
Suppress INFO-level uvicorn logs in GUI server

### DIFF
--- a/gui/src/strawpot_gui/server.py
+++ b/gui/src/strawpot_gui/server.py
@@ -68,4 +68,4 @@ def main(port: int = DEFAULT_PORT, host: str = DEFAULT_HOST) -> None:
     from strawpot_gui.app import create_app
 
     app = create_app(host=host, port=port)
-    uvicorn.run(app, host=host, port=port, log_level="info", timeout_graceful_shutdown=5)
+    uvicorn.run(app, host=host, port=port, log_level="warning", timeout_graceful_shutdown=5)


### PR DESCRIPTION
## Summary
- Change uvicorn `log_level` from `"info"` to `"warning"` to suppress per-request logging and startup messages

## Test plan
- [ ] Start the GUI and verify no INFO lines printed to console
- [ ] Verify warnings and errors still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)