### PR TITLE
Wait for adapter processes to exit in orphan cleanup

### DIFF
--- a/gui/src/strawpot_gui/routers/integrations.py
+++ b/gui/src/strawpot_gui/routers/integrations.py
@@ -6,6 +6,7 @@ import os
 import shlex
 import signal
 import subprocess
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -359,7 +360,6 @@ def _stop_if_running(conn, name: str) -> bool:
         except (ProcessLookupError, OSError):
             pass
         # Wait for the process to actually exit before proceeding
-        import time
         for _ in range(50):  # up to 5 seconds
             if not _is_process_alive(pid):
                 break
@@ -647,6 +647,18 @@ def mark_orphaned_integrations_stopped(db_path: str) -> None:
                     )
                 except (ProcessLookupError, OSError):
                     pass
+                # Wait for the process to exit before proceeding — without
+                # this, auto_start_integrations can spawn a replacement while
+                # the old process is still alive, leaking zombie adapters.
+                for _ in range(50):  # up to 5 seconds
+                    if not _is_process_alive(pid):
+                        break
+                    time.sleep(0.1)
+                else:
+                    try:
+                        os.kill(pid, signal.SIGKILL)
+                    except (ProcessLookupError, OSError):
+                        pass
             conn.execute(
                 "UPDATE integrations SET status = 'stopped', pid = NULL WHERE name = ?",
                 (row["name"],),


### PR DESCRIPTION
## Summary
- `mark_orphaned_integrations_stopped` now waits up to 5s for each process to die after SIGTERM, with SIGKILL fallback
- Previously it sent SIGTERM and immediately cleared the PID, so `auto_start_integrations` spawned replacements while old processes were still alive — accumulating zombie adapters across GUI restarts
- Moved `import time` from local scope to module level (already used in two functions)

## Test plan
- [ ] Restart GUI server — verify only one adapter process per integration after restart
- [ ] Stop/start integration from GUI — verify old process is fully dead before new one spawns

🤖 Generated with [Claude Code](https://claude.com/claude-code)