### PR TITLE
Fix strawhub CLI not found when installed via pipx

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -13,6 +13,25 @@ import click
 
 logger = logging.getLogger(__name__)
 
+
+def _strawhub_cmd() -> list[str] | None:
+    """Locate the strawhub CLI. Returns the command prefix list, or None."""
+    path = shutil.which("strawhub")
+    if path:
+        return [path]
+    # pipx only exposes the main package's entry points on PATH, so strawhub
+    # (a dependency) won't be found by shutil.which even though it's installed
+    # in the same venv.  Fall back to running it as a Python module.
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "strawhub", "--version"],
+            capture_output=True,
+            check=True,
+        )
+        return [sys.executable, "-m", "strawhub"]
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
 from strawpot import __version__
 from strawpot._process import is_pid_alive
 from strawpot.agents.interactive import (
@@ -249,13 +268,13 @@ def _ensure_agent_installed(name: str, working_dir: str, *, auto_setup: bool = F
         ):
             return
 
-    cmd = shutil.which("strawhub")
+    cmd = _strawhub_cmd()
     if cmd is None:
-        click.echo("Error: strawhub CLI not found on PATH.", err=True)
+        click.echo("Error: strawhub CLI not found.", err=True)
         click.echo("Install it with: pip install strawhub", err=True)
         return
 
-    install_cmd = [cmd, "install", "agent", name, "--global"]
+    install_cmd = [*cmd, "install", "agent", name, "--global"]
     if auto_setup:
         install_cmd.append("--yes")
     result = subprocess.run(
@@ -321,13 +340,13 @@ def _ensure_skill_installed(name: str, working_dir: str, *, auto_setup: bool = F
         [str(c) for c in candidates],
     )
 
-    cmd = shutil.which("strawhub")
+    cmd = _strawhub_cmd()
     if cmd is None:
-        click.echo("Error: strawhub CLI not found on PATH.", err=True)
+        click.echo("Error: strawhub CLI not found.", err=True)
         click.echo("Install it with: pip install strawhub", err=True)
         return
 
-    install_cmd = [cmd, "install", "skill", name, "--global"]
+    install_cmd = [*cmd, "install", "skill", name, "--global"]
     if auto_setup:
         install_cmd.append("--yes")
     result = subprocess.run(
@@ -356,13 +375,13 @@ def _ensure_memory_installed(name: str, working_dir: str, *, auto_setup: bool = 
         ):
             return
 
-    cmd = shutil.which("strawhub")
+    cmd = _strawhub_cmd()
     if cmd is None:
-        click.echo("Error: strawhub CLI not found on PATH.", err=True)
+        click.echo("Error: strawhub CLI not found.", err=True)
         click.echo("Install it with: pip install strawhub", err=True)
         return
 
-    install_cmd = [cmd, "install", "memory", name, "--global"]
+    install_cmd = [*cmd, "install", "memory", name, "--global"]
     if auto_setup:
         install_cmd.append("--yes")
     result = subprocess.run(
@@ -397,13 +416,13 @@ def _ensure_role_installed(name: str, working_dir: str, *, auto_setup: bool = Fa
         [str(c) for c in candidates],
     )
 
-    cmd = shutil.which("strawhub")
+    cmd = _strawhub_cmd()
     if cmd is None:
-        click.echo("Error: strawhub CLI not found on PATH.", err=True)
+        click.echo("Error: strawhub CLI not found.", err=True)
         click.echo("Install it with: pip install strawhub", err=True)
         return
 
-    install_cmd = [cmd, "install", "role", name, "--global"]
+    install_cmd = [*cmd, "install", "role", name, "--global"]
     if auto_setup:
         install_cmd.append("--yes")
     result = subprocess.run(
@@ -873,13 +892,13 @@ def gui(port):
 
 def _strawhub(*args: str) -> None:
     """Run a strawhub CLI command, passing through stdout/stderr."""
-    cmd = shutil.which("strawhub")
+    cmd = _strawhub_cmd()
     if cmd is None:
-        click.echo("Error: strawhub CLI not found on PATH.", err=True)
+        click.echo("Error: strawhub CLI not found.", err=True)
         click.echo("Install it with: pip install strawhub", err=True)
         sys.exit(1)
     result = subprocess.run(
-        [cmd, *args],
+        [*cmd, *args],
         stdin=sys.stdin,
         stdout=sys.stdout,
         stderr=sys.stderr,

--- a/gui/src/strawpot_gui/routers/registry.py
+++ b/gui/src/strawpot_gui/routers/registry.py
@@ -277,16 +277,32 @@ def put_resource_config(resource_type: str, name: str, data: dict = Body(...)):
     return {"ok": True}
 
 
+def _strawhub_cmd() -> list[str] | None:
+    """Locate the strawhub CLI, falling back to python -m for pipx installs."""
+    path = shutil.which("strawhub")
+    if path:
+        return [path]
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "strawhub", "--version"],
+            capture_output=True,
+            check=True,
+        )
+        return [sys.executable, "-m", "strawhub"]
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
 def run_strawhub(*args: str) -> dict:
     """Run a strawhub CLI command and return result."""
-    cmd = shutil.which("strawhub")
+    cmd = _strawhub_cmd()
     if cmd is None:
         raise HTTPException(
             503,
-            "strawhub CLI not found on PATH. Install it with: pip install strawhub",
+            "strawhub CLI not found. Install it with: pip install strawhub",
         )
     result = subprocess.run(
-        [cmd, *args],
+        [*cmd, *args],
         stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary
- `pipx install strawpot` installs `strawhub` as a dependency but only exposes `strawpot`'s entry points on PATH — `shutil.which("strawhub")` fails
- Added `_strawhub_cmd()` helper that tries `shutil.which` first, then falls back to `sys.executable -m strawhub`
- Applied to all 6 call sites in `cli.py` (5) and `registry.py` (1)
- Fixes onboarding wizard crash: `FileNotFoundError: Agent not found` after `strawhub CLI not found`

## Test plan
- [ ] `pipx install strawpot` on a clean machine → `strawpot gui` should complete onboarding without "strawhub CLI not found"
- [ ] Existing installs where `strawhub` is on PATH → no behavior change
- [ ] All 40 existing bootstrap tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)