### PR TITLE
Fix RuntimeError when sending on already-closed WebSocket

### DIFF
--- a/gui/src/strawpot_gui/routers/ws.py
+++ b/gui/src/strawpot_gui/routers/ws.py
@@ -253,8 +253,11 @@ async def session_ws(websocket: WebSocket, run_id: str) -> None:
                         await _send_log_snapshot(aid)
         except (asyncio.TimeoutError, WebSocketDisconnect):
             pass
-        await websocket.send_json({"type": "stream_complete"})
-        await websocket.close()
+        try:
+            await websocket.send_json({"type": "stream_complete"})
+            await websocket.close()
+        except (RuntimeError, WebSocketDisconnect):
+            pass
         return
 
     # ---- Active session: watch files + handle client messages ----


### PR DESCRIPTION
## Summary
- Guard `send_json`/`close` calls after the WebSocket drain loop so they don't raise `RuntimeError` when the client has already disconnected
- The drain loop catches `WebSocketDisconnect` but previously fell through to send on the closed socket

## Test plan
- [ ] Open a session WebSocket, disconnect the client mid-drain, and verify no ASGI exception is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)