### PR TITLE
Add demo GIF to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ An open runtime for role-based AI agents. Agents are defined as roles that orche
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
 </p>
 
-<!-- TODO: Replace with actual demo GIF/video — this is the #1 factor for GitHub star conversion -->
 <p align="center">
-  <img src="https://strawpot.com/demo.gif" alt="StrawPot demo — role-based AI agents running locally" width="720">
+  <img src="https://strawpot.com/demo.gif" alt="StrawPot demo — role-based AI agents running locally" width="960">
 </p>
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Remove the TODO placeholder comment for the demo GIF
- Point `<img>` at `https://strawpot.com/demo.gif` (dark mode, 1.1 MB, 15 frames, ~30s loop)
- Update width from 720 to 960 to match the higher resolution capture

The GIF itself is deployed via the strawpot.com repo (see companion PR).

## Demo GIF covers
- Agent delegation tree (hero opener)
- Session detail: overview, trace (41 spans), artifacts (75)
- Bot Imu conversation with package install table
- Workflow pipeline visualization
- Projects, roles, and skills registries

🤖 Generated with [Claude Code](https://claude.com/claude-code)