### PR TITLE
Add project_id to integration tables (DESIGN items 42-43)

### DIFF
--- a/designs/integration/DESIGN.md
+++ b/designs/integration/DESIGN.md
@@ -1181,8 +1181,8 @@ lifecycle are per-instance.
 | 39 | Strawhub CLI: add `--global` flag to `install/uninstall/update integration` (default True, opt-in local) | |
 | 40 | Strawhub CLI: shared binary model — project-scoped install records in local lockfile, downloads to global | |
 | 41 | Strawhub CLI: `[integrations]` section in `strawpot.toml` (`ProjectFile`) | |
-| 42 | Database: `project_id` column on `integrations`, `integration_config`, `integration_notifications` tables | |
-| 43 | Database: migration — rebuild tables with composite PK `(name, project_id)`, default 0 for existing rows | |
+| 42 | Database: `project_id` column on `integrations`, `integration_config`, `integration_notifications` tables | Done |
+| 43 | Database: migration — rebuild tables with composite PK `(name, project_id)`, default 0 for existing rows | Done |
 | 44 | Backend: thread `project_id` through all integration endpoints and helper functions | |
 | 45 | Backend: `_build_env()` — project-scoped `STRAWPOT_API_URL`, `STRAWPOT_DATA_DIR`, `STRAWPOT_PROJECT_ID` | |
 | 46 | Backend: `/via/p/{project_id}/{name}/...` middleware URL pattern + `X-Strawpot-Project-Id` header | |

--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -73,33 +73,39 @@ CREATE TABLE IF NOT EXISTS scheduled_tasks (
 );
 
 CREATE TABLE IF NOT EXISTS integrations (
-    name        TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    project_id  INTEGER NOT NULL DEFAULT 0,
     status      TEXT NOT NULL DEFAULT 'stopped',
     pid         INTEGER,
     auto_start  INTEGER NOT NULL DEFAULT 0,
     last_error  TEXT,
     started_at  TEXT,
-    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (name, project_id)
 );
 
 CREATE TABLE IF NOT EXISTS integration_config (
-    integration_name TEXT NOT NULL REFERENCES integrations(name) ON DELETE CASCADE,
+    integration_name TEXT NOT NULL,
+    project_id       INTEGER NOT NULL DEFAULT 0,
     key              TEXT NOT NULL,
     value            TEXT,
-    PRIMARY KEY (integration_name, key)
+    PRIMARY KEY (integration_name, project_id, key),
+    FOREIGN KEY (integration_name, project_id) REFERENCES integrations(name, project_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS integration_notifications (
     id               INTEGER PRIMARY KEY,
-    integration_name TEXT NOT NULL REFERENCES integrations(name) ON DELETE CASCADE,
+    integration_name TEXT NOT NULL,
+    project_id       INTEGER NOT NULL DEFAULT 0,
     chat_id          TEXT,
     message          TEXT NOT NULL,
     created_at       TEXT NOT NULL DEFAULT (datetime('now')),
-    delivered_at     TEXT
+    delivered_at     TEXT,
+    FOREIGN KEY (integration_name, project_id) REFERENCES integrations(name, project_id) ON DELETE CASCADE
 );
 
 CREATE INDEX IF NOT EXISTS idx_integration_notifications_pending
-    ON integration_notifications(integration_name, delivered_at)
+    ON integration_notifications(integration_name, project_id, delivered_at)
     WHERE delivered_at IS NULL;
 """
 
@@ -388,6 +394,67 @@ def _migrate(conn: sqlite3.Connection) -> None:
     if "source" not in cols:
         conn.execute("ALTER TABLE conversations ADD COLUMN source TEXT")
         conn.execute("ALTER TABLE conversations ADD COLUMN source_meta TEXT")
+
+    # Add project_id to integration tables for project-scoped integrations
+    # (added 2026-03-18).  Existing rows get project_id=0 (global/imu).
+    int_cols = {r[1] for r in conn.execute("PRAGMA table_info(integrations)").fetchall()}
+    if "project_id" not in int_cols:
+        conn.executescript("""
+            PRAGMA foreign_keys=OFF;
+
+            CREATE TABLE integrations_new (
+                name        TEXT NOT NULL,
+                project_id  INTEGER NOT NULL DEFAULT 0,
+                status      TEXT NOT NULL DEFAULT 'stopped',
+                pid         INTEGER,
+                auto_start  INTEGER NOT NULL DEFAULT 0,
+                last_error  TEXT,
+                started_at  TEXT,
+                created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (name, project_id)
+            );
+            INSERT INTO integrations_new (name, status, pid, auto_start, last_error, started_at, created_at)
+                SELECT name, status, pid, auto_start, last_error, started_at, created_at
+                FROM integrations;
+            DROP TABLE integrations;
+            ALTER TABLE integrations_new RENAME TO integrations;
+
+            CREATE TABLE integration_config_new (
+                integration_name TEXT NOT NULL,
+                project_id       INTEGER NOT NULL DEFAULT 0,
+                key              TEXT NOT NULL,
+                value            TEXT,
+                PRIMARY KEY (integration_name, project_id, key),
+                FOREIGN KEY (integration_name, project_id) REFERENCES integrations(name, project_id) ON DELETE CASCADE
+            );
+            INSERT INTO integration_config_new (integration_name, key, value)
+                SELECT integration_name, key, value
+                FROM integration_config;
+            DROP TABLE integration_config;
+            ALTER TABLE integration_config_new RENAME TO integration_config;
+
+            CREATE TABLE integration_notifications_new (
+                id               INTEGER PRIMARY KEY,
+                integration_name TEXT NOT NULL,
+                project_id       INTEGER NOT NULL DEFAULT 0,
+                chat_id          TEXT,
+                message          TEXT NOT NULL,
+                created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+                delivered_at     TEXT,
+                FOREIGN KEY (integration_name, project_id) REFERENCES integrations(name, project_id) ON DELETE CASCADE
+            );
+            INSERT INTO integration_notifications_new (id, integration_name, chat_id, message, created_at, delivered_at)
+                SELECT id, integration_name, chat_id, message, created_at, delivered_at
+                FROM integration_notifications;
+            DROP TABLE integration_notifications;
+            ALTER TABLE integration_notifications_new RENAME TO integration_notifications;
+
+            CREATE INDEX IF NOT EXISTS idx_integration_notifications_pending
+                ON integration_notifications(integration_name, project_id, delivered_at)
+                WHERE delivered_at IS NULL;
+
+            PRAGMA foreign_keys=ON;
+        """)
 
 
 @contextmanager


### PR DESCRIPTION
## Summary

- Add `project_id INTEGER NOT NULL DEFAULT 0` to `integrations`, `integration_config`, and `integration_notifications` tables
- Change PKs to composites: `(name, project_id)` for integrations, `(integration_name, project_id, key)` for config
- Migration rebuilds all three tables for existing databases, preserving data with `project_id=0` (global/imu)
- Mark DESIGN items 42-43 as Done

## Test plan

- [ ] Fresh install: verify tables created with correct schema
- [ ] Existing database: verify migration adds project_id=0 to all existing rows
- [ ] Existing integrations still start/stop/configure correctly (backward compat with project_id=0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)