### PR TITLE
Add project-scoped _build_env with data dir isolation (item 45)

### DIFF
--- a/gui/src/strawpot_gui/routers/integrations.py
+++ b/gui/src/strawpot_gui/routers/integrations.py
@@ -486,7 +486,17 @@ def _is_process_alive(pid: int) -> bool:
         return False
 
 
-def _build_env(name: str, config_values: dict, request: Request, *, project_id: int = 0) -> dict:
+def _get_project_working_dir(conn, project_id: int) -> str | None:
+    """Look up a project's working_dir from the projects table."""
+    row = conn.execute(
+        "SELECT working_dir FROM projects WHERE id = ?", (project_id,)
+    ).fetchone()
+    return row["working_dir"] if row else None
+
+
+def _build_env(
+    name: str, config_values: dict, request: Request, conn, *, project_id: int = 0
+) -> dict:
     """Build environment variables for the adapter subprocess."""
     env = os.environ.copy()
 
@@ -510,8 +520,18 @@ def _build_env(name: str, config_values: dict, request: Request, *, project_id: 
         env["STRAWPOT_API_URL"] = f"{base}/via/{name}"
     env["STRAWPOT_INTEGRATION_NAME"] = name
 
-    # Persistent data directory for adapter state (survives reinstalls)
-    data_dir = get_strawpot_home() / "data" / "integrations" / name
+    # Persistent data directory for adapter state (survives reinstalls).
+    # Project-scoped instances store data under the project's working dir;
+    # global instances use the strawpot home directory.
+    if project_id > 0:
+        working_dir = _get_project_working_dir(conn, project_id)
+        if working_dir:
+            data_dir = Path(working_dir) / ".strawpot" / "data" / "integrations" / name
+            env["STRAWPOT_PROJECT_DIR"] = working_dir
+        else:
+            data_dir = get_strawpot_home() / "data" / "integrations" / name
+    else:
+        data_dir = get_strawpot_home() / "data" / "integrations" / name
     data_dir.mkdir(parents=True, exist_ok=True)
     env["STRAWPOT_DATA_DIR"] = str(data_dir)
 
@@ -557,7 +577,7 @@ def start_integration(
         # PID stale — clean up below
 
     config_values = _get_db_config(conn, name, project_id)
-    env = _build_env(name, config_values, request, project_id=project_id)
+    env = _build_env(name, config_values, request, conn, project_id=project_id)
 
     # Log file for adapter output
     log_path = integration_dir / ".log"
@@ -754,10 +774,22 @@ def auto_start_integrations(db_path: str, *, host: str = "127.0.0.1", port: int 
         env["PATH"] = ":".join(extra_paths) + ":" + env.get("PATH", "")
         if project_id > 0:
             env["STRAWPOT_API_URL"] = f"http://{host}:{port}/via/p/{project_id}/{name}"
+            env["STRAWPOT_PROJECT_ID"] = str(project_id)
         else:
             env["STRAWPOT_API_URL"] = f"http://{host}:{port}/via/{name}"
         env["STRAWPOT_INTEGRATION_NAME"] = name
-        data_dir = home / "data" / "integrations" / name
+
+        # Project-scoped data dir mirrors _build_env logic
+        if project_id > 0:
+            with get_db(db_path) as conn2:
+                working_dir = _get_project_working_dir(conn2, project_id)
+            if working_dir:
+                data_dir = Path(working_dir) / ".strawpot" / "data" / "integrations" / name
+                env["STRAWPOT_PROJECT_DIR"] = working_dir
+            else:
+                data_dir = home / "data" / "integrations" / name
+        else:
+            data_dir = home / "data" / "integrations" / name
         data_dir.mkdir(parents=True, exist_ok=True)
         env["STRAWPOT_DATA_DIR"] = str(data_dir)
         for key, value in config_values.items():

--- a/gui/tests/test_integrations_api.py
+++ b/gui/tests/test_integrations_api.py
@@ -924,3 +924,131 @@ class TestManifestParsing:
         assert data[0]["entry_point"] == ""
         assert data[0]["auto_start"] is False
         assert data[0]["env_schema"] == {}
+
+
+class TestBuildEnv:
+    """Tests for _build_env environment variable construction."""
+
+    def test_global_data_dir(self, client, home):
+        """Global instance uses strawpot home for data dir."""
+        from starlette.testclient import TestClient as _TC
+        from strawpot_gui.routers.integrations import _build_env
+        from strawpot_gui.db import get_db
+
+        _create_integration(home, "telegram")
+        db_path = client.app.state.db_path
+
+        # Use a real request object via the test client
+        with _TC(client.app) as tc:
+            # Build a mock-ish request from the app
+            from starlette.requests import Request
+            from starlette.datastructures import URL
+
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/",
+                "headers": [],
+                "query_string": b"",
+                "root_path": "",
+                "server": ("testserver", 80),
+            }
+            request = Request(scope)
+
+            with get_db(db_path) as conn:
+                env = _build_env("telegram", {}, request, conn, project_id=0)
+
+        assert env["STRAWPOT_INTEGRATION_NAME"] == "telegram"
+        assert env["STRAWPOT_API_URL"].endswith("/via/telegram")
+        assert env["STRAWPOT_DATA_DIR"] == str(home / "data" / "integrations" / "telegram")
+        assert "STRAWPOT_PROJECT_ID" not in env
+        assert "STRAWPOT_PROJECT_DIR" not in env
+
+    def test_project_scoped_data_dir(self, client, home, tmp_path):
+        """Project-scoped instance uses project working dir for data dir."""
+        from strawpot_gui.routers.integrations import _build_env
+        from strawpot_gui.db import get_db
+        from starlette.requests import Request
+
+        _create_integration(home, "discord")
+        db_path = client.app.state.db_path
+        project_dir = str(tmp_path / "my_project")
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [],
+            "query_string": b"",
+            "root_path": "",
+            "server": ("testserver", 80),
+        }
+        request = Request(scope)
+
+        with get_db(db_path) as conn:
+            conn.execute(
+                "INSERT INTO projects (id, display_name, working_dir) VALUES (?, ?, ?)",
+                (5, "My Project", project_dir),
+            )
+            env = _build_env("discord", {}, request, conn, project_id=5)
+
+        expected_data = str(tmp_path / "my_project" / ".strawpot" / "data" / "integrations" / "discord")
+        assert env["STRAWPOT_DATA_DIR"] == expected_data
+        assert env["STRAWPOT_PROJECT_DIR"] == project_dir
+        assert env["STRAWPOT_PROJECT_ID"] == "5"
+        assert env["STRAWPOT_API_URL"].endswith("/via/p/5/discord")
+
+    def test_project_scoped_fallback_when_project_missing(self, client, home):
+        """Project-scoped instance falls back to global data dir if project not found."""
+        from strawpot_gui.routers.integrations import _build_env
+        from strawpot_gui.db import get_db
+        from starlette.requests import Request
+
+        _create_integration(home, "slack")
+        db_path = client.app.state.db_path
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [],
+            "query_string": b"",
+            "root_path": "",
+            "server": ("testserver", 80),
+        }
+        request = Request(scope)
+
+        with get_db(db_path) as conn:
+            # No project with id=99 exists
+            env = _build_env("slack", {}, request, conn, project_id=99)
+
+        assert env["STRAWPOT_DATA_DIR"] == str(home / "data" / "integrations" / "slack")
+        assert "STRAWPOT_PROJECT_DIR" not in env
+
+    def test_config_values_passed_through(self, client, home):
+        """Config values are set as env vars."""
+        from strawpot_gui.routers.integrations import _build_env
+        from strawpot_gui.db import get_db
+        from starlette.requests import Request
+
+        _create_integration(home, "telegram")
+        db_path = client.app.state.db_path
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [],
+            "query_string": b"",
+            "root_path": "",
+            "server": ("testserver", 80),
+        }
+        request = Request(scope)
+
+        config = {"STRAWPOT_BOT_TOKEN": "123:ABC", "EMPTY_VAL": ""}
+        with get_db(db_path) as conn:
+            env = _build_env("telegram", config, request, conn)
+
+        assert env["STRAWPOT_BOT_TOKEN"] == "123:ABC"
+        # Empty values should not be set
+        assert "EMPTY_VAL" not in env


### PR DESCRIPTION
## Summary
- Add `_get_project_working_dir` helper to look up project `working_dir` from DB
- Update `_build_env` to set project-scoped `STRAWPOT_DATA_DIR` (`{project_dir}/.strawpot/data/integrations/{name}/`), `STRAWPOT_PROJECT_DIR`, and `STRAWPOT_PROJECT_ID` when `project_id > 0`
- Mirror the same project-scoped data dir logic in `auto_start_integrations`
- Add 4 new tests for `_build_env`: global data dir, project-scoped data dir, fallback when project missing, config passthrough

## Test plan
- [x] All 76 tests pass (72 existing + 4 new)
- [ ] Verify project-scoped integration starts with correct data dir
- [ ] Verify global integration behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)