### PR TITLE
Update CONTRIBUTING.md with builder guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,66 +1,276 @@
 # Contributing to StrawPot
 
-StrawPot is built by AI agents. Humans contribute by describing what they
-want — features, bug fixes, improvements — and agents handle the code.
+StrawPot grows through builders solving real problems and sharing
+what works. Whether you create a role, write a skill, build a
+memory provider, or improve the core — every contribution makes
+the ecosystem stronger for everyone.
 
-## How to Contribute
+If you've built something useful for your own workflow, consider
+publishing it. The next person shouldn't have to start from
+scratch.
 
-### Report a Bug
+---
 
-Open a [GitHub Issue](https://github.com/strawpot/strawpot/issues) with:
+## What You Can Contribute
 
-- **What happened** — the error, unexpected behavior, or crash
-- **What you expected** — the correct behavior
-- **Steps to reproduce** — commands, config, or sequence of actions
-- **Environment** — OS, Python version, StrawPot version (`strawpot --version`)
+| Contribution | What It Is | Where It Lives |
+|---|---|---|
+| **Role** | A markdown file that defines an agent's behavior, responsibilities, and delegation rules | Your project's `roles/<role-name>/ROLE.md` |
+| **Skill** | A markdown file that gives an agent domain-specific knowledge or capabilities | Your project's `skills/<skill-name>/SKILL.md` |
+| **Memory provider** | A pluggable backend for persistent agent memory (e.g., Dial) | Core or StrawHub |
+| **Agent adapter** | Runtime integration for a new AI tool (Claude Code, Codex, Gemini, etc.) | Core |
+| **Integration** | Connect StrawPot to external platforms (GitHub, Slack, etc.) | StrawHub |
+| **Documentation** | Guides, tutorials, API references at [docs.strawpot.com](https://docs.strawpot.com) | `docs/` |
+| **Bug reports & ideas** | Issues describing problems or improvements | [GitHub Issues](https://github.com/strawpot/strawpot/issues) |
 
-Paste logs or tracebacks if available. Screenshots of the GUI help too.
+You don't need deep StrawPot expertise to contribute. If you can
+write markdown, you can write a role.
 
-### Request a Feature
+---
 
-Open a [GitHub Issue](https://github.com/strawpot/strawpot/issues) with:
+## Getting Started
 
-- **What you want** — describe the outcome, not the implementation
-- **Why it matters** — what workflow it enables or what problem it solves
-- **Example** — a concrete scenario showing how you'd use it
+### Prerequisites
 
-Good: "I want to run the same schedule in multiple projects with different configs."
-Less helpful: "Add a `project_id` column to the `scheduled_tasks` table."
+- Python 3.11+
+- Git
+- A supported AI runtime (Claude Code, Codex, or Gemini)
 
-### Share an Idea or Ask a Question
+### Install StrawPot
 
-Join the [Discord](https://discord.gg/6RMpzuKrRd) for discussion, feedback,
-and help getting started.
+```bash
+pip install strawpot
+```
 
-## What Happens Next
+Verify the installation:
 
-1. You submit an issue describing a bug or feature
-2. An AI agent picks it up, reads the codebase, and creates a PR
-3. The maintainer reviews and merges
+```bash
+strawpot --version
+```
 
-You don't need to write code, set up a dev environment, or understand the
-internals. A clear description of the problem is the most valuable contribution.
+### Set Up a Dev Environment
 
-## Writing Good Prompts
+1. Fork and clone the repository:
 
-The better you describe the problem, the better the result. Tips:
+   ```bash
+   git clone https://github.com/<your-username>/strawpot.git
+   cd strawpot
+   ```
 
-- **Be specific** — "the Telegram adapter crashes when the bot token is
-  empty" beats "integration doesn't work"
-- **Include context** — what were you doing, what config do you have
-- **One issue per issue** — don't bundle unrelated requests
-- **Show examples** — paste terminal output, screenshots, or sample config
+2. Install the CLI in development mode:
 
-## Other Ways to Contribute
+   ```bash
+   pip install -e "./cli[dev]"
+   ```
 
-- **Design feedback** — review design docs in `designs/` and comment on
-  open issues about upcoming features
-- **Testing** — try new releases, report what breaks
-- **Documentation** — suggest improvements to README or user-facing docs
-- **Community adapters** — build and publish integration adapters for new
-  platforms via [StrawHub](https://strawhub.dev)
+3. Run the test suite to confirm everything works:
+
+   ```bash
+   pytest cli/tests/
+   ```
+
+4. Start the GUI to explore the system:
+
+   ```bash
+   strawpot gui
+   ```
+
+---
+
+## Creating a Role
+
+A role is a markdown file that tells an agent what it does, how it
+behaves, and who it can delegate to. Roles are the building blocks
+of every StrawPot workflow.
+
+### Quick example
+
+Create `roles/my-role/ROLE.md` in your project:
+
+```markdown
+---
+name: my-role
+description: Generates inline documentation for source files
+metadata:
+  strawpot:
+    dependencies:
+      skills:
+        - git-workflow
+        - python-dev
+      roles:
+        - code-reviewer
+---
+You are a code documentation generator. You read source files
+and produce clear, concise inline documentation.
+```
+
+Roles use YAML frontmatter for metadata (name, description,
+dependencies) and plain markdown for the agent's instructions.
+
+### Key concepts
+
+- **One role = one responsibility.** A role should do one thing
+  well. Use delegation for multi-step workflows.
+- **Skills extend roles.** List skills under
+  `metadata.strawpot.dependencies.skills` to give a role
+  specific knowledge.
+- **Delegation chains.** List delegatable roles under
+  `metadata.strawpot.dependencies.roles`. Roles delegate to
+  other roles, forming a coordination tree with policy controls.
+
+For the full guide — including delegation rules, memory
+configuration, and evaluation workflows — see the
+[roles documentation](https://docs.strawpot.com).
+
+---
+
+## Creating a Skill
+
+A skill is domain-specific knowledge packaged as a markdown file.
+Roles reference skills to gain capabilities without duplicating
+instructions.
+
+### Quick example
+
+Create `skills/my-skill/SKILL.md` in your project:
+
+```markdown
+# My Custom Skill
+
+Use this skill when the user asks to format Python code
+according to the project's style guide.
+
+## Style Rules
+
+- Use Black with line length 88
+- Sort imports with isort
+- Type hints required on all public functions
+```
+
+### Guidelines
+
+- **Trigger condition first.** Start with "Use this skill
+  when..." so agents know when to activate it.
+- **Focused scope.** One skill covers one domain. Don't combine
+  unrelated knowledge into a single skill.
+- **Actionable content.** Include the actual instructions an
+  agent needs — not just pointers to external docs.
+
+Full skill authoring guide:
+[docs.strawpot.com](https://docs.strawpot.com)
+
+---
+
+## Publishing to StrawHub
+
+[StrawHub](https://strawhub.dev) is the package registry for
+roles, skills, agents, and integrations. Install what the
+community built. Publish what you've built.
+
+### Install a package
+
+```bash
+strawhub install role code-reviewer
+strawhub install skill git-workflow
+```
+
+### Publish your work
+
+```bash
+strawhub publish role my-custom-role
+strawhub publish skill my-custom-skill
+```
+
+The publish command validates your package, bundles it, and
+uploads it to the registry. Once published, anyone can install
+it with a single command.
+
+For publishing requirements and package metadata, see the
+[publishing guide](https://docs.strawpot.com).
+
+---
+
+## Code Standards and Conventions
+
+- **Roles and skills are markdown.** No Python, no orchestration
+  code. Define behavior in plain text.
+- **Configuration is TOML.** Project-level config lives in
+  `strawpot.toml`.
+- **Branch naming:** `claude/<branch-name>` for all feature
+  branches.
+- **Never push directly to `main`.** Always open a PR.
+- **Tests:** Run `pytest` before submitting. Add tests for new
+  functionality when applicable.
+- **Linting:** Follow the project's existing code style.
+
+For architecture details, see the
+[concepts documentation](https://docs.strawpot.com).
+
+---
+
+## Pull Request Process
+
+1. **Create a branch** from `main`:
+
+   ```bash
+   git checkout -b claude/my-feature
+   ```
+
+2. **Make your changes.** Keep commits focused — one logical
+   change per commit.
+
+3. **Rebase from main** before opening the PR:
+
+   ```bash
+   git fetch origin && git rebase origin/main
+   ```
+
+4. **Open a PR** with a clear title and description:
+   - What changed and why
+   - How to test it
+   - Link to the related issue, if any
+
+5. **Wait for review.** A maintainer will review your PR. Address
+   feedback by pushing new commits (don't force-push unless
+   asked).
+
+6. **Merge.** Once approved, the maintainer merges your PR.
+   Don't reuse merged branches — create a fresh branch for the
+   next change.
+
+---
+
+## Community Guidelines
+
+We keep it straightforward:
+
+- **Be respectful.** Disagree on ideas, not people.
+- **Be constructive.** Criticism is welcome when paired with
+  suggestions.
+- **Be inclusive.** No gatekeeping — first-time contributors are
+  as welcome as experienced ones.
+- **Be honest.** If something doesn't work, say so. If you're
+  unsure, ask.
+- **Credit others.** When featuring community work, name the
+  creator.
+
+We don't tolerate harassment, discrimination, or bad-faith
+engagement.
+
+---
+
+## Where to Get Help
+
+| Channel | Use For |
+|---|---|
+| [Discord](https://discord.gg/6RMpzuKrRd) | Questions, feedback, real-time discussion |
+| [GitHub Issues](https://github.com/strawpot/strawpot/issues) | Bug reports, feature requests |
+| [docs.strawpot.com](https://docs.strawpot.com) | Guides, API reference, tutorials |
+| [StrawHub](https://strawhub.dev) | Browse and publish packages |
+
+---
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the
-[MIT License](LICENSE).
+By contributing, you agree that your contributions will be
+licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- Replaced the minimal CONTRIBUTING.md with a comprehensive guide for ecosystem builders
- Covers all contribution types: roles, skills, memory providers, agent adapters, integrations, and docs
- Includes correct YAML frontmatter format for roles (matching actual codebase conventions)
- Dev environment setup with accurate paths (`./cli[dev]`, `cli/tests/`)
- StrawHub publishing workflow (install + publish)
- PR process aligned with CLAUDE.md conventions
- Tone aligned with brand-voice.md community/contributor messaging

## Test plan

- [ ] Verify dev setup instructions work (`pip install -e "./cli[dev]"`, `pytest cli/tests/`)
- [ ] Confirm role example format matches actual role parser expectations
- [ ] Check all links resolve (docs.strawpot.com, strawhub.dev, Discord, GitHub Issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)