### PR TITLE
Fix "unknown" requester in delegation race condition

### DIFF
--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -939,7 +939,12 @@ def handle_delegate(
                     parent_agent_id=request.parent_agent_id,
                 )
 
-        # 7b. Spawn
+        # 7b. Register agent BEFORE spawning so that if the child
+        # immediately issues a delegation via denden, _agent_role()
+        # can already resolve its role (avoids "unknown" requester).
+        if register_agent is not None:
+            register_agent(agent_id, request.role_slug, request.parent_agent_id, None)
+
         env = {
             "DENDEN_ADDR": denden_addr or config.denden_addr,
             "DENDEN_AGENT_ID": agent_id,
@@ -962,6 +967,11 @@ def handle_delegate(
             task=task_text,
             env=env,
         )
+        # Update the registered entry with the actual PID now that
+        # the process has been spawned.
+        if register_agent is not None:
+            register_agent(agent_id, request.role_slug, request.parent_agent_id, handle.pid)
+
         if tracer is not None and delegate_span_id is not None:
             agent_context = role_prompt
             if memory_prompt:
@@ -983,10 +993,6 @@ def handle_delegate(
             )
             if agent_spans is not None:
                 agent_spans[agent_id] = delegate_span_id
-
-        # 7c. Register agent in session state for depth tracking
-        if register_agent is not None:
-            register_agent(agent_id, request.role_slug, request.parent_agent_id, handle.pid)
 
         # 8. Wait
         result = runtime.wait(handle, timeout=config.agent_timeout)

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -465,6 +465,16 @@ class Session:
                 "STRAWPOT_ROLE": self.config.orchestrator_role,
             }
 
+            # Register the agent BEFORE spawning so that if the
+            # orchestrator immediately issues a delegation via denden,
+            # _agent_role() can already resolve its role (avoids
+            # "unknown" requester).
+            self._register_agent(
+                agent_id,
+                role=self.config.orchestrator_role,
+                parent_id=None,
+            )
+
             handle = self.runtime.spawn(
                 agent_id=agent_id,
                 working_dir=self._env.path,
@@ -478,6 +488,7 @@ class Session:
                 env=env,
             )
             self._orchestrator_handle = handle
+            self._agent_info[agent_id]["pid"] = handle.pid
             if self._tracer is not None:
                 agent_context = role_prompt
                 if memory_prompt:
@@ -497,12 +508,6 @@ class Session:
                     context=agent_context,
                 )
                 self._agent_spans[agent_id] = self._session_span_id
-            self._register_agent(
-                agent_id,
-                role=self.config.orchestrator_role,
-                parent_id=None,
-                pid=handle.pid,
-            )
 
             # 6. Write session state file
             self._write_session_file()

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -1592,10 +1592,17 @@ class TestIntegration:
             ),
         )
 
-        assert len(registered) == 1
+        # register_agent is called twice: once before spawn (pid=None)
+        # and once after spawn (pid set) to avoid a race where the
+        # child issues a delegation before registration completes.
+        assert len(registered) == 2
         agent_id, role, parent_id, pid = registered[0]
         assert role == "worker"
         assert parent_id == "agent_parent"
+        assert pid is None
+        # Second call has the actual PID
+        assert registered[1][0] == agent_id
+        assert registered[1][3] is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Bug**: When an agent delegates, the requester shows as "unknown" instead of the actual role name (e.g., "ai-ceo")
- **Root cause**: `_register_agent()` was called after `runtime.spawn()`, but the spawned process can immediately issue delegation calls via denden gRPC before registration completes — `_agent_role()` then falls back to `"unknown"`
- **Fix**: Register agents in `_agent_info` before spawning in both `session.py` (orchestrator) and `delegation.py` (child agents), then update the PID after spawn

## Test plan
- [x] All 579 CLI tests pass
- [x] All 508 GUI tests pass
- [ ] Verify delegated agents see correct requester role name instead of "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)