### PR TITLE
Move conversation history to per-conversation folder

### DIFF
--- a/designs/context/DESIGN.md
+++ b/designs/context/DESIGN.md
@@ -211,10 +211,10 @@ Older turns in the History section continue to use recap only, condensed to 120-
 
 ### Phase 2: Conversation history file
 
-Write a `.strawpot/conversation_history.md` file to the project working directory before spawning the agent. The context prefix includes a hint telling the agent where to find it.
+Write a `.strawpot/conversations/{id}/history.md` file to the project working directory before spawning the agent. The context prefix includes a hint telling the agent where to find it.
 
 ```
-> Full session outputs available at `.strawpot/conversation_history.md` —
+> Full session outputs available at `.strawpot/conversations/{id}/history.md` —
 > read it if you need more detail than the summaries above.
 ```
 
@@ -462,17 +462,19 @@ def em_conversation_dir(storage_dir: Path, conversation_id: str) -> Path:
 
 #### 5d. Conversation-scoped history file
 
-Change `_write_conversation_history()` to include conversation_id in the filename:
+Change `_write_conversation_history()` to scope the history file per conversation:
 
 ```python
 # Before:
-history_path = history_dir / "conversation_history.md"
+history_path = Path(working_dir) / ".strawpot" / "conversation_history.md"
 
 # After:
-history_path = history_dir / f"conversation_{conversation_id}_history.md"
+history_dir = Path(working_dir) / ".strawpot" / "conversations" / str(conversation_id)
+history_dir.mkdir(parents=True, exist_ok=True)
+history_path = history_dir / "history.md"
 ```
 
-The data written is already filtered by conversation_id (SQL WHERE clause). The fix prevents concurrent conversations from overwriting each other's history.
+Each conversation gets its own directory at `.strawpot/conversations/{id}/`, with `history.md` inside. The per-conversation folder structure allows future expansion (conversation-level metadata, config, etc.). The data written is already filtered by conversation_id (SQL WHERE clause). The fix prevents concurrent conversations from overwriting each other's history.
 
 The hint in `_build_conversation_context()` already uses the returned path, so it will automatically reference the correct file.
 
@@ -523,7 +525,7 @@ global          ~/.strawpot/memory/dial-data/
 | strawpot | `cli/src/strawpot/session.py` | Accept conversation_id, pass to all memory calls |
 | strawpot | `cli/src/strawpot/delegation.py` | Pass conversation_id to child agent memory calls |
 | strawpot | `gui/src/strawpot_gui/routers/sessions.py` | Pass `--conversation-id` in subprocess cmd |
-| strawpot | `gui/src/strawpot_gui/routers/conversations.py` | Scope history file to `conversation_{id}_history.md` |
+| strawpot | `gui/src/strawpot_gui/routers/conversations.py` | Scope history file to `conversations/{id}/history.md` |
 
 ## Implementation status
 

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -101,7 +101,7 @@ The context builder applies tiered condensation: older turns get brief summaries
 
 Agents in a conversation are asked to end their response with a structured `## Session Recap` section covering accomplishments (with file paths and specifics), changes made, key decisions, and open items. The database stores the full agent output as the session summary. When building context for the next turn, the context builder extracts the recap section for condensed history lines, while the **Pending Follow-up** for the last turn includes both the structured recap and a tail of the raw agent output — giving the next session both curated insight and ground truth.
 
-Additionally, full session outputs are written to `.strawpot/conversation_{id}_history.md` in the project directory before each session spawns (one file per conversation). The agent can read this file on demand when the condensed summaries in the context prefix aren't sufficient. The file includes full output for the last 5 turns and recap only for older turns (up to 10 total).
+Additionally, full session outputs are written to `.strawpot/conversations/{id}/history.md` in the project directory before each session spawns (one file per conversation). The agent can read this file on demand when the condensed summaries in the context prefix aren't sufficient. The file includes full output for the last 5 turns and recap only for older turns (up to 10 total).
 
 ## Crash Recovery
 

--- a/docs/gui/quickstart.mdx
+++ b/docs/gui/quickstart.mdx
@@ -73,7 +73,7 @@ Each new session in a conversation receives a **Prior Conversation** prefix cont
 - **History** — A condensed summary of each prior turn (what was asked, what was done). Recent turns retain more detail than older ones. Only the most recent 10 turns are included.
 - **File changes** — Which files were modified in recent turns, so the agent knows where to look.
 - **Pending Follow-up** — For the last turn, includes both the structured recap (up to 1500 chars) and a tail of the raw agent output (last 1500 chars). The recap tells the next agent *what to know*; the raw output shows *what actually happened*.
-- **Conversation history file** — Full session outputs are written to `.strawpot/conversation_{id}_history.md` in the project directory before each session (one file per conversation). The agent can read this file on demand for more detail than the condensed summaries provide. Recent turns (last 5) include full output; older turns include recap only.
+- **Conversation history file** — Full session outputs are written to `.strawpot/conversations/{id}/history.md` in the project directory before each session (one file per conversation). The agent can read this file on demand for more detail than the condensed summaries provide. Recent turns (last 5) include full output; older turns include recap only.
 - **Recap instruction** — Asks the agent to end its response with a structured `## Session Recap` section covering what was accomplished, files changed, key decisions, and open items. The recap is extracted for use in subsequent turn summaries.
 
 This is separate from [memory](/concepts/memory), which operates across conversations. Both work together: conversation context provides the sequential narrative, while memory provides long-lived knowledge.

--- a/gui/src/strawpot_gui/routers/conversations.py
+++ b/gui/src/strawpot_gui/routers/conversations.py
@@ -191,7 +191,7 @@ def _build_conversation_context(conn, conversation_id: int, *, history_path: str
 
 
 def _write_conversation_history(conn, conversation_id: int, working_dir: str) -> str | None:
-    """Write full conversation history to .strawpot/conversation_history.md.
+    """Write full conversation history to .strawpot/conversations/{id}/history.md.
 
     Returns the absolute path to the file, or None if nothing was written.
     Last 5 turns get full output; turns 6-10 get recap only; older turns omitted.
@@ -259,9 +259,9 @@ def _write_conversation_history(conn, conversation_id: int, working_dir: str) ->
         parts.append("---")
         parts.append("")
 
-    history_dir = Path(working_dir) / ".strawpot"
+    history_dir = Path(working_dir) / ".strawpot" / "conversations" / str(conversation_id)
     history_dir.mkdir(parents=True, exist_ok=True)
-    history_path = history_dir / f"conversation_{conversation_id}_history.md"
+    history_path = history_dir / "history.md"
     try:
         history_path.write_text("\n".join(parts), encoding="utf-8")
         return str(history_path)

--- a/gui/tests/test_conversations.py
+++ b/gui/tests/test_conversations.py
@@ -1084,8 +1084,8 @@ class TestWriteConversationHistory:
 
         # Different files
         assert path_a != path_b
-        assert f"conversation_{cid_a}_history.md" in path_a
-        assert f"conversation_{cid_b}_history.md" in path_b
+        assert path_a.endswith(f"conversations/{cid_a}/history.md")
+        assert path_b.endswith(f"conversations/{cid_b}/history.md")
 
         # Each file contains only its own conversation's content
         content_a = open(path_a).read()


### PR DESCRIPTION
## Summary
- Change history file path from `.strawpot/conversation_{id}_history.md` to `.strawpot/conversations/{id}/history.md`
- Per-conversation folder structure allows future expansion (metadata, config, etc.)
- Update docs (sessions.mdx, quickstart.mdx) and DESIGN.md to match

## Test plan
- [x] All 7 history-related tests pass
- [ ] Verify history file written to correct path in running conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)