### PR TITLE
Thread group_id through session, delegation, and tracer

### DIFF
--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -763,6 +763,7 @@ def handle_delegate(
     agent_spans: dict[str, str] | None = None,
     register_agent: Callable[[str, str, str, int | None], None] | None = None,
     files_dirs: list[str] | None = None,
+    group_id: str | None = None,
 ) -> DelegateResult:
     """Handle a delegation request end-to-end.
 
@@ -922,6 +923,7 @@ def handle_delegate(
                 behavior_ref=role_prompt,
                 task=task_text,
                 parent_agent_id=request.parent_agent_id,
+                group_id=group_id,
             )
             if get_result.context_cards:
                 memory_prompt = _format_memory_prompt(get_result)
@@ -937,6 +939,7 @@ def handle_delegate(
                     cards=get_result.context_cards or [],
                     card_count=len(get_result.context_cards) if get_result.context_cards else 0,
                     parent_agent_id=request.parent_agent_id,
+                    group_id=group_id,
                 )
 
         # 7b. Register agent BEFORE spawning so that if the child
@@ -1024,6 +1027,7 @@ def handle_delegate(
                 status=_agent_status(result, timed_out=timed_out),
                 output=result.output,
                 parent_agent_id=request.parent_agent_id,
+                group_id=group_id,
             )
             if tracer is not None and delegate_span_id is not None:
                 tracer.memory_dump(
@@ -1037,6 +1041,7 @@ def handle_delegate(
                     status=_agent_status(result, timed_out=timed_out),
                     output=result.output,
                     parent_agent_id=request.parent_agent_id,
+                    group_id=group_id,
                 )
 
         # 8b. Handle timeout — no retry on timeout

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -435,6 +435,7 @@ class Session:
                     role=self.config.orchestrator_role,
                     behavior_ref=role_prompt,
                     task=self.memory_task,
+                    group_id=self._group_id,
                 )
                 if get_result.context_cards:
                     memory_prompt = _format_memory_prompt(get_result)
@@ -449,6 +450,7 @@ class Session:
                         task=self.memory_task,
                         cards=get_result.context_cards or [],
                         card_count=len(get_result.context_cards) if get_result.context_cards else 0,
+                        group_id=self._group_id,
                     )
 
             # 5b. Resolve project files directories
@@ -552,6 +554,7 @@ class Session:
                         task=self.memory_task,
                         status=status,
                         output=output,
+                        group_id=self._group_id,
                     )
                 except Exception:
                     logger.debug("Orchestrator memory.dump failed", exc_info=True)
@@ -566,6 +569,7 @@ class Session:
                         task=self.memory_task,
                         status=status,
                         output=output,
+                        group_id=self._group_id,
                     )
 
         # 0b. Emit session_end trace event before cleanup that might fail
@@ -983,6 +987,7 @@ class Session:
                 agent_spans=self._agent_spans,
                 register_agent=self._register_agent,
                 files_dirs=self._files_dirs,
+                group_id=self._group_id,
             )
             if result.exit_code != 0:
                 msg = f"Sub-agent exited with code {result.exit_code}"
@@ -1129,6 +1134,7 @@ class Session:
                 content=remember.content,
                 keywords=list(remember.keywords) or None,
                 scope=remember.scope or "project",
+                group_id=self._group_id,
             )
             if self._tracer is not None:
                 span_id = self._agent_spans.get(
@@ -1147,6 +1153,7 @@ class Session:
                         status=result.status,
                         entry_id=result.entry_id,
                         parent_agent_id=None,
+                        group_id=self._group_id,
                     )
             return ok_response(
                 request.request_id,
@@ -1186,6 +1193,7 @@ class Session:
                 keywords=list(recall.keywords) or None,
                 scope=recall.scope or "",
                 max_results=recall.max_results or 10,
+                group_id=self._group_id,
             )
             recall_entries = [
                 denden_pb2.RecallEntry(
@@ -1216,6 +1224,7 @@ class Session:
                             for e in result.entries
                         ] if result.entries else None,
                         parent_agent_id=None,
+                        group_id=self._group_id,
                     )
             return ok_response(
                 request.request_id,

--- a/cli/src/strawpot/trace.py
+++ b/cli/src/strawpot/trace.py
@@ -216,6 +216,7 @@ class Tracer:
         cards: list,
         card_count: int,
         parent_agent_id: str | None = None,
+        group_id: str | None = None,
     ) -> None:
         """Emit ``memory_get``.  Stores serialised cards as artifact."""
         cards_content = json.dumps([str(c) for c in cards]) if cards else ""
@@ -234,6 +235,7 @@ class Tracer:
             cards_ref=cards_ref,
             card_count=card_count,
             parent_agent_id=parent_agent_id,
+            group_id=group_id,
         )
 
     def memory_remember(
@@ -250,6 +252,7 @@ class Tracer:
         status: str = "",
         entry_id: str = "",
         parent_agent_id: str | None = None,
+        group_id: str | None = None,
     ) -> None:
         """Emit ``memory_remember``.  Stores content as artifact."""
         content_ref = self.store_artifact(content)
@@ -266,6 +269,7 @@ class Tracer:
             status=status,
             entry_id=entry_id,
             parent_agent_id=parent_agent_id,
+            group_id=group_id,
         )
 
     def memory_recall(
@@ -281,6 +285,7 @@ class Tracer:
         result_count: int = 0,
         results: list | None = None,
         parent_agent_id: str | None = None,
+        group_id: str | None = None,
     ) -> None:
         """Emit ``memory_recall``.  Stores results as artifact."""
         results_content = json.dumps(results, indent=2) if results else ""
@@ -297,6 +302,7 @@ class Tracer:
             result_count=result_count,
             results_ref=results_ref,
             parent_agent_id=parent_agent_id,
+            group_id=group_id,
         )
 
     def memory_dump(
@@ -312,6 +318,7 @@ class Tracer:
         status: str = "",
         output: str = "",
         parent_agent_id: str | None = None,
+        group_id: str | None = None,
     ) -> None:
         """Emit ``memory_dump``.  Stores behavior_ref and output as artifacts."""
         behavior_artifact = self.store_artifact(behavior_ref)
@@ -329,6 +336,7 @@ class Tracer:
             status=status,
             output_ref=output_ref,
             parent_agent_id=parent_agent_id,
+            group_id=group_id,
         )
 
     def agent_spawn(

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -1669,7 +1669,7 @@ def _mock_memory_provider(context_cards=None):
 
 class TestMemoryIntegration:
     def _run_delegate(self, tmp_path, runtime=None, memory_provider=None,
-                      **config_overrides):
+                      group_id=None, **config_overrides):
         """Helper to run handle_delegate with minimal setup."""
         base = str(tmp_path / "registry")
         role_path = _write_role(base, "implementer", "Implement things.")
@@ -1692,6 +1692,7 @@ class TestMemoryIntegration:
             resolve_role=lambda slug, kind="role": resolved,
             resolve_role_dirs=lambda s: None,
             memory_provider=memory_provider,
+            group_id=group_id,
         )
 
     def test_no_memory_provider_skips_calls(self, tmp_path):
@@ -1769,6 +1770,28 @@ class TestMemoryIntegration:
 
         dump_kwargs = provider.dump.call_args.kwargs
         assert dump_kwargs["status"] == "timeout"
+
+    def test_group_id_passed_to_memory_calls(self, tmp_path):
+        """group_id is forwarded to both memory.get and memory.dump."""
+        provider = _mock_memory_provider()
+        self._run_delegate(tmp_path, memory_provider=provider, group_id="conv_42")
+
+        get_kwargs = provider.get.call_args.kwargs
+        assert get_kwargs["group_id"] == "conv_42"
+
+        dump_kwargs = provider.dump.call_args.kwargs
+        assert dump_kwargs["group_id"] == "conv_42"
+
+    def test_group_id_none_by_default(self, tmp_path):
+        """Without group_id, memory calls receive None."""
+        provider = _mock_memory_provider()
+        self._run_delegate(tmp_path, memory_provider=provider)
+
+        get_kwargs = provider.get.call_args.kwargs
+        assert get_kwargs["group_id"] is None
+
+        dump_kwargs = provider.dump.call_args.kwargs
+        assert dump_kwargs["group_id"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Pass `group_id` from `Session` to all memory provider calls (`get`, `dump`, `remember`, `recall`) and all tracer memory events (DESIGN item 19)
- `handle_delegate` accepts `group_id` and forwards to sub-agent memory/tracer calls
- Requires dial#22 (accept group_id) to avoid TypeError at runtime

## Test plan

- [x] All 581 CLI tests pass (including 2 new delegation tests)
- [x] All 510 GUI tests pass
- [x] `test_group_id_passed_to_memory_calls` — verifies group_id flows to get/dump
- [x] `test_group_id_none_by_default` — verifies None when not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)