### PR TITLE
Mark Phase 5 items Done, drop item 23

### DIFF
--- a/designs/context/DESIGN.md
+++ b/designs/context/DESIGN.md
@@ -433,13 +433,14 @@ def em_group_dir(storage_dir: Path, group_id: str) -> Path:
 
 | em_scope | group_id | Behavior |
 |----------|----------|----------|
-| `"session"` | any | Current session only (unchanged) |
 | `"group"` | set | All sessions in this group's directory |
-| `"group"` | None | Falls back to session scope |
+| `"group"` | None | Falls back to project scope |
 | `"project"` | any | All sessions in project `em/` (unchanged — opt-in for cross-group) |
 | `"global"` | any | Project + global (unchanged) |
 | `"auto"` | set | → `"group"` |
 | `"auto"` | None | → `"project"` |
+
+`"session"` scope was removed — session IDs are unique UUIDs so a session's own EM file is always empty at `get()` time (`dump()` writes at the end). There is no useful "current session only" read.
 
 **EM write (dump):** When `group_id` is set, write to `em/groups/{group_id}/{session_id}.jsonl` instead of `em/{session_id}.jsonl`.
 


### PR DESCRIPTION
## Summary
- Mark items 18, 19, 21, 22 as Done in DESIGN.md
- Drop item 23 (group scope for remember/recall) with reasoning: knowledge (SM/RM) should stay shared across conversations — EM handles conversation-scoped context, knowledge handles durable project facts
- Update scope hierarchy diagram (EM-only for groups)
- Update files-to-modify table

## Test plan
- [x] DESIGN.md reflects correct status for all Phase 5 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)