### PR TITLE
Drain conversation task queue when session stops

### DIFF
--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -117,6 +117,7 @@ def _refresh_session_status(conn, run_id: str) -> None:
                     "UPDATE sessions SET status = 'failed' WHERE run_id = ?",
                     (run_id,),
                 )
+                _drain_pending_task(conn, row["conversation_id"])
         return
 
     session_json = os.path.join(session_dir, "session.json")
@@ -172,6 +173,7 @@ def _refresh_session_status(conn, run_id: str) -> None:
                 "UPDATE sessions SET status = 'failed' WHERE run_id = ?",
                 (run_id,),
             )
+            _drain_pending_task(conn, row["conversation_id"])
 
 
 # ---------------------------------------------------------------------------
@@ -580,12 +582,14 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
     project_id = row["project_id"]
     conversation_id = row["conversation_id"]
 
-    # Clear any queued pending_task — user explicitly interrupted the flow
-    if conversation_id:
+    def _mark_stopped_and_drain() -> dict:
         conn.execute(
-            "UPDATE conversations SET pending_task = NULL WHERE id = ?",
-            (conversation_id,),
+            "UPDATE sessions SET status = 'stopped', summary = COALESCE(summary, 'Interrupted') WHERE run_id = ?",
+            (run_id,),
         )
+        _drain_pending_task(conn, conversation_id)
+        event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
+        return {"run_id": run_id, "status": "stopped"}
 
     # Read PID from session.json
     session_dir = Path(row["session_dir"])
@@ -594,50 +598,30 @@ def stop_session(run_id: str, conn=Depends(get_db_conn)):
         data = json.loads(session_json.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         # session.json not created yet — session never fully started
-        conn.execute(
-            "UPDATE sessions SET status = 'stopped', summary = COALESCE(summary, 'Interrupted') WHERE run_id = ?",
-            (run_id,),
-        )
-        event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
-        return {"run_id": run_id, "status": "stopped"}
+        return _mark_stopped_and_drain()
 
     pid = data.get("pid")
     if pid is None:
-        # No PID recorded — mark as stopped
-        conn.execute(
-            "UPDATE sessions SET status = 'stopped', summary = COALESCE(summary, 'Interrupted') WHERE run_id = ?",
-            (run_id,),
-        )
-        event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
-        return {"run_id": run_id, "status": "stopped"}
+        return _mark_stopped_and_drain()
 
     # Check liveness and send SIGTERM
     try:
         os.kill(pid, 0)
     except (ProcessLookupError, OSError):
         # Process already gone
-        conn.execute(
-            "UPDATE sessions SET status = 'stopped', summary = COALESCE(summary, 'Interrupted') WHERE run_id = ?",
-            (run_id,),
-        )
-        event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
-        return {"run_id": run_id, "status": "stopped"}
+        return _mark_stopped_and_drain()
 
     try:
         os.kill(pid, signal.SIGTERM)
     except (ProcessLookupError, OSError):
         # Race: died between check and kill
-        conn.execute(
-            "UPDATE sessions SET status = 'stopped', summary = COALESCE(summary, 'Interrupted') WHERE run_id = ?",
-            (run_id,),
-        )
-        event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
-        return {"run_id": run_id, "status": "stopped"}
+        return _mark_stopped_and_drain()
 
     conn.execute(
         "UPDATE sessions SET status = 'stopped' WHERE run_id = ?",
         (run_id,),
     )
+    _drain_pending_task(conn, conversation_id)
     event_bus.publish(SessionEvent(kind="session_stopped", run_id=run_id, project_id=project_id))
     return {"run_id": run_id, "status": "stopped"}
 

--- a/gui/tests/test_session_stop.py
+++ b/gui/tests/test_session_stop.py
@@ -4,6 +4,7 @@ import json
 import os
 from unittest.mock import patch
 
+from test_conversations import _create_conversation, _submit_task
 from test_sessions_sync import _register_project, _write_session
 
 from strawpot_gui.db import get_db, sync_sessions
@@ -139,3 +140,54 @@ class TestStopSession:
         resp = client.post("/api/sessions/run_nopid/stop")
         assert resp.status_code == 200
         assert resp.json() == {"run_id": "run_nopid", "status": "stopped"}
+
+    def test_stop_drains_queued_task(self, client, tmp_path, app):
+        """Stopping a session drains the next queued task."""
+        d = tmp_path / "proj"
+        d.mkdir()
+        pid = _register_project(client, d)
+        conv = _create_conversation(client, pid)
+        cid = conv["id"]
+
+        # Launch first task — creates a session
+        resp1 = _submit_task(client, cid, task="First task")
+        run_id1 = resp1.json()["run_id"]
+
+        # Queue a second task (session already active → 202)
+        _submit_task(client, cid, task="Queued task")
+
+        # Verify task is queued
+        with get_db(app.state.db_path) as conn:
+            queued = conn.execute(
+                "SELECT task FROM conversation_task_queue WHERE conversation_id = ?",
+                (cid,),
+            ).fetchall()
+        assert len(queued) == 1
+        assert queued[0]["task"] == "Queued task"
+
+        # Stop the first session — should drain the queued task
+        with patch("strawpot_gui.routers.sessions.os.kill"), \
+             patch("strawpot_gui.routers.sessions.shutil.which", return_value="/usr/bin/strawpot"), \
+             patch("strawpot_gui.routers.sessions.subprocess.Popen"), \
+             patch("strawpot_gui.routers.sessions.load_config") as mock_config:
+            from strawpot.config import StrawPotConfig
+            mock_config.return_value = StrawPotConfig()
+            resp = client.post(f"/api/sessions/{run_id1}/stop")
+
+        assert resp.status_code == 200
+
+        # Queue should be empty — task was drained
+        with get_db(app.state.db_path) as conn:
+            remaining = conn.execute(
+                "SELECT id FROM conversation_task_queue WHERE conversation_id = ?",
+                (cid,),
+            ).fetchall()
+        assert len(remaining) == 0
+
+        # A new session should have been created for the queued task
+        with get_db(app.state.db_path) as conn:
+            sessions = conn.execute(
+                "SELECT run_id FROM sessions WHERE conversation_id = ?",
+                (cid,),
+            ).fetchall()
+        assert len(sessions) == 2


### PR DESCRIPTION
## Summary
- `stop_session` and `_refresh_session_status` failure paths were not calling `_drain_pending_task()`, so queued tasks never launched after a session ended
- Consolidated 4 duplicate stop-and-update blocks in `stop_session` into a `_mark_stopped_and_drain()` helper
- Added `_drain_pending_task()` to all terminal paths: stop_session (all exit paths), _refresh_session_status PID-gone and session-dir-timeout cases

## Test plan
- [x] Added `test_stop_drains_queued_task` — verifies stopping a session pops the next queued task and launches a new session
- [x] All 9 session stop tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)