### PR TITLE
Integration UI cleanup

### DIFF
--- a/gui/frontend/src/components/IntegrationDetailSheet.tsx
+++ b/gui/frontend/src/components/IntegrationDetailSheet.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/sheet";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Switch } from "@/components/ui/switch";
-import { Play, Square } from "lucide-react";
+import { Eye, EyeOff, Play, Square } from "lucide-react";
 import { toast } from "sonner";
 
 interface Props {
@@ -337,19 +337,34 @@ function ConfigField({
   value: string;
   onChange: (value: string) => void;
 }) {
+  const [visible, setVisible] = useState(false);
   return (
     <div className="space-y-1.5">
       <Label htmlFor={`config-${name}`}>
         {name}
         {field.required && <span className="text-destructive ml-0.5">*</span>}
       </Label>
-      <Input
-        id={`config-${name}`}
-        type="password"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={field.description}
-      />
+      <div className="relative">
+        <Input
+          id={`config-${name}`}
+          type={visible ? "text" : "password"}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.description}
+          className="pr-8"
+        />
+        <button
+          type="button"
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          onClick={() => setVisible((v) => !v)}
+        >
+          {visible ? (
+            <EyeOff className="h-3.5 w-3.5" />
+          ) : (
+            <Eye className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </div>
       {field.description && (
         <p className="text-xs text-muted-foreground">{field.description}</p>
       )}

--- a/gui/frontend/src/components/ProjectIntegrationsTab.tsx
+++ b/gui/frontend/src/components/ProjectIntegrationsTab.tsx
@@ -1,10 +1,6 @@
 import { useState } from "react";
 import { useIntegrations } from "@/hooks/queries/use-integrations";
-import { useInstallIntegration } from "@/hooks/mutations/use-integrations";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   Table,
@@ -14,18 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Skeleton } from "@/components/ui/skeleton";
-import { CheckCircle2, Download, XCircle } from "lucide-react";
-import { toast } from "sonner";
 import type { Integration } from "@/api/types";
 import IntegrationDetailSheet from "@/components/IntegrationDetailSheet";
 import IntegrationLogSheet from "@/components/IntegrationLogSheet";
@@ -50,7 +35,6 @@ export default function ProjectIntegrationsTab({ projectId }: Props) {
   const [sheetOpen, setSheetOpen] = useState(false);
   const [logName, setLogName] = useState<string | null>(null);
   const [logProjectId, setLogProjectId] = useState<number | undefined>(undefined);
-  const [installOpen, setInstallOpen] = useState(false);
 
   const integrationList = integrations ?? [];
 
@@ -62,16 +46,6 @@ export default function ProjectIntegrationsTab({ projectId }: Props) {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">
-          Integrations installed in this project
-        </p>
-        <Button onClick={() => setInstallOpen(true)} size="sm">
-          <Download className="mr-2 h-4 w-4" />
-          Install
-        </Button>
-      </div>
-
       {isLoading ? (
         <div className="space-y-2">
           {Array.from({ length: 3 }).map((_, i) => (
@@ -144,122 +118,6 @@ export default function ProjectIntegrationsTab({ projectId }: Props) {
         onOpenChange={(open) => { if (!open) setLogName(null); }}
       />
 
-      <InstallProjectIntegrationDialog
-        open={installOpen}
-        onOpenChange={setInstallOpen}
-        projectId={projectId}
-      />
     </div>
-  );
-}
-
-function InstallProjectIntegrationDialog({
-  open,
-  onOpenChange,
-  projectId,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  projectId: number;
-}) {
-  const install = useInstallIntegration();
-  const [name, setName] = useState("");
-  const [result, setResult] = useState<{ status: "success" | "error"; message: string } | null>(null);
-  const [output, setOutput] = useState<string | null>(null);
-  const isDone = result?.status === "success";
-
-  const handleInstall = () => {
-    if (!name.trim()) return;
-    setResult(null);
-    setOutput(null);
-    install.mutate({ name: name.trim(), projectId }, {
-      onSuccess: (res) => {
-        if (res.exit_code === 0) {
-          toast.success(`Installed ${name.trim()}`);
-          setResult({ status: "success", message: `Successfully installed ${name.trim()}` });
-          setOutput(res.stdout || null);
-        } else {
-          setResult({ status: "error", message: "Installation failed" });
-          setOutput(res.stderr || res.stdout || "Unknown error.");
-        }
-      },
-      onError: () => {
-        setResult({ status: "error", message: "Install request failed" });
-        toast.error("Install request failed");
-      },
-    });
-  };
-
-  const handleClose = (v: boolean) => {
-    if (!v) {
-      setResult(null);
-      setOutput(null);
-      setName("");
-    }
-    onOpenChange(v);
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Install Integration</DialogTitle>
-          <DialogDescription>
-            Install a chat adapter for this project from Strawhub by name.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="flex flex-col gap-4">
-          {result && (
-            <Alert variant={result.status === "error" ? "destructive" : "default"} className={result.status === "success" ? "border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-300" : ""}>
-              {result.status === "success" ? (
-                <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
-              ) : (
-                <XCircle className="h-4 w-4" />
-              )}
-              <AlertTitle>{result.status === "success" ? "Installed" : "Error"}</AlertTitle>
-              <AlertDescription>{result.message}</AlertDescription>
-            </Alert>
-          )}
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="install-project-integration-name">Package Name</Label>
-            <Input
-              id="install-project-integration-name"
-              autoFocus
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="e.g. telegram"
-              readOnly={isDone}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleInstall();
-              }}
-            />
-          </div>
-          {output && (
-            <details className="text-sm">
-              <summary className="cursor-pointer text-xs font-medium text-muted-foreground">
-                Output
-              </summary>
-              <pre className="mt-2 max-h-40 overflow-auto rounded-md bg-muted p-3 text-xs">
-                {output}
-              </pre>
-            </details>
-          )}
-        </div>
-        <DialogFooter>
-          {isDone ? (
-            <Button onClick={() => handleClose(false)}>
-              Done
-            </Button>
-          ) : (
-            <Button
-              onClick={handleInstall}
-              disabled={!name.trim() || install.isPending}
-            >
-              {install.isPending ? "Installing..." : "Install"}
-            </Button>
-          )}
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 }

--- a/gui/frontend/src/layouts/AppLayout.tsx
+++ b/gui/frontend/src/layouts/AppLayout.tsx
@@ -1,9 +1,9 @@
 import { useRef, useState } from "react";
 import { Link, NavLink, Outlet, useLocation, useMatch, useNavigate } from "react-router-dom";
 import { useTheme } from "next-themes";
-import { ArrowLeft, LayoutDashboard, FolderKanban, Clock, CalendarClock, History, BotMessageSquare, Users, Wrench, Bot, Brain, Plug, Pencil, Plus, Settings, Sun, Moon, Check, ChevronsUpDown, Trash2 } from "lucide-react";
+import { ArrowLeft, LayoutDashboard, FolderKanban, Clock, CalendarClock, History, BotMessageSquare, Users, Wrench, Bot, Brain, Plug, Pencil, Plus, Settings, Sun, Moon, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useProject, useProjects } from "@/hooks/queries/use-projects";
+import { useProject } from "@/hooks/queries/use-projects";
 import { useImuConversations, useProjectConversations } from "@/hooks/queries/use-conversations";
 import { useCreateConversation, useCreateImuConversation, useDeleteImuConversation, useDeleteConversation, useRenameConversation, useRenameImuConversation } from "@/hooks/mutations/use-conversations";
 import type { ImuConversation } from "@/api/types";
@@ -386,7 +386,7 @@ function useBreadcrumbs() {
   const { data: imuConversations } = useImuConversations();
   const imuConvTitle = imuConversations?.find((c) => c.id === imuConvId)?.title ?? null;
 
-  const crumbs: { label: string; href?: string; projectSwitcher?: boolean }[] = [];
+  const crumbs: { label: string; href?: string }[] = [];
 
   if (segments[0] === "projects") {
     // Bot Imu (project_id=0) has its own section in the nav — show as "Bot Imu" not "Projects > Bot Imu"
@@ -401,7 +401,7 @@ function useBreadcrumbs() {
       if (segments[1]) {
         const projectHref = `/projects/${segments[1]}`;
         const projectLabel = project?.display_name ?? `Project #${segments[1]}`;
-        crumbs.push({ label: projectLabel, href: projectHref, projectSwitcher: true });
+        crumbs.push({ label: projectLabel, href: projectHref });
 
         if (segments[2] === "sessions" && segments[3]) {
           crumbs.push({ label: `Session ${segments[3].slice(0, 8)}…` });
@@ -461,8 +461,6 @@ function useBreadcrumbs() {
 
 export default function AppLayout() {
   const crumbs = useBreadcrumbs();
-  const navigate = useNavigate();
-  const allProjects = useProjects();
   const { data: imuConversations } = useImuConversations();
   const hasActiveImuSession = (imuConversations ?? []).some((c) => c.active_session_count > 0);
   const { setTheme } = useTheme();
@@ -573,29 +571,7 @@ export default function AppLayout() {
                 return (
                   <BreadcrumbItem key={crumb.label}>
                     {i > 0 && <BreadcrumbSeparator />}
-                    {crumb.projectSwitcher ? (
-                      <DropdownMenu>
-                        <DropdownMenuTrigger className="flex items-center gap-1 text-sm font-medium text-foreground hover:text-foreground/80 transition-colors">
-                          {crumb.label}
-                          <ChevronsUpDown className="h-3 w-3 text-muted-foreground" />
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="start">
-                          {(allProjects.data ?? []).map((proj) => (
-                            <DropdownMenuItem
-                              key={proj.id}
-                              onClick={() => navigate(`/projects/${proj.id}`)}
-                            >
-                              {crumb.href === `/projects/${proj.id}` ? (
-                                <Check className="mr-2 h-3.5 w-3.5" />
-                              ) : (
-                                <span className="mr-2 inline-block w-3.5" />
-                              )}
-                              {proj.display_name}
-                            </DropdownMenuItem>
-                          ))}
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    ) : isLast ? (
+                    {isLast ? (
                       <BreadcrumbPage>{crumb.label}</BreadcrumbPage>
                     ) : (
                       <BreadcrumbLink href={crumb.href}>


### PR DESCRIPTION
## Summary
- Add Eye/EyeOff toggle on integration config fields to reveal env values (both global and project detail sheets)
- Replace project switcher dropdown in breadcrumb header with a regular link to the project page
- Remove Install button and dialog from project integrations tab
- Remove redundant "Integrations installed in this project" label

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [ ] Verify eye toggle shows/hides config values in integration detail sheet
- [ ] Verify breadcrumb project name links to project page
- [ ] Verify project integrations tab no longer shows Install button

🤖 Generated with [Claude Code](https://claude.com/claude-code)