### PR TITLE
Fix conversation scroll-up bug and persist interactive mode

### DIFF
--- a/gui/frontend/src/hooks/mutations/use-conversations.ts
+++ b/gui/frontend/src/hooks/mutations/use-conversations.ts
@@ -53,7 +53,7 @@ export function useSubmitConversationTask(conversationId: number) {
           (old) => {
             if (!old) return old;
             const pages = old.pages.map((page, i) => {
-              if (i !== old.pages.length - 1) return page;
+              if (i !== 0) return page;
               const newTask = {
                 id: -Date.now(), // temporary ID until refetch
                 task: variables.task,

--- a/gui/frontend/src/hooks/queries/use-conversations.ts
+++ b/gui/frontend/src/hooks/queries/use-conversations.ts
@@ -25,9 +25,9 @@ export function useConversationInfinite(
         `/conversations/${id}?limit=20${pageParam ? `&before_id=${encodeURIComponent(pageParam)}` : ""}`,
       ),
     initialPageParam: null as string | null,
-    getPreviousPageParam: (firstPage) =>
-      firstPage.has_more ? (firstPage.sessions[0]?.run_id ?? null) : null,
-    getNextPageParam: () => null,
+    getPreviousPageParam: () => null,
+    getNextPageParam: (lastPage) =>
+      lastPage.has_more ? (lastPage.sessions[0]?.run_id ?? null) : null,
     ...options,
   });
 }

--- a/gui/frontend/src/pages/ConversationView.tsx
+++ b/gui/frontend/src/pages/ConversationView.tsx
@@ -156,7 +156,15 @@ export default function ConversationView() {
   const [advCacheDelegations, setAdvCacheDelegations] = useState("");
   const [advCacheMaxEntries, setAdvCacheMaxEntries] = useState("");
   const [advCacheTtl, setAdvCacheTtl] = useState("");
-  const [interactive, setInteractive] = useState(false);
+  const [interactive, setInteractive] = useState(() => {
+    try { return localStorage.getItem(`conv:${cid}:interactive`) === "true"; } catch { return false; }
+  });
+  useEffect(() => {
+    try { setInteractive(localStorage.getItem(`conv:${cid}:interactive`) === "true"); } catch {}
+  }, [cid]);
+  useEffect(() => {
+    try { localStorage.setItem(`conv:${cid}:interactive`, String(interactive)); } catch {}
+  }, [cid, interactive]);
   const [askUserResponse, setAskUserResponse] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -180,12 +188,12 @@ export default function ConversationView() {
   } | undefined;
 
   // Initial load — no polling yet
-  const { data, isLoading, error, fetchPreviousPage, hasPreviousPage, isFetchingPreviousPage } =
+  const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useConversationInfinite(cid);
 
-  // Flatten pages: pages[0]=oldest loaded, pages[last]=newest
-  const allSessions = data?.pages.flatMap((p) => p.sessions) ?? [];
-  const conversation = data?.pages[data.pages.length - 1];
+  // Flatten pages: pages[0]=newest, pages[1+]=older → reverse for chronological display
+  const allSessions = data?.pages.slice().reverse().flatMap((p) => p.sessions) ?? [];
+  const conversation = data?.pages[0];
   const lastSession = allSessions[allSessions.length - 1];
   const hasActiveSession =
     lastSession?.status === "running" || lastSession?.status === "starting";
@@ -210,7 +218,7 @@ export default function ConversationView() {
 
   const isActive = hasActiveSession;
 
-  // Scroll anchor: restore position when older pages are prepended
+  // Scroll anchor: restore position when older pages are appended (rendered at top)
   useEffect(() => {
     if (!scrollRef.current) return;
     const delta = scrollRef.current.scrollHeight - prevScrollHeightRef.current;
@@ -243,16 +251,16 @@ export default function ConversationView() {
     if (!sentinelRef.current || !scrollRef.current) return;
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting && hasPreviousPage && !isFetchingPreviousPage) {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
           prevScrollHeightRef.current = scrollRef.current?.scrollHeight ?? 0;
-          fetchPreviousPage();
+          fetchNextPage();
         }
       },
       { root: scrollRef.current, threshold: 0.1 },
     );
     observer.observe(sentinelRef.current);
     return () => observer.disconnect();
-  }, [hasPreviousPage, isFetchingPreviousPage, fetchPreviousPage]);
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const agentNames = (projectResources ?? [])
     .filter((r) => r.type === "agents")
@@ -434,7 +442,7 @@ export default function ConversationView() {
         <div className="mx-auto w-full max-w-2xl space-y-6 py-4">
           {/* Sentinel at top triggers loading older sessions */}
           <div ref={sentinelRef} className="h-1" />
-          {isFetchingPreviousPage && (
+          {isFetchingNextPage && (
             <div className="flex justify-center py-2">
               <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
             </div>

--- a/gui/frontend/src/pages/ImuPage.tsx
+++ b/gui/frontend/src/pages/ImuPage.tsx
@@ -196,7 +196,15 @@ function ImuOnboarding({ onSelectPrompt }: { onSelectPrompt: (text: string) => v
 
 function ImuConversationView({ cid }: { cid: number }) {
   const [task, setTask] = useState("");
-  const [interactive, setInteractive] = useState(false);
+  const [interactive, setInteractive] = useState(() => {
+    try { return localStorage.getItem(`conv:${cid}:interactive`) === "true"; } catch { return false; }
+  });
+  useEffect(() => {
+    try { setInteractive(localStorage.getItem(`conv:${cid}:interactive`) === "true"); } catch {}
+  }, [cid]);
+  useEffect(() => {
+    try { localStorage.setItem(`conv:${cid}:interactive`, String(interactive)); } catch {}
+  }, [cid, interactive]);
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -231,11 +239,12 @@ function ImuConversationView({ cid }: { cid: number }) {
       prev.includes(path) ? prev.filter((p) => p !== path) : [...prev, path],
     );
 
-  const { data, isLoading, error, fetchPreviousPage, hasPreviousPage, isFetchingPreviousPage } =
+  const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useConversationInfinite(cid);
 
-  const allSessions = data?.pages.flatMap((p) => p.sessions) ?? [];
-  const conversation = data?.pages[data.pages.length - 1];
+  // Flatten pages: pages[0]=newest, pages[1+]=older → reverse for chronological display
+  const allSessions = data?.pages.slice().reverse().flatMap((p) => p.sessions) ?? [];
+  const conversation = data?.pages[0];
   const lastSession = allSessions[allSessions.length - 1];
   const hasActiveSession =
     lastSession?.status === "running" || lastSession?.status === "starting";
@@ -303,16 +312,16 @@ function ImuConversationView({ cid }: { cid: number }) {
     if (!sentinelRef.current || !scrollRef.current) return;
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting && hasPreviousPage && !isFetchingPreviousPage) {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
           prevScrollHeightRef.current = scrollRef.current?.scrollHeight ?? 0;
-          fetchPreviousPage();
+          fetchNextPage();
         }
       },
       { root: scrollRef.current, threshold: 0.1 },
     );
     observer.observe(sentinelRef.current);
     return () => observer.disconnect();
-  }, [hasPreviousPage, isFetchingPreviousPage, fetchPreviousPage]);
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const handleDragOver = (e: React.DragEvent) => { e.preventDefault(); setIsDragging(true); };
   const handleDragEnter = (e: React.DragEvent) => { e.preventDefault(); setIsDragging(true); };
@@ -435,7 +444,7 @@ function ImuConversationView({ cid }: { cid: number }) {
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-2xl space-y-6 py-4">
           <div ref={sentinelRef} className="h-1" />
-          {isFetchingPreviousPage && (
+          {isFetchingNextPage && (
             <div className="flex justify-center py-2">
               <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
             </div>


### PR DESCRIPTION
## Summary
- **Scroll fix**: Inverted infinite query pagination direction so `pages[0]` = newest. When global WebSocket events trigger `invalidateQueries` mid-refetch, the newest page (most important) now survives instead of being dropped. Applied to both ConversationView and ImuPage.
- **Interactive mode persist**: Auto/Interactive toggle is now saved per conversation in `localStorage`, surviving navigation away and back. Reads stored value on conversation switch via sidebar.

## Test plan
- [ ] Open a conversation with multiple sessions, scroll up to load older sessions, scroll back down — newest sessions should remain visible
- [ ] Toggle to Interactive mode, navigate away, come back — mode should be restored
- [ ] Switch between conversations via sidebar — each conversation's toggle state should be independent
- [ ] Verify same behavior on Imu page

🤖 Generated with [Claude Code](https://claude.com/claude-code)