### PR TITLE
Display schedule times in local timezone

### DIFF
--- a/gui/frontend/src/components/CreateScheduleDialog.tsx
+++ b/gui/frontend/src/components/CreateScheduleDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import cronstrue from "cronstrue";
+import { cronLocalToUtc, cronUtcToLocal } from "@/lib/utils";
 import { useProjects } from "@/hooks/queries/use-projects";
 import { useProjectResources } from "@/hooks/queries/use-project-resources";
 import { useProjectConversations, useImuConversations } from "@/hooks/queries/use-conversations";
@@ -42,6 +43,7 @@ const CRON_PRESETS = [
   { label: "Every hour", value: "0 * * * *" },
   { label: "Daily at midnight", value: "0 0 * * *" },
   { label: "Weekdays at 9am", value: "0 9 * * 1-5" },
+  { label: "Weekdays at 10am", value: "0 10 * * 1-5" },
   { label: "Weekly Monday 9am", value: "0 9 * * 1" },
 ];
 
@@ -100,7 +102,7 @@ export default function CreateScheduleDialog({
       setName(editing.name);
       setProjectId(String(editing.project_id));
       setTask(editing.task);
-      setCronExpr(editing.cron_expr ?? "");
+      setCronExpr(editing.cron_expr ? cronUtcToLocal(editing.cron_expr) : "");
       setRole(editing.role ?? "");
       setSystemPrompt(editing.system_prompt ?? "");
       setSkipIfRunning(editing.skip_if_running);
@@ -145,7 +147,7 @@ export default function CreateScheduleDialog({
       const body = {
         name: name.trim(),
         task: task.trim(),
-        cron_expr: cronExpr.trim(),
+        cron_expr: cronLocalToUtc(cronExpr.trim()),
         role: role.trim() || undefined,
         system_prompt: systemPrompt.trim() || undefined,
         skip_if_running: skipIfRunning,

--- a/gui/frontend/src/lib/utils.ts
+++ b/gui/frontend/src/lib/utils.ts
@@ -4,3 +4,37 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Convert a UTC cron expression's hour/minute fields to local time.
+ * Only handles simple numeric hour/minute (not ranges or steps).
+ * Returns the original string if it can't convert.
+ */
+export function cronUtcToLocal(cron: string): string {
+  const parts = cron.split(/\s+/);
+  if (parts.length < 5) return cron;
+  const [min, hour, ...rest] = parts;
+  const utcH = parseInt(hour, 10);
+  const utcM = parseInt(min, 10);
+  if (isNaN(utcH) || isNaN(utcM)) return cron;
+  const d = new Date();
+  d.setUTCHours(utcH, utcM, 0, 0);
+  return `${d.getMinutes()} ${d.getHours()} ${rest.join(" ")}`;
+}
+
+/**
+ * Convert a local-time cron expression's hour/minute fields to UTC.
+ * Only handles simple numeric hour/minute (not ranges or steps).
+ * Returns the original string if it can't convert.
+ */
+export function cronLocalToUtc(cron: string): string {
+  const parts = cron.split(/\s+/);
+  if (parts.length < 5) return cron;
+  const [min, hour, ...rest] = parts;
+  const localH = parseInt(hour, 10);
+  const localM = parseInt(min, 10);
+  if (isNaN(localH) || isNaN(localM)) return cron;
+  const d = new Date();
+  d.setHours(localH, localM, 0, 0);
+  return `${d.getUTCMinutes()} ${d.getUTCHours()} ${rest.join(" ")}`;
+}

--- a/gui/frontend/src/pages/ScheduledTasks.tsx
+++ b/gui/frontend/src/pages/ScheduledTasks.tsx
@@ -1,4 +1,6 @@
 import { useState } from "react";
+import cronstrue from "cronstrue";
+import { cronUtcToLocal } from "@/lib/utils";
 import { useSchedules } from "@/hooks/queries/use-schedules";
 import { useDeleteSchedule, useToggleSchedule } from "@/hooks/mutations/use-schedules";
 import CreateScheduleDialog from "@/components/CreateScheduleDialog";
@@ -22,6 +24,15 @@ import {
 import { AlertCircle, Pause, Pencil, Play, Plus, Trash2 } from "lucide-react";
 import type { Schedule } from "@/api/types";
 
+function cronToLocalDesc(cron: string | null): string {
+  if (!cron) return "—";
+  try {
+    return cronstrue.toString(cronUtcToLocal(cron));
+  } catch {
+    return cron;
+  }
+}
+
 function formatRelative(iso: string | null): string {
   if (!iso) return "—";
   try {
@@ -39,6 +50,18 @@ function formatRelative(iso: string | null): string {
       return diffMs > 0 ? `in ${hours}h` : `${hours}h ago`;
     }
     return d.toLocaleDateString();
+  } catch {
+    return "—";
+  }
+}
+
+function formatLocalDateTime(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      weekday: "short", month: "short", day: "numeric",
+      hour: "numeric", minute: "2-digit",
+    });
   } catch {
     return "—";
   }
@@ -120,7 +143,7 @@ export default function ScheduledTasks() {
               <TableRow>
                 <TableHead>Name</TableHead>
                 <TableHead>Project</TableHead>
-                <TableHead>Cron</TableHead>
+                <TableHead>Schedule</TableHead>
                 <TableHead>Next Run</TableHead>
                 <TableHead>Last Run</TableHead>
                 <TableHead>Status</TableHead>
@@ -134,13 +157,12 @@ export default function ScheduledTasks() {
                   <TableCell className="text-muted-foreground">
                     {s.project_name}
                   </TableCell>
-                  <TableCell>
-                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
-                      {s.cron_expr}
-                    </code>
+                  <TableCell className="text-sm">
+                    {cronToLocalDesc(s.cron_expr)}
                   </TableCell>
                   <TableCell className="text-sm text-muted-foreground">
-                    {formatRelative(s.next_run_at)}
+                    <span>{formatLocalDateTime(s.next_run_at)}</span>
+                    <span className="ml-1 text-xs opacity-60">({formatRelative(s.next_run_at)})</span>
                   </TableCell>
                   <TableCell className="text-sm text-muted-foreground">
                     {formatRelative(s.last_run_at)}


### PR DESCRIPTION
## Summary
- Add `cronUtcToLocal` / `cronLocalToUtc` helpers to convert cron hour/minute between UTC and local time
- Schedule table replaces raw cron with human-readable local description (via cronstrue)
- Next Run column shows local datetime with relative time in parentheses
- Edit dialog shows cron in local time, converts to UTC on save
- Presets in create dialog use local times

## Test plan
- [ ] Verify Schedule column shows correct local times (e.g., "At 10:00 AM, only on Friday" for PDT)
- [ ] Verify Next Run matches the Schedule description
- [ ] Edit a schedule and confirm cron input shows local time
- [ ] Save and verify the stored cron is UTC (check DB)
- [ ] Create a new schedule with a preset, verify it saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)