### PR TITLE
Limit schedule dialog height with scrollable overflow

### DIFF
--- a/gui/frontend/src/components/CreateOneTimeScheduleDialog.tsx
+++ b/gui/frontend/src/components/CreateOneTimeScheduleDialog.tsx
@@ -141,7 +141,7 @@ export default function CreateOneTimeScheduleDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Create One-Time Schedule</DialogTitle>
         </DialogHeader>

--- a/gui/frontend/src/components/CreateScheduleDialog.tsx
+++ b/gui/frontend/src/components/CreateScheduleDialog.tsx
@@ -182,7 +182,7 @@ export default function CreateScheduleDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {editing ? "Edit Schedule" : "Create Schedule"}


### PR DESCRIPTION
## Summary
- Add `max-h-[90vh] overflow-y-auto` to both CreateScheduleDialog and CreateOneTimeScheduleDialog
- Matches existing LaunchDialog pattern
- Covers all four dialog modes: Create Schedule, Edit Schedule, Create One-Time, Edit One-Time

## Test plan
- [ ] Open Create Schedule, expand Advanced Options, verify dialog scrolls instead of overflowing viewport
- [ ] Same for Create One-Time Schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)