### PR TITLE
Fix config crash on string skills/roles entries

### DIFF
--- a/cli/src/strawpot/config.py
+++ b/cli/src/strawpot/config.py
@@ -92,12 +92,16 @@ def _apply(config: StrawPotConfig, data: dict) -> None:
 
     skills_section = data.get("skills", {})
     for slug, skill_data in skills_section.items():
+        if not isinstance(skill_data, dict):
+            continue
         env_data = skill_data.get("env", {})
         if env_data:
             config.skills.setdefault(slug, {}).update(env_data)
 
     roles_section = data.get("roles", {})
     for slug, role_data in roles_section.items():
+        if not isinstance(role_data, dict):
+            continue
         config.roles.setdefault(slug, {}).update(role_data)
 
     if "memory" in data:


### PR DESCRIPTION
## Summary
- Skip non-dict entries (e.g. `"*"` version constraints) in `[skills]` and `[roles]` sections of `strawpot.toml`
- Fixes `AttributeError: 'str' object has no attribute 'get'` when project toml has lockfile-style entries

## Test plan
- [x] All 22 config tests pass
- [x] Verified against the failing `~/strawpot/strawpot.toml` that has `architecture-review = "*"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)