### PR TITLE
Fix ask_user prompts leaking across conversations

### DIFF
--- a/gui/frontend/src/hooks/useSessionWS.ts
+++ b/gui/frontend/src/hooks/useSessionWS.ts
@@ -25,6 +25,7 @@ export interface AgentLogState {
 export function useSessionWS(
   runId: string,
   active: boolean,
+  scopeKey?: string | number,
 ): {
   pendingAskUsers: AskUserPending[];
   chatMessages: ChatMessage[];
@@ -76,7 +77,7 @@ export function useSessionWS(
     );
   }, []);
 
-  // Reset all session state when switching to a different session
+  // Reset all session state when switching to a different session or scope
   useEffect(() => {
     setPendingAskUsers([]);
     setChatMessages([]);
@@ -86,7 +87,7 @@ export function useSessionWS(
     subscribedAgentsRef.current.clear();
     streamDoneRef.current = false;
     traceOffsetRef.current = 0;
-  }, [runId]);
+  }, [runId, scopeKey]);
 
   useEffect(() => {
     if (!active) {

--- a/gui/frontend/src/pages/ConversationView.tsx
+++ b/gui/frontend/src/pages/ConversationView.tsx
@@ -209,6 +209,7 @@ export default function ConversationView() {
   const { pendingAskUsers, chatMessages, respond } = useSessionWS(
     lastSession?.run_id ?? "",
     hasActiveSession && interactive,
+    cid,
   );
 
   const roleError =

--- a/gui/frontend/src/pages/ImuPage.tsx
+++ b/gui/frontend/src/pages/ImuPage.tsx
@@ -259,6 +259,7 @@ function ImuConversationView({ cid }: { cid: number }) {
   const { pendingAskUsers, chatMessages, respond } = useSessionWS(
     lastSession?.run_id ?? "",
     hasActiveSession && interactive,
+    cid,
   );
 
   const agentNames = (agents ?? []).map((a: { name: string }) => a.name);


### PR DESCRIPTION
## Summary
- Add `scopeKey` param to `useSessionWS` that resets all state (pendingAskUsers, chatMessages, traceEvents, etc.) when it changes
- Pass `cid` (conversation ID) as scopeKey from ConversationView and ImuPage
- Fixes ask_user prompts from conversation A appearing in conversation B when switching via the left panel

## Test plan
- [x] Frontend type-check passes
- [ ] Open conversation A with a pending ask_user, switch to conversation B, verify prompt disappears
- [ ] Switch back to conversation A, verify prompt reappears (WS reconnects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)