### PR TITLE
Add missing -y flag to project resource update

### DIFF
--- a/gui/src/strawpot_gui/routers/project_resources.py
+++ b/gui/src/strawpot_gui/routers/project_resources.py
@@ -237,7 +237,7 @@ def update_project_resource(
     if not resource_type or not name:
         raise HTTPException(400, "Both 'type' and 'name' are required")
     singular = singular_type(resource_type)
-    return run_strawhub("--root", working_dir, "update", singular, name)
+    return run_strawhub("--root", working_dir, "update", singular, "-y", name)
 
 
 @router.post("/{project_id}/resources/reinstall")


### PR DESCRIPTION
## Summary
- Add `-y` flag to `strawhub update` call in project resource update endpoint
- Without it, strawhub prompts for tool install confirmation which fails since stdin is DEVNULL
- Global update endpoint already had `-y`; only project-level was missing

## Test plan
- [ ] Update a project resource that has tool prerequisites, verify it succeeds on first try

🤖 Generated with [Claude Code](https://claude.com/claude-code)