### PR TITLE
Show memory_recall and memory_remember in Artifacts sidebar

### DIFF
--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -562,6 +562,20 @@ function extractArtifacts(events: TraceEvent[]): ArtifactEntry[] {
         });
       }
     }
+    if (e.event === "memory_remember" && d.content_ref) {
+      artifacts.push({
+        label: `Memory Remember (${d.provider || "memory"})`,
+        hash: String(d.content_ref),
+        event: e.event,
+      });
+    }
+    if (e.event === "memory_recall" && d.results_ref) {
+      artifacts.push({
+        label: `Memory Recall (${d.provider || "memory"})`,
+        hash: String(d.results_ref),
+        event: e.event,
+      });
+    }
     if (e.event === "delegate_start" && d.context_ref) {
       artifacts.push({
         label: `Delegation Context (${d.role || "delegate"})`,


### PR DESCRIPTION
## Summary
- Add `memory_recall` and `memory_remember` events to the `extractArtifacts()` function in `SessionDetail.tsx`
- These memory events were already rendered in the trace panel but missing from the Artifacts sidebar
- Follows the exact same pattern as existing event handlers (`memory_get`, `memory_dump`, etc.)

Closes #402

## Test plan
- [ ] Verify `memory_remember` events appear in the Artifacts sidebar with label "Memory Remember (provider)"
- [ ] Verify `memory_recall` events appear in the Artifacts sidebar with label "Memory Recall (provider)"
- [ ] Verify existing artifact types still render correctly
- [ ] Verify trace panel behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)