### PR TITLE
Improve API key error messages and document prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ Workflows improve over time as roles are reused and refined.
 
 - Python 3.11 or later
 - pip
+- An LLM API key (e.g., [Anthropic API key](https://console.anthropic.com))
 
 ### Install and run
 
 ```bash
 pip install strawpot
+export ANTHROPIC_API_KEY=sk-ant-...  # Get yours at console.anthropic.com
 strawpot gui
 ```
 

--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -62,6 +62,25 @@ _SEEDED_AGENTS = [
     ("strawpot-codex", "OpenAI Codex CLI — requires OpenAI API key"),
 ]
 
+_API_KEY_GUIDANCE: dict[str, dict[str, str]] = {
+    "ANTHROPIC_API_KEY": {
+        "name": "an Anthropic API key",
+        "url": "https://console.anthropic.com/settings/keys",
+    },
+    "OPENAI_API_KEY": {
+        "name": "an OpenAI API key",
+        "url": "https://platform.openai.com/api-keys",
+    },
+    "GEMINI_API_KEY": {
+        "name": "a Google Gemini API key",
+        "url": "https://aistudio.google.com/apikey",
+    },
+    "GOOGLE_API_KEY": {
+        "name": "a Google API key",
+        "url": "https://aistudio.google.com/apikey",
+    },
+}
+
 
 def needs_onboarding(config, working_dir: str) -> bool:
     """Return True when the first-run onboarding wizard should be shown.
@@ -597,14 +616,30 @@ def start(role, runtime, isolation, merge_strategy, pull, host, port, task, head
 
     if validation.missing_env:
         if headless:
-            click.echo(
-                f"Error: missing environment variables: {', '.join(validation.missing_env)}",
-                err=True,
+            lines = ["Error: StrawPot needs an LLM API key to run.\n"]
+            lines.append(f"Missing: {', '.join(validation.missing_env)}\n")
+            for var in validation.missing_env:
+                guidance = _API_KEY_GUIDANCE.get(var)
+                if guidance:
+                    lines.append(
+                        f"To get started:\n"
+                        f"  1. Sign up at {guidance['url']}\n"
+                        f"  2. Create an API key\n"
+                        f"  3. Set it: export {var}=...\n"
+                    )
+            lines.append(
+                "Or set it permanently in your shell profile (~/.bashrc, ~/.zshrc).\n\n"
+                "See: https://docs.strawpot.com/quickstart"
             )
+            click.echo("\n".join(lines), err=True)
             sys.exit(1)
         agent_env_values: dict[str, str] = {}
         for var in validation.missing_env:
-            value = click.prompt(f"Enter value for {var}")
+            guidance = _API_KEY_GUIDANCE.get(var)
+            if guidance:
+                click.echo(f"\nStrawPot needs {guidance['name']}.")
+                click.echo(f"Get one at: {guidance['url']}\n")
+            value = click.prompt(f"Enter your {var}")
             os.environ[var] = value
             agent_env_values[var] = value
         if agent_env_values:

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -167,6 +167,8 @@ def test_start_missing_env_prompts(
 
     assert result.exit_code == 0
     assert os.environ.get("ANTHROPIC_API_KEY") == "sk-test-key-123"
+    assert "console.anthropic.com" in result.output
+    assert "Enter your ANTHROPIC_API_KEY" in result.output
 
     # Clean up
     os.environ.pop("ANTHROPIC_API_KEY", None)
@@ -474,3 +476,31 @@ def test_start_headless_fails_when_not_configured(mock_load, _mock_onboarding):
 
     assert result.exit_code != 0
     assert "StrawPot is not configured" in result.output
+
+
+@patch("strawpot.cli._ensure_memory_installed")
+@patch("strawpot.cli._ensure_role_installed")
+@patch("strawpot.cli._ensure_skill_installed")
+@patch("strawpot.cli._ensure_agent_installed")
+@patch("strawpot.cli.resolve_agent")
+@patch("strawpot.cli.validate_agent")
+@patch("strawpot.cli.load_config")
+def test_start_headless_missing_env_shows_guidance(
+    mock_load, mock_validate, mock_resolve,
+    mock_ensure_agent, mock_ensure_skill, mock_ensure_role, mock_ensure_memory
+):
+    """--headless exits 1 with actionable guidance when API key is missing."""
+    from strawpot.config import StrawPotConfig
+
+    mock_load.return_value = StrawPotConfig()
+    mock_resolve.return_value = _make_spec()
+    mock_validate.return_value = ValidationResult(missing_env=["ANTHROPIC_API_KEY"])
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["start", "--headless", "--task", "do stuff"])
+
+    assert result.exit_code != 0
+    assert "StrawPot needs an LLM API key" in result.output
+    assert "ANTHROPIC_API_KEY" in result.output
+    assert "console.anthropic.com" in result.output
+    assert "docs.strawpot.com/quickstart" in result.output


### PR DESCRIPTION
## Summary

- Replaced generic "missing environment variables" error with actionable guidance including signup URLs, setup commands, and docs link
- Added `_API_KEY_GUIDANCE` dict mapping env vars to provider-specific URLs (Anthropic, OpenAI, Gemini, Google)
- Headless mode now shows dynamic, provider-specific signup instructions
- Interactive mode now shows guidance text before prompting for each key
- README Quick Start now lists API key as a prerequisite with `export` example
- Added new test for headless missing-env guidance; updated existing interactive test assertions

Closes #413

## Test plan

- [x] All 16 CLI tests pass (`pytest cli/tests/test_cli.py`)
- [x] New `test_start_headless_missing_env_shows_guidance` verifies headless error includes key name, URL, and docs link
- [x] Updated `test_start_missing_env_prompts` verifies interactive mode shows guidance URL and new prompt text
- [x] Existing `test_start_missing_env_persists_to_config` still passes (save flow unchanged)
- [x] No regressions in any other test

🤖 Generated with [Claude Code](https://claude.com/claude-code)