### PR TITLE
Parse stream-json log for result text and token usage

### DIFF
--- a/cli/src/strawpot/agents/wrapper.py
+++ b/cli/src/strawpot/agents/wrapper.py
@@ -14,10 +14,62 @@ import sys
 import time
 
 from strawpot._process import is_pid_alive, kill_process_tree
-from strawpot.agents.protocol import AgentHandle, AgentResult
+from strawpot.agents.protocol import AgentHandle, AgentResult, TokenUsage
 from strawpot.agents.registry import AgentSpec
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_stream_json_log(
+    log_content: str,
+) -> tuple[str, TokenUsage | None]:
+    """Parse a stream-json JSONL log to extract result text and token usage.
+
+    Returns ``(output_text, usage)`` where *output_text* is the human-readable
+    result and *usage* is a :class:`TokenUsage` if a ``result`` message was
+    found, otherwise ``(raw_content, None)`` as a fallback for non-stream-json
+    logs.
+    """
+    if not log_content.strip():
+        return "", None
+
+    result_msg = None
+    for line in log_content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(parsed, dict) and parsed.get("type") == "result":
+            result_msg = parsed
+
+    if result_msg is None:
+        # Not stream-json format — return raw content.
+        return log_content, None
+
+    output_text = result_msg.get("result", "")
+    if not isinstance(output_text, str):
+        output_text = str(output_text) if output_text is not None else ""
+
+    raw_usage = result_msg.get("usage")
+    if isinstance(raw_usage, dict):
+        usage = TokenUsage(
+            input_tokens=raw_usage.get("input_tokens", 0),
+            output_tokens=raw_usage.get("output_tokens", 0),
+            cache_read_input_tokens=raw_usage.get("cache_read_input_tokens", 0),
+            cache_creation_input_tokens=raw_usage.get(
+                "cache_creation_input_tokens", 0
+            ),
+        )
+    else:
+        usage = TokenUsage()
+
+    usage.cost_usd = result_msg.get("cost_usd")
+    usage.model = result_msg.get("model", "")
+
+    return output_text, usage
 
 
 class WrapperRuntime:
@@ -265,17 +317,20 @@ class WrapperRuntime:
                     time.sleep(poll_interval)
                     elapsed += poll_interval
 
-        # Read captured output
+        # Read captured output and parse stream-json if available
         log_path = self._log_file(handle.agent_id)
-        output = ""
+        raw_log = ""
         if os.path.exists(log_path):
             with open(log_path, encoding="utf-8") as f:
-                output = f.read()
+                raw_log = f.read()
+
+        output, usage = _parse_stream_json_log(raw_log)
 
         return AgentResult(
             summary="Agent completed",
             output=output,
             exit_code=exit_code,
+            usage=usage,
         )
 
     def is_alive(self, handle: AgentHandle) -> bool:

--- a/cli/tests/test_agents_wrapper.py
+++ b/cli/tests/test_agents_wrapper.py
@@ -9,9 +9,9 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 
-from strawpot.agents.protocol import AgentHandle, AgentResult, AgentRuntime
+from strawpot.agents.protocol import AgentHandle, AgentResult, AgentRuntime, TokenUsage
 from strawpot.agents.registry import AgentSpec
-from strawpot.agents.wrapper import WrapperRuntime
+from strawpot.agents.wrapper import WrapperRuntime, _parse_stream_json_log
 from strawpot._process import kill_process_tree
 
 
@@ -702,3 +702,114 @@ def test_spawn_skill_dirs_precede_system_path(tmp_path, monkeypatch):
     path = popen_captured["env"]["PATH"]
     assert path.startswith(str(skills_dir / "mytool"))
     assert original_path in path
+
+
+# --- _parse_stream_json_log ---
+
+
+def test_parse_stream_json_valid():
+    """Parse a valid stream-json log with result message."""
+    log = (
+        '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"thinking..."}]}}\n'
+        '{"type":"result","subtype":"success","cost_usd":0.05,"result":"Final output","total_cost_usd":0.08,'
+        '"usage":{"input_tokens":5000,"output_tokens":2000,"cache_creation_input_tokens":0,"cache_read_input_tokens":1500}}\n'
+    )
+    output, usage = _parse_stream_json_log(log)
+    assert output == "Final output"
+    assert usage is not None
+    assert usage.input_tokens == 5000
+    assert usage.output_tokens == 2000
+    assert usage.cache_read_input_tokens == 1500
+    assert usage.cache_creation_input_tokens == 0
+    assert usage.cost_usd == 0.05
+
+
+def test_parse_stream_json_plain_text_fallback():
+    """Non-stream-json (plain text) logs fall back to raw content."""
+    log = "This is just plain text output from an agent.\nNo JSON here."
+    output, usage = _parse_stream_json_log(log)
+    assert output == log
+    assert usage is None
+
+
+def test_parse_stream_json_empty_log():
+    """Empty log returns empty output and no usage."""
+    output, usage = _parse_stream_json_log("")
+    assert output == ""
+    assert usage is None
+
+
+def test_parse_stream_json_whitespace_only():
+    """Whitespace-only log returns empty output and no usage."""
+    output, usage = _parse_stream_json_log("   \n\n  ")
+    assert output == ""
+    assert usage is None
+
+
+def test_parse_stream_json_error_result():
+    """Error result with no 'result' field returns empty string."""
+    log = '{"type":"result","subtype":"error","cost_usd":0.01,"usage":{"input_tokens":100,"output_tokens":0}}\n'
+    output, usage = _parse_stream_json_log(log)
+    assert output == ""
+    assert usage is not None
+    assert usage.input_tokens == 100
+    assert usage.cost_usd == 0.01
+
+
+def test_parse_stream_json_no_usage_field():
+    """Result message without usage field still works."""
+    log = '{"type":"result","subtype":"success","result":"done"}\n'
+    output, usage = _parse_stream_json_log(log)
+    assert output == "done"
+    assert usage is not None
+    assert usage.input_tokens == 0
+    assert usage.cost_usd is None
+
+
+def test_parse_stream_json_mixed_lines():
+    """Log with mixed valid JSON and non-JSON lines."""
+    log = (
+        "some stderr noise\n"
+        '{"type":"assistant","message":{"role":"assistant"}}\n'
+        "more noise\n"
+        '{"type":"result","result":"output","cost_usd":0.02,'
+        '"usage":{"input_tokens":300,"output_tokens":100}}\n'
+    )
+    output, usage = _parse_stream_json_log(log)
+    assert output == "output"
+    assert usage is not None
+    assert usage.input_tokens == 300
+    assert usage.cost_usd == 0.02
+
+
+def test_parse_stream_json_with_model():
+    """Model field from result message is captured."""
+    log = '{"type":"result","result":"done","model":"claude-sonnet-4-20250514","cost_usd":0.03,"usage":{"input_tokens":1000,"output_tokens":500}}\n'
+    output, usage = _parse_stream_json_log(log)
+    assert usage is not None
+    assert usage.model == "claude-sonnet-4-20250514"
+
+
+def test_wait_parses_stream_json_log(tmp_path):
+    """wait() extracts result text and token usage from stream-json logs."""
+    rt = WrapperRuntime(_make_spec(), session_dir=str(tmp_path))
+    log_dir = tmp_path / "agents" / "sjson01"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    stream_json_log = (
+        '{"type":"assistant","message":{"role":"assistant"}}\n'
+        '{"type":"result","subtype":"success","result":"The answer is 42",'
+        '"cost_usd":0.07,"usage":{"input_tokens":3000,"output_tokens":1000,'
+        '"cache_read_input_tokens":500,"cache_creation_input_tokens":0}}\n'
+    )
+    (log_dir / ".log").write_text(stream_json_log)
+
+    handle = AgentHandle(agent_id="sjson01", runtime_name="test-agent")
+    result = rt.wait(handle)
+
+    assert result.output == "The answer is 42"
+    assert result.usage is not None
+    assert result.usage.input_tokens == 3000
+    assert result.usage.output_tokens == 1000
+    assert result.usage.cache_read_input_tokens == 500
+    assert result.usage.cost_usd == 0.07


### PR DESCRIPTION
## Summary

- Add `_parse_stream_json_log()` helper to extract result text and `TokenUsage` from Claude Code's stream-json JSONL output
- Modify `WrapperRuntime.wait()` to parse logs through the helper
- Falls back gracefully to raw content + `None` usage for non-stream-json logs (backward compat for other runtimes)
- Handles edge cases: empty log, no result line, malformed JSON lines, error results, missing usage fields

**Base branch**: `claude/token-usage-dataclass` (depends on #424 for `TokenUsage` dataclass)

Closes #425
Part of #422 (Cost Observability Phase 1).

## Test plan

- [x] 9 new tests covering: valid stream-json, plain text fallback, empty log, whitespace-only, error result, no usage field, mixed lines, model field, integration with `wait()`
- [x] All 46 wrapper tests pass (37 existing + 9 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)