### PR TITLE
Add token usage fields to delegate_end and agent_end trace events

### DIFF
--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from strawpot.trace import Tracer
 
-from strawpot.agents.protocol import AgentHandle, AgentResult, AgentRuntime
+from strawpot.agents.protocol import AgentHandle, AgentResult, AgentRuntime, TokenUsage
 from strawpot.agents.registry import resolve_agent
 from strawpot.agents.wrapper import WrapperRuntime
 from strawpot.config import StrawPotConfig, get_strawpot_home
@@ -732,10 +732,12 @@ def _emit_delegate_end(
     role: str = "",
     session_id: str = "",
     agent_id: str = "",
+    usage: TokenUsage | None = None,
 ) -> None:
     """Emit delegate_end if tracer is active."""
     if tracer is not None and span_id is not None:
         duration_ms = int((time.monotonic() - start_time) * 1000)
+        u = usage or TokenUsage()
         tracer.delegate_end(
             span_id=span_id,
             exit_code=exit_code,
@@ -744,6 +746,12 @@ def _emit_delegate_end(
             role=role,
             session_id=session_id,
             agent_id=agent_id,
+            input_tokens=u.input_tokens,
+            output_tokens=u.output_tokens,
+            cache_read_input_tokens=u.cache_read_input_tokens,
+            cache_creation_input_tokens=u.cache_creation_input_tokens,
+            cost_usd=u.cost_usd,
+            model=u.model,
         )
 
 
@@ -1053,6 +1061,7 @@ def _handle_delegate_body(
             agent_duration_ms = int(
                 (time.monotonic() - spawn_time) * 1000
             )
+            u = result.usage or TokenUsage()
             tracer.agent_end(
                 span_id=delegate_span_id,
                 exit_code=result.exit_code,
@@ -1061,6 +1070,12 @@ def _handle_delegate_body(
                 agent_id=agent_id,
                 role=request.role_slug,
                 session_id=request.run_id,
+                input_tokens=u.input_tokens,
+                output_tokens=u.output_tokens,
+                cache_read_input_tokens=u.cache_read_input_tokens,
+                cache_creation_input_tokens=u.cache_creation_input_tokens,
+                cost_usd=u.cost_usd,
+                model=u.model,
             )
 
         # 8a. Memory dump — record result after wait
@@ -1101,7 +1116,7 @@ def _handle_delegate_body(
                 tracer, delegate_span_id, 1,
                 delegate_start_time, output=result.output,
                 role=request.role_slug, session_id=request.run_id,
-                agent_id=agent_id,
+                agent_id=agent_id, usage=result.usage,
             )
             return DelegateResult(
                 output=result.output,
@@ -1114,7 +1129,7 @@ def _handle_delegate_body(
                 tracer, delegate_span_id, result.exit_code,
                 delegate_start_time, output=result.output,
                 role=request.role_slug, session_id=request.run_id,
-                agent_id=agent_id,
+                agent_id=agent_id, usage=result.usage,
             )
             return DelegateResult(
                 output=result.output,
@@ -1130,7 +1145,7 @@ def _handle_delegate_body(
                 tracer, delegate_span_id, result.exit_code,
                 delegate_start_time, output=result.output,
                 role=request.role_slug, session_id=request.run_id,
-                agent_id=agent_id,
+                agent_id=agent_id, usage=result.usage,
             )
             return DelegateResult(
                 output=result.output,
@@ -1150,7 +1165,7 @@ def _handle_delegate_body(
                 tracer, delegate_span_id, result.exit_code,
                 delegate_start_time, output=result.output,
                 role=request.role_slug, session_id=request.run_id,
-                agent_id=agent_id,
+                agent_id=agent_id, usage=result.usage,
             )
             return DelegateResult(
                 output=result.output,
@@ -1177,7 +1192,7 @@ def _handle_delegate_body(
         tracer, delegate_span_id, result.exit_code,
         delegate_start_time, output=result.output,
         role=request.role_slug, session_id=request.run_id,
-        agent_id=agent_id,
+        agent_id=agent_id, usage=result.usage,
     )
     return DelegateResult(
         output=result.output,

--- a/cli/src/strawpot/trace.py
+++ b/cli/src/strawpot/trace.py
@@ -174,6 +174,12 @@ class Tracer:
         session_id: str = "",
         agent_id: str = "",
         cache_hit: bool = False,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cache_read_input_tokens: int = 0,
+        cache_creation_input_tokens: int = 0,
+        cost_usd: float | None = None,
+        model: str = "",
     ) -> None:
         """Emit ``delegate_end``.  Stores output as artifact."""
         output_ref = self.store_artifact(output)
@@ -187,6 +193,12 @@ class Tracer:
             session_id=session_id,
             agent_id=agent_id,
             cache_hit=cache_hit,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+            cost_usd=cost_usd if cost_usd is not None else 0.0,
+            model=model,
         )
 
     def delegate_denied(
@@ -386,6 +398,12 @@ class Tracer:
         agent_id: str = "",
         role: str = "",
         session_id: str = "",
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cache_read_input_tokens: int = 0,
+        cache_creation_input_tokens: int = 0,
+        cost_usd: float | None = None,
+        model: str = "",
     ) -> None:
         """Emit ``agent_end``.  Stores output as artifact."""
         output_ref = self.store_artifact(output)
@@ -398,6 +416,12 @@ class Tracer:
             agent_id=agent_id,
             role=role,
             session_id=session_id,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+            cost_usd=cost_usd if cost_usd is not None else 0.0,
+            model=model,
         )
 
     def ask_user_start(

--- a/cli/tests/test_trace.py
+++ b/cli/tests/test_trace.py
@@ -267,6 +267,37 @@ class TestDelegateEvents:
         with open(artifact_path, encoding="utf-8") as f:
             assert f.read() == "task output here"
 
+    def test_delegate_end_with_token_usage(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.delegate_end(
+            span_id="s1", exit_code=0, duration_ms=5000,
+            output="done", role="implementer",
+            input_tokens=5000, output_tokens=2000,
+            cache_read_input_tokens=1500, cache_creation_input_tokens=0,
+            cost_usd=0.05, model="claude-sonnet-4-20250514",
+        )
+        events = _read_events(session_dir)
+        data = events[0]["data"]
+        assert data["input_tokens"] == 5000
+        assert data["output_tokens"] == 2000
+        assert data["cache_read_input_tokens"] == 1500
+        assert data["cache_creation_input_tokens"] == 0
+        assert data["cost_usd"] == 0.05
+        assert data["model"] == "claude-sonnet-4-20250514"
+
+    def test_delegate_end_without_token_usage(self, tmp_path):
+        """Token fields default to zero when not provided."""
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.delegate_end(
+            span_id="s1", exit_code=0, duration_ms=1000, output="ok",
+        )
+        events = _read_events(session_dir)
+        data = events[0]["data"]
+        assert data["input_tokens"] == 0
+        assert data["output_tokens"] == 0
+        assert data["cost_usd"] == 0.0
+        assert data["model"] == ""
+
     def test_delegate_denied_event(self, tmp_path):
         tracer, session_dir = _make_tracer(tmp_path)
         tracer.delegate_denied(
@@ -466,6 +497,24 @@ class TestAgentEvents:
         artifact_path = os.path.join(session_dir, "artifacts", ref)
         with open(artifact_path, encoding="utf-8") as f:
             assert f.read() == "task completed successfully"
+
+    def test_agent_end_with_token_usage(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.agent_end(
+            span_id="s1", exit_code=0,
+            output="done", duration_ms=8000,
+            agent_id="a1", role="reviewer",
+            input_tokens=3000, output_tokens=1000,
+            cache_read_input_tokens=500, cost_usd=0.03,
+            model="claude-sonnet-4-20250514",
+        )
+        events = _read_events(session_dir)
+        data = events[0]["data"]
+        assert data["input_tokens"] == 3000
+        assert data["output_tokens"] == 1000
+        assert data["cache_read_input_tokens"] == 500
+        assert data["cost_usd"] == 0.03
+        assert data["model"] == "claude-sonnet-4-20250514"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `cost_usd`, `model` params to `Tracer.delegate_end()` and `Tracer.agent_end()`
- Update `_emit_delegate_end()` in delegation.py to accept and pass `TokenUsage`
- Update all 6 `_emit_delegate_end()` call sites + `agent_end` call to pass `result.usage`
- Token fields default to 0/empty when `AgentResult.usage` is None (backward compat)

**Base branch**: `claude/parse-stream-json-log` (depends on #425)

Closes #426
Part of #422 (Cost Observability Phase 1).

## Test plan

- [x] New tests: `test_delegate_end_with_token_usage`, `test_delegate_end_without_token_usage`, `test_agent_end_with_token_usage`
- [x] All 92 tests pass across protocol, wrapper, and trace test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)