### PR TITLE
Add session cost rollup to session detail API

### DIFF
--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -524,6 +524,61 @@ def list_sessions(
     }
 
 
+def _compute_session_cost(events: list[dict]) -> dict | None:
+    """Aggregate token costs from ``delegate_end`` trace events.
+
+    Returns a cost summary dict or ``None`` when no token data is present.
+    """
+    total_input = 0
+    total_output = 0
+    total_cache_read = 0
+    total_cost: float | None = None
+    by_role: dict[str, dict] = {}
+    has_data = False
+
+    for ev in events:
+        if ev.get("event") != "delegate_end":
+            continue
+        data = ev.get("data", {})
+        inp = data.get("input_tokens", 0) or 0
+        out = data.get("output_tokens", 0) or 0
+        cr = data.get("cache_read_input_tokens", 0) or 0
+        cost = data.get("cost_usd")
+
+        if inp or out or cr or cost:
+            has_data = True
+
+        total_input += inp
+        total_output += out
+        total_cache_read += cr
+        if cost is not None:
+            total_cost = (total_cost or 0.0) + cost
+
+        role = data.get("role", "unknown")
+        if role not in by_role:
+            by_role[role] = {
+                "role": role,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cost_usd": None,
+            }
+        by_role[role]["input_tokens"] += inp
+        by_role[role]["output_tokens"] += out
+        if cost is not None:
+            by_role[role]["cost_usd"] = (by_role[role]["cost_usd"] or 0.0) + cost
+
+    if not has_data:
+        return None
+
+    return {
+        "total_input_tokens": total_input,
+        "total_output_tokens": total_output,
+        "total_cache_read_tokens": total_cache_read,
+        "total_cost_usd": total_cost,
+        "by_role": list(by_role.values()),
+    }
+
+
 @router.get("/projects/{project_id}/sessions/{run_id}")
 def get_session(project_id: int, run_id: str, conn=Depends(get_db_conn)):
     # Refresh status for active sessions before returning
@@ -569,6 +624,7 @@ def get_session(project_id: int, run_id: str, conn=Depends(get_db_conn)):
     except (OSError, json.JSONDecodeError):
         pass
     result["events"] = events
+    result["cost"] = _compute_session_cost(events)
 
     # Build agent tree from session.json + trace.jsonl
     from strawpot_gui.routers.ws import _build_full_state

--- a/gui/tests/test_session_cost.py
+++ b/gui/tests/test_session_cost.py
@@ -1,0 +1,135 @@
+"""Tests for session cost rollup (_compute_session_cost)."""
+
+from strawpot_gui.routers.sessions import _compute_session_cost
+
+
+def test_cost_rollup_with_token_data():
+    """Sum token data from delegate_end events."""
+    events = [
+        {
+            "event": "delegate_start",
+            "data": {"role": "implementer"},
+        },
+        {
+            "event": "delegate_end",
+            "data": {
+                "role": "implementer",
+                "input_tokens": 5000,
+                "output_tokens": 2000,
+                "cache_read_input_tokens": 1000,
+                "cost_usd": 0.05,
+            },
+        },
+        {
+            "event": "delegate_end",
+            "data": {
+                "role": "code-reviewer",
+                "input_tokens": 3000,
+                "output_tokens": 1000,
+                "cache_read_input_tokens": 500,
+                "cost_usd": 0.03,
+            },
+        },
+    ]
+    cost = _compute_session_cost(events)
+    assert cost is not None
+    assert cost["total_input_tokens"] == 8000
+    assert cost["total_output_tokens"] == 3000
+    assert cost["total_cache_read_tokens"] == 1500
+    assert cost["total_cost_usd"] == 0.08
+    assert len(cost["by_role"]) == 2
+    roles = {r["role"]: r for r in cost["by_role"]}
+    assert roles["implementer"]["input_tokens"] == 5000
+    assert roles["implementer"]["cost_usd"] == 0.05
+    assert roles["code-reviewer"]["input_tokens"] == 3000
+    assert roles["code-reviewer"]["cost_usd"] == 0.03
+
+
+def test_cost_rollup_no_token_data():
+    """Old trace events without token fields return None."""
+    events = [
+        {
+            "event": "delegate_end",
+            "data": {
+                "role": "implementer",
+                "exit_code": 0,
+                "duration_ms": 5000,
+            },
+        },
+    ]
+    cost = _compute_session_cost(events)
+    assert cost is None
+
+
+def test_cost_rollup_empty_events():
+    """No events at all return None."""
+    assert _compute_session_cost([]) is None
+
+
+def test_cost_rollup_no_delegate_end():
+    """Events without delegate_end return None."""
+    events = [
+        {"event": "session_start", "data": {}},
+        {"event": "session_end", "data": {}},
+    ]
+    assert _compute_session_cost(events) is None
+
+
+def test_cost_rollup_mixed_with_and_without_cost():
+    """Events with partial cost data — only some have cost_usd."""
+    events = [
+        {
+            "event": "delegate_end",
+            "data": {
+                "role": "implementer",
+                "input_tokens": 5000,
+                "output_tokens": 2000,
+                "cost_usd": 0.05,
+            },
+        },
+        {
+            "event": "delegate_end",
+            "data": {
+                "role": "reviewer",
+                "input_tokens": 3000,
+                "output_tokens": 1000,
+                # no cost_usd
+            },
+        },
+    ]
+    cost = _compute_session_cost(events)
+    assert cost is not None
+    assert cost["total_input_tokens"] == 8000
+    assert cost["total_cost_usd"] == 0.05  # only first had cost
+    roles = {r["role"]: r for r in cost["by_role"]}
+    assert roles["reviewer"]["cost_usd"] is None
+
+
+def test_cost_rollup_same_role_multiple_delegations():
+    """Multiple delegations to the same role are aggregated."""
+    events = [
+        {
+            "event": "delegate_end",
+            "data": {
+                "role": "implementer",
+                "input_tokens": 2000,
+                "output_tokens": 500,
+                "cost_usd": 0.02,
+            },
+        },
+        {
+            "event": "delegate_end",
+            "data": {
+                "role": "implementer",
+                "input_tokens": 3000,
+                "output_tokens": 700,
+                "cost_usd": 0.03,
+            },
+        },
+    ]
+    cost = _compute_session_cost(events)
+    assert cost is not None
+    assert len(cost["by_role"]) == 1
+    assert cost["by_role"][0]["input_tokens"] == 5000
+    assert cost["by_role"][0]["output_tokens"] == 1200
+    assert cost["by_role"][0]["cost_usd"] == 0.05


### PR DESCRIPTION
## Summary

- Add `_compute_session_cost()` helper that aggregates token usage from `delegate_end` trace events
- Returns total input/output tokens, cache read tokens, total cost USD, and per-role breakdown
- Wire into `GET /api/projects/{id}/sessions/{run_id}` response as `cost` field
- Returns `null` for sessions with no token data (backward compat with old traces)

**Base branch**: `claude/trace-token-usage` (depends on #426)

Closes #427
Part of #422 (Cost Observability Phase 1).

## Test plan

- [x] 6 new tests: with token data, no token data, empty events, no delegate_end, mixed cost data, same role multiple delegations
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)