### PR TITLE
Display session cost and per-role breakdown in SessionDetail

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -47,11 +47,27 @@ export interface TraceEvent {
   data: Record<string, unknown>;
 }
 
+export interface RoleCost {
+  role: string;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number | null;
+}
+
+export interface SessionCost {
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cache_read_tokens: number;
+  total_cost_usd: number | null;
+  by_role: RoleCost[];
+}
+
 export interface SessionDetail extends Session {
   interactive: boolean;
   agents: Record<string, AgentInfo>;
   events: TraceEvent[];
   tree: TreeData;
+  cost: SessionCost | null;
 }
 
 export interface AskUserPending {

--- a/gui/frontend/src/lib/utils.ts
+++ b/gui/frontend/src/lib/utils.ts
@@ -5,6 +5,18 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return n.toString();
+}
+
+export function formatCost(usd: number | null): string | null {
+  if (usd == null) return null;
+  if (usd >= 1) return `$${usd.toFixed(2)}`;
+  return `$${usd.toFixed(4)}`;
+}
+
 /**
  * Convert a UTC cron expression's hour/minute fields to local time.
  * Only handles simple numeric hour/minute (not ranges or steps).

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -34,7 +34,7 @@ import {
 } from "@/components/ui/collapsible";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import ViewToggle from "@/components/ViewToggle";
-import { cn } from "@/lib/utils";
+import { cn, formatTokens, formatCost } from "@/lib/utils";
 import {
   AlertCircle,
   ArrowLeft,
@@ -159,6 +159,31 @@ export default function SessionDetail() {
                 runId={sessionData.run_id}
                 hash={outputRef}
               />
+            </OverviewSection>
+          )}
+
+          {sessionData.cost && sessionData.cost.by_role.length > 0 && (
+            <OverviewSection label="Cost Breakdown" defaultOpen={false}>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Role</TableHead>
+                    <TableHead className="text-right">Input</TableHead>
+                    <TableHead className="text-right">Output</TableHead>
+                    <TableHead className="text-right">Cost</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {sessionData.cost.by_role.map((rc) => (
+                    <TableRow key={rc.role}>
+                      <TableCell className="font-medium">{rc.role}</TableCell>
+                      <TableCell className="text-right">{formatTokens(rc.input_tokens)}</TableCell>
+                      <TableCell className="text-right">{formatTokens(rc.output_tokens)}</TableCell>
+                      <TableCell className="text-right">{formatCost(rc.cost_usd) ?? "-"}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
             </OverviewSection>
           )}
 
@@ -371,6 +396,23 @@ function SessionMetadata({ session }: { session: SessionDetailType }) {
             <>
               <dt className="font-medium text-muted-foreground">Exit Code</dt>
               <dd>{session.exit_code}</dd>
+            </>
+          )}
+          {session.cost && (
+            <>
+              {session.cost.total_cost_usd != null && (
+                <>
+                  <dt className="font-medium text-muted-foreground">Cost</dt>
+                  <dd>{formatCost(session.cost.total_cost_usd)}</dd>
+                </>
+              )}
+              <dt className="font-medium text-muted-foreground">Tokens</dt>
+              <dd>
+                {formatTokens(session.cost.total_input_tokens)} in / {formatTokens(session.cost.total_output_tokens)} out
+                {session.cost.total_cache_read_tokens > 0 && (
+                  <span className="text-muted-foreground"> ({formatTokens(session.cost.total_cache_read_tokens)} cached)</span>
+                )}
+              </dd>
             </>
           )}
         </dl>


### PR DESCRIPTION
## Summary

- Add `SessionCost` and `RoleCost` types to `types.ts`
- Add `cost: SessionCost | null` to `SessionDetail` interface
- Add `formatTokens()` (k/M suffixes) and `formatCost()` (USD formatting) to `lib/utils.ts`
- Display cost and token summary in `SessionMetadata` card (Cost and Tokens rows)
- Add collapsible "Cost Breakdown" table in Overview tab showing per-role input/output tokens and cost
- Graceful null handling: nothing rendered when `cost` is null

**Base branch**: `claude/session-cost-rollup` (depends on #427)

Closes #428
Part of #422 (Cost Observability Phase 1).

## Test plan

- [x] TypeScript compiles with no errors (`tsc --noEmit`)
- [x] Vite production build succeeds
- [x] Cost display is conditional — only appears when `cost` is non-null
- [x] Token formatting: 5000 -> "5.0k", 1500000 -> "1.5M"
- [x] Cost formatting: 0.05 -> "$0.0500", 1.25 -> "$1.25"

🤖 Generated with [Claude Code](https://claude.com/claude-code)