### PR TITLE
Optimize Ubuntu GUI test CI from ~17min to ~2min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,7 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Run tests
-        run: pytest tests/ -v --timeout=30
+        run: pytest tests/ -v --timeout=30 --durations=20
+        env:
+          STRAWPOT_WS_DRAIN_TIMEOUT: "0.1"
+          STRAWPOT_WS_DRAIN_TIMEOUT_LONG: "0.1"

--- a/gui/src/strawpot_gui/routers/ws.py
+++ b/gui/src/strawpot_gui/routers/ws.py
@@ -50,6 +50,11 @@ from strawpot_gui.sse import (
 
 router = APIRouter(tags=["websocket"])
 
+# Configurable drain timeouts — low defaults work for localhost; override via
+# environment for high-latency networks or to speed up test teardown.
+WS_DRAIN_TIMEOUT = float(os.environ.get("STRAWPOT_WS_DRAIN_TIMEOUT", "1.0"))
+WS_DRAIN_TIMEOUT_LONG = float(os.environ.get("STRAWPOT_WS_DRAIN_TIMEOUT_LONG", "2.0"))
+
 
 # ---------------------------------------------------------------------------
 # Helpers (shared logic with the former SSE tree router)
@@ -172,7 +177,7 @@ async def session_ws(websocket: WebSocket, run_id: str) -> None:
     early_subscribes: list[dict] = []
     try:
         while True:
-            raw = await asyncio.wait_for(websocket.receive_text(), timeout=1.0)
+            raw = await asyncio.wait_for(websocket.receive_text(), timeout=WS_DRAIN_TIMEOUT)
             try:
                 msg = json.loads(raw)
             except (json.JSONDecodeError, ValueError):
@@ -247,7 +252,7 @@ async def session_ws(websocket: WebSocket, run_id: str) -> None:
         # Drain additional subscribe_logs from the client
         try:
             while True:
-                raw = await asyncio.wait_for(websocket.receive_text(), timeout=2.0)
+                raw = await asyncio.wait_for(websocket.receive_text(), timeout=WS_DRAIN_TIMEOUT_LONG)
                 try:
                     msg = json.loads(raw)
                 except json.JSONDecodeError:

--- a/gui/tests/conftest.py
+++ b/gui/tests/conftest.py
@@ -1,23 +1,71 @@
 """Shared fixtures for GUI tests."""
 
+import os
+import sqlite3
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from strawpot_gui.app import create_app
+from strawpot_gui.db import get_db
+
+# Tables deleted in an order that avoids FK constraint violations.
+_TABLES = [
+    "conversation_task_queue",
+    "integration_notifications",
+    "integration_config",
+    "sessions",
+    "scheduled_tasks",
+    "integrations",
+    "conversations",
+    "projects",
+]
 
 
-@pytest.fixture
-def app(tmp_path):
-    """Create a test app with a temp database."""
-    db_path = str(tmp_path / "test_gui.db")
+@pytest.fixture(scope="module")
+def app(tmp_path_factory):
+    """Create a test app with a temp database (one per test module)."""
+    db_path = str(tmp_path_factory.mktemp("gui") / "test_gui.db")
     return create_app(db_path=db_path)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def client(app):
-    """TestClient for making requests to the test app."""
-    with patch("strawpot_gui.app._ensure_imu_role"):
-        with TestClient(app) as c:
-            yield c
+    """Module-scoped TestClient — enters ASGI lifespan once per test file."""
+    with patch("strawpot_gui.app._ensure_imu_role"), TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clean_db(request):
+    """Reset all database tables between tests for isolation.
+
+    Only runs when the test's module has an initialised app with a real
+    database (i.e. the ``client`` fixture was used).  Re-inserts a stub
+    IMU project (id=0) after cleanup so subsequent tests can reference it.
+    """
+    yield
+    # Resolve the db_path from the module's app fixture, if present.
+    try:
+        app_instance = request.getfixturevalue("app")
+    except pytest.FixtureLookupError:
+        return
+    db_path = app_instance.state.db_path
+    if not os.path.exists(db_path):
+        return
+    with get_db(db_path) as conn:
+        for table in _TABLES:
+            try:
+                conn.execute(f"DELETE FROM {table}")  # noqa: S608
+            except sqlite3.OperationalError as exc:
+                if "no such table" not in str(exc):
+                    raise
+        conn.execute(
+            "DELETE FROM sqlite_sequence"
+            " WHERE name IN ('conversations', 'conversation_task_queue')"
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO projects (id, display_name, working_dir)"
+            " VALUES (0, 'Bot Imu', '/tmp/imu')"
+        )


### PR DESCRIPTION
## Summary

- **Module-scoped `client` fixture** — reduces TestClient lifecycle from 526 (one per test) to ~29 (one per module), eliminating the ~2.2s/test overhead on Ubuntu shared vCPUs
- **Autouse `_clean_db` fixture** — truncates all DB tables between tests to preserve isolation while reusing the TestClient
- **Configurable WebSocket drain timeouts** — `STRAWPOT_WS_DRAIN_TIMEOUT` / `STRAWPOT_WS_DRAIN_TIMEOUT_LONG` env vars with production defaults (1.0s/2.0s); CI overrides to 0.1s
- **`--durations=20`** added to CI pytest command for ongoing slow-test monitoring

### Root cause
The function-scoped `client` fixture created a full TestClient lifecycle (thread + event loop + SQLite DDL + 15 migrations + scheduler start/stop) for every single test — 526 times. Each lifecycle costs ~2.2s on Ubuntu shared vCPUs vs ~0.19s on macOS M1.

## Test plan

- [x] All 526 GUI tests pass locally with env overrides (18s)
- [x] All 526 GUI tests pass locally without env overrides (50s)
- [ ] CI passes on Ubuntu and macOS across Python 3.11/3.12/3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)