### PR TITLE
Fix circular dependency between strawpot and strawpot-gui

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "tomli_w>=1.0",
     "strawhub",
     "strawpot-memory",
-    "strawpot-gui",
     "denden-server",
 ]
 
@@ -37,6 +36,9 @@ Issues = "https://github.com/strawpot/strawpot/issues"
 strawpot = "strawpot.cli:cli"
 
 [project.optional-dependencies]
+gui = [
+    "strawpot-gui",
+]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=6.0",

--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -1065,8 +1065,15 @@ def gui(port, skip_update_check):
     if config.memory:
         _ensure_memory_installed(config.memory, working_dir, auto_setup=True)
 
-    from strawpot_gui.server import DEFAULT_PORT
-    from strawpot_gui.server import main as gui_main
+    try:
+        from strawpot_gui.server import DEFAULT_PORT, main as gui_main
+    except ImportError:
+        click.echo(
+            "Error: strawpot-gui is not installed.\n"
+            "Install it with:  pip install 'strawpot[gui]'",
+            err=True,
+        )
+        sys.exit(1)
 
     gui_main(port=port or DEFAULT_PORT)
 


### PR DESCRIPTION
## Summary

- Remove `strawpot-gui` from hard `[project.dependencies]` in `cli/pyproject.toml`, breaking the circular dependency with `strawpot-gui` → `strawpot`
- Add `strawpot-gui` under `[project.optional-dependencies]` as a `gui` extra — install with `pip install strawpot[gui]`
- Guard the `strawpot_gui` import in the `gui` command with a try/except that shows a clear install instruction when the package is missing

Closes #462

## Test plan

- [x] Existing tests pass (`test_update_check.py` — gui command tests with mocked strawpot_gui)
- [ ] Fresh venv install of `strawpot` succeeds without strawpot-gui
- [ ] `pip install strawpot[gui]` installs both packages
- [ ] `strawpot gui` without strawpot-gui installed shows helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)