### PR TITLE
Fix fragile pipx detection in _detect_installer()

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -1088,9 +1088,14 @@ def _detect_installer() -> str:
     # PyInstaller frozen binary
     if getattr(sys, "_MEIPASS", None):
         return "binary"
-    # pipx: venv lives under ~/.local/share/pipx/venvs/ (or PIPX_HOME)
-    pipx_home = os.environ.get("PIPX_HOME", os.path.expanduser("~/.local/share/pipx"))
-    if pipx_home in sys.prefix:
+    # pipx detection: check whether the active virtualenv lives under a pipx-
+    # managed directory.  PIPX_HOME alone is insufficient (it's a user config
+    # variable that may be set even for pip-installed packages).
+    venv = os.environ.get("VIRTUAL_ENV", "")
+    pipx_home = os.environ.get("PIPX_HOME", "")
+    if pipx_home and venv.startswith(pipx_home):
+        return "pipx"
+    if f"{os.sep}pipx{os.sep}" in venv:
         return "pipx"
     return "pip"
 

--- a/cli/tests/test_update_check.py
+++ b/cli/tests/test_update_check.py
@@ -2,6 +2,8 @@
 
 import os
 import subprocess
+import sys
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,6 +11,7 @@ from click.testing import CliRunner
 
 from strawpot.cli import (
     _check_update_async,
+    _detect_installer,
     _maybe_check_update,
     _prompt_update,
     _should_skip_update_check,
@@ -275,6 +278,85 @@ class TestEnvVarSkip:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("STRAWPOT_SKIP_UPDATE_CHECK", None)
             assert _should_skip_update_check() is False
+
+
+# ---------------------------------------------------------------------------
+# _detect_installer
+# ---------------------------------------------------------------------------
+
+
+class TestDetectInstaller:
+    def test_frozen_binary(self):
+        """Binary detection takes priority over all env-based signals."""
+        with patch.object(sys, "_MEIPASS", "/tmp/frozen", create=True), \
+             patch.dict(os.environ, {"PIPX_HOME": "/custom/pipx"}, clear=False):
+            assert _detect_installer() == "binary"
+
+    def test_pipx_home_with_matching_venv(self):
+        """PIPX_HOME + VIRTUAL_ENV under it => pipx."""
+        env = {
+            "PIPX_HOME": "/custom/pipx",
+            "VIRTUAL_ENV": "/custom/pipx/venvs/strawpot",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            assert _detect_installer() == "pipx"
+
+    def test_pipx_home_without_matching_venv(self):
+        """PIPX_HOME set but venv is elsewhere => pip (not a false positive)."""
+        env = {
+            "PIPX_HOME": "/custom/pipx",
+            "VIRTUAL_ENV": "/home/user/.venv",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            assert _detect_installer() == "pip"
+
+    def test_pipx_home_empty_string(self):
+        """PIPX_HOME='' (set but empty) => treated as unset."""
+        with patch.dict(os.environ, {"PIPX_HOME": "", "VIRTUAL_ENV": "/home/user/.venv"}, clear=False):
+            assert _detect_installer() == "pip"
+
+    def test_virtual_env_with_pipx_segment(self):
+        venv_path = f"/home/user/.local/share/pipx{os.sep}venvs/strawpot"
+        with self._without_env("PIPX_HOME"), \
+             patch.dict(os.environ, {"VIRTUAL_ENV": venv_path}, clear=False):
+            assert _detect_installer() == "pipx"
+
+    def test_plain_pip(self):
+        with self._without_env("PIPX_HOME"), \
+             patch.dict(os.environ, {"VIRTUAL_ENV": "/home/user/.venv"}, clear=False):
+            assert _detect_installer() == "pip"
+
+    def test_no_virtual_env_no_pipx(self):
+        with self._without_env("PIPX_HOME"), \
+             self._without_env("VIRTUAL_ENV"):
+            assert _detect_installer() == "pip"
+
+    def test_pipx_substring_in_unrelated_path_no_match(self):
+        """A path like '/home/pipxfan/.venv' should NOT trigger pipx detection."""
+        with self._without_env("PIPX_HOME"), \
+             patch.dict(os.environ, {"VIRTUAL_ENV": "/home/pipxfan/.venv"}, clear=False):
+            assert _detect_installer() == "pip"
+
+    def test_both_pipx_home_and_venv_segment(self):
+        """When both signals agree, still returns pipx."""
+        env = {
+            "PIPX_HOME": "/home/user/.local/share/pipx",
+            "VIRTUAL_ENV": "/home/user/.local/share/pipx/venvs/strawpot",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            assert _detect_installer() == "pipx"
+
+    @staticmethod
+    @contextmanager
+    def _without_env(key: str):
+        """Context manager that temporarily removes an env var if present."""
+        sentinel = object()
+        old = os.environ.pop(key, sentinel)
+        try:
+            yield
+        finally:
+            if old is not sentinel:
+                os.environ[key] = old
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace the fragile `pipx_home in sys.prefix` substring check with robust environment variable-based detection
- Check if `VIRTUAL_ENV` starts with `PIPX_HOME` (when both are set), then fall back to looking for a `/pipx/` path segment in `VIRTUAL_ENV`
- Add 9 tests covering: binary priority, PIPX_HOME+matching venv, PIPX_HOME+non-matching venv, empty PIPX_HOME, VIRTUAL_ENV path segment, plain pip, no env vars, false-positive prevention, and combined signals

Closes #464

## Why

The old detection used `pipx_home in sys.prefix` which:
- Could produce false positives (e.g., a directory named `pipx` in an unrelated path)
- Could produce false negatives (e.g., non-standard pipx install locations)
- Had inverted containment semantics (checked if the pipx home was a substring of sys.prefix, not vice versa)

The new approach avoids relying on `PIPX_HOME` alone (it's a user config variable that may be set even for pip-installed packages) and instead validates that the active virtualenv actually lives under the pipx directory.

## Test plan

- [x] All 40 tests in `test_update_check.py` pass (31 existing + 9 new)
- [x] `TestDetectInstaller` covers binary, pipx (env var + path), pipx (path segment only), pip, no-env, false-positive prevention, and combined signals
- [x] False-positive test: `PIPX_HOME` set but venv elsewhere → returns `pip`
- [x] False-positive test: `/home/pipxfan/.venv` → returns `pip` (not `pipx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)