### PR TITLE
fix: exit 0 when strawpot is invoked with no arguments

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -125,9 +125,10 @@ def _show_first_run_banner() -> None:
 
 
 
-@click.group(cls=GroupedGroup, epilog=HELP_EPILOG)
+@click.group(cls=GroupedGroup, epilog=HELP_EPILOG, invoke_without_command=True)
 @click.version_option(version=__version__)
-def cli():
+@click.pass_context
+def cli(ctx):
     """StrawPot — AI agent orchestration.
 
     Compose AI agents that delegate tasks, share memory, and coordinate
@@ -135,6 +136,8 @@ def cli():
     and more.
     """
     _show_first_run_banner()
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 # ---------------------------------------------------------------------------
 # Quickstart guide

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -23,6 +23,20 @@ def _make_spec(**overrides):
 
 
 # ---------------------------------------------------------------------------
+# No-args invocation (issue #446)
+# ---------------------------------------------------------------------------
+
+
+@patch("strawpot.cli._show_first_run_banner")
+def test_no_args_shows_help_and_exits_zero(_mock_banner):
+    """Running ``strawpot`` with no arguments should show help and exit 0."""
+    runner = CliRunner()
+    result = runner.invoke(cli, [])
+    assert result.exit_code == 0
+    assert "StrawPot" in result.output
+
+
+# ---------------------------------------------------------------------------
 # Agent resolution
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Set `invoke_without_command=True` on the CLI group so bare `strawpot` invocation exits 0 instead of 2
- Added `@click.pass_context` and a `ctx.invoked_subcommand is None` guard to print help text when no subcommand is given
- Added test `test_no_args_shows_help_and_exits_zero` confirming exit code 0 and help output

Closes #446

## Test plan
- [x] `test_no_args_shows_help_and_exits_zero` — verifies exit code 0 and "StrawPot" in output
- [x] All 27 existing CLI tests pass (no regressions to subcommand routing)
- [x] Manual: `strawpot` with no args shows help and exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)