### PR TITLE
Add ProgressEvent dataclass + Session on_event + _emit_event

### DIFF
--- a/cli/src/strawpot/progress.py
+++ b/cli/src/strawpot/progress.py
@@ -1,0 +1,29 @@
+"""Progress event types for real-time session feedback."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ProgressEvent:
+    """A single progress event emitted during a session.
+
+    Consumed by renderers (terminal, JSON) or adapters (GUI EventBus).
+
+    Valid ``kind`` values::
+
+        session_start, delegate_start, delegate_end,
+        delegate_denied, delegate_cached,
+        ask_user_start, ask_user_end, session_end
+
+    Valid ``status`` values::
+
+        ok, error, denied, cached, "" (empty for start events)
+    """
+
+    kind: str
+    role: str  # e.g. "implementer", "code-reviewer"
+    detail: str  # human-readable (truncated task text or reason)
+    timestamp: str  # ISO 8601 UTC
+    duration_ms: int  # 0 for start events, elapsed for end events
+    status: str
+    depth: int  # delegation depth (0 = orchestrator)

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -45,6 +45,7 @@ from strawpot_memory.memory_protocol import MemoryProvider
 from strawpot.memory.registry import MemorySpec, load_provider, resolve_memory
 from strawpot.isolation.protocol import IsolatedEnv, Isolator, NoneIsolator
 from strawpot.isolation.worktree import WorktreeIsolator, _git
+from strawpot.progress import ProgressEvent
 from strawpot.trace import Tracer
 
 logger = logging.getLogger(__name__)
@@ -309,6 +310,7 @@ class Session:
         memory_task: str = "",
         group_id: str | None = None,
         keep_branch: bool = False,
+        on_event: Callable[[ProgressEvent], None] | None = None,
     ) -> None:
         self.config = config
         self.wrapper = wrapper
@@ -324,6 +326,7 @@ class Session:
         self._headless = headless
         self._group_id: str | None = group_id
         self._keep_branch: bool = keep_branch
+        self._on_event = on_event
 
         self._run_id: str | None = None
         self._env: IsolatedEnv | None = None
@@ -1027,6 +1030,21 @@ class Session:
                 delegate_res,
                 time.monotonic(),
             )
+
+    def _emit_event(self, event: ProgressEvent) -> None:
+        """Emit a progress event to the registered callback.
+
+        Swallows ``Exception`` subclasses -- ``BaseException`` (KeyboardInterrupt,
+        SystemExit) still propagates.  On the first failure the callback is
+        disabled for the rest of the session (circuit-breaker).
+        """
+        if self._on_event is None:
+            return
+        try:
+            self._on_event(event)
+        except Exception:
+            logger.warning("Event callback failed; progress output disabled", exc_info=True)
+            self._on_event = None
 
     def _handle_delegate(
         self, request: denden_pb2.DenDenRequest

--- a/cli/tests/test_progress.py
+++ b/cli/tests/test_progress.py
@@ -1,0 +1,155 @@
+"""Tests for progress event types and Session event emission."""
+
+import logging
+from unittest.mock import MagicMock
+
+from strawpot.progress import ProgressEvent
+
+
+# ---------------------------------------------------------------------------
+# ProgressEvent dataclass tests
+# ---------------------------------------------------------------------------
+
+_FIXED_TS = "2026-03-24T10:00:00+00:00"
+
+
+class TestProgressEvent:
+    """ProgressEvent dataclass stores all fields correctly."""
+
+    def test_fields_set_correctly(self):
+        event = ProgressEvent(
+            kind="delegate_start",
+            role="implementer",
+            detail="Add dark mode toggle",
+            timestamp=_FIXED_TS,
+            duration_ms=0,
+            status="",
+            depth=1,
+        )
+        assert event.kind == "delegate_start"
+        assert event.role == "implementer"
+        assert event.detail == "Add dark mode toggle"
+        assert event.timestamp == _FIXED_TS
+        assert event.duration_ms == 0
+        assert event.status == ""
+        assert event.depth == 1
+
+    def test_has_exactly_seven_fields(self):
+        """Guard against accidental field additions or removals."""
+        field_names = [f.name for f in ProgressEvent.__dataclass_fields__.values()]
+        assert field_names == [
+            "kind",
+            "role",
+            "detail",
+            "timestamp",
+            "duration_ms",
+            "status",
+            "depth",
+        ]
+
+    def test_end_event_with_duration(self):
+        event = ProgressEvent(
+            kind="delegate_end",
+            role="code-reviewer",
+            detail="",
+            timestamp=_FIXED_TS,
+            duration_ms=12345,
+            status="ok",
+            depth=2,
+        )
+        assert event.duration_ms == 12345
+        assert event.status == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Session._emit_event tests
+# ---------------------------------------------------------------------------
+
+
+def _make_session(**kwargs):
+    """Build a minimal Session with mocked dependencies for testing _emit_event."""
+    from strawpot.session import Session
+
+    defaults = {
+        "config": MagicMock(),
+        "wrapper": MagicMock(),
+        "runtime": MagicMock(),
+        "isolator": MagicMock(),
+        "resolve_role": MagicMock(return_value={}),
+        "resolve_role_dirs": MagicMock(return_value=None),
+    }
+    return Session(**{**defaults, **kwargs})
+
+
+def _sample_event():
+    return ProgressEvent(
+        kind="delegate_start",
+        role="implementer",
+        detail="test task",
+        timestamp=_FIXED_TS,
+        duration_ms=0,
+        status="",
+        depth=1,
+    )
+
+
+class TestEmitEvent:
+    """Tests for Session._emit_event()."""
+
+    def test_noop_when_no_callback(self):
+        """No error when on_event is None (the default)."""
+        session = _make_session()
+        session._emit_event(_sample_event())  # should not raise
+
+    def test_calls_callback_with_event(self):
+        callback = MagicMock()
+        session = _make_session(on_event=callback)
+        event = _sample_event()
+        session._emit_event(event)
+        callback.assert_called_once_with(event)
+
+    def test_swallows_callback_exception_and_disables(self, caplog):
+        """A raising callback must not crash the session; circuit-breaker disables it."""
+
+        def bad_callback(event):
+            raise RuntimeError("renderer exploded")
+
+        session = _make_session(on_event=bad_callback)
+        with caplog.at_level(logging.WARNING):
+            session._emit_event(_sample_event())  # should not raise
+        assert "Event callback failed" in caplog.text
+        # Circuit-breaker: callback is now disabled
+        assert session._on_event is None
+
+    def test_circuit_breaker_prevents_repeated_failures(self):
+        """After one failure, subsequent _emit_event calls are no-ops."""
+        call_count = 0
+
+        def bad_callback(event):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("boom")
+
+        session = _make_session(on_event=bad_callback)
+        session._emit_event(_sample_event())  # fails, disables
+        session._emit_event(_sample_event())  # should be a no-op
+        session._emit_event(_sample_event())  # should be a no-op
+        assert call_count == 1  # only called once before circuit-breaker
+
+    def test_keyboard_interrupt_propagates(self):
+        """BaseException subclasses must not be swallowed."""
+        import pytest
+
+        def bad_callback(event):
+            raise KeyboardInterrupt()
+
+        session = _make_session(on_event=bad_callback)
+        with pytest.raises(KeyboardInterrupt):
+            session._emit_event(_sample_event())
+
+    def test_multiple_events(self):
+        callback = MagicMock()
+        session = _make_session(on_event=callback)
+        for _ in range(5):
+            session._emit_event(_sample_event())
+        assert callback.call_count == 5


### PR DESCRIPTION
## Summary

- New `ProgressEvent` dataclass in `cli/src/strawpot/progress.py` with 7 fields (kind, role, detail, timestamp, duration_ms, status, depth)
- `Session.__init__` accepts `on_event: Callable[[ProgressEvent], None] | None` callback
- `Session._emit_event()` with circuit-breaker: on first failure, logs warning and disables callback
- 9 tests in `cli/tests/test_progress.py` covering fields, callback invocation, circuit-breaker, and BaseException propagation

Closes #495

## Test plan

- [x] 9 new tests pass (`pytest cli/tests/test_progress.py`)
- [x] All 740 existing + new tests pass (`pytest cli/tests/`)
- [x] ProgressEvent follows TraceEvent dataclass pattern
- [x] on_event follows ask_user_handler callback pattern
- [x] Circuit-breaker prevents repeated failures from spamming logs
- [x] KeyboardInterrupt propagates (not swallowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)