### PR TITLE
Emit ProgressEvents from all Session lifecycle points

### DIFF
--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -380,6 +380,7 @@ class Session:
             self._ask_user_handler = make_file_bridge_handler(self._session_dir())
 
         # Initialize tracer (before try block so session_dir exists)
+        self._session_start_time = time.monotonic()
         if self.config.trace:
             self._tracer = Tracer(self._session_dir(), self._run_id)
             self._session_span_id = self._tracer.session_start(
@@ -389,7 +390,6 @@ class Session:
                 isolation=self.config.isolation,
                 task=self.task or "",
             )
-            self._session_start_time = time.monotonic()
 
         original_sigint = signal.getsignal(signal.SIGINT)
         try:
@@ -536,6 +536,10 @@ class Session:
                 )
                 self._agent_spans[agent_id] = self._session_span_id
 
+            self._emit(
+                "session_start", self.config.orchestrator_role,
+            )
+
             # 6. Write session state file
             self._write_session_file()
 
@@ -595,22 +599,29 @@ class Session:
                         group_id=self._group_id,
                     )
 
-        # 0b. Emit session_end trace event before cleanup that might fail
+        # 0b. Emit session_end trace + progress events before cleanup
+        end_duration_ms = self._elapsed_ms(self._session_start_time)
+        files_changed = self._detect_files_changed()
+
         if self._tracer is not None and self._session_span_id is not None:
-            duration_ms = int(
-                (time.monotonic() - self._session_start_time) * 1000
-            )
             result = self._orchestrator_result
             exit_code = result.exit_code if result else 0
-            files_changed = self._detect_files_changed()
             self._tracer.session_end(
                 span_id=self._session_span_id,
                 merge_action="pending",
-                duration_ms=duration_ms,
+                duration_ms=end_duration_ms,
                 output=result.output if result else "",
                 exit_code=exit_code,
                 files_changed=files_changed,
             )
+
+        orch_result = self._orchestrator_result
+        end_status = "ok" if (orch_result is None or orch_result.exit_code == 0) else "error"
+        files_detail = f"{len(files_changed)} files changed" if files_changed else ""
+        self._emit(
+            "session_end", self.config.orchestrator_role,
+            detail=files_detail, duration_ms=end_duration_ms, status=end_status,
+        )
 
         # 1. Kill remaining sub-agents
         for agent_id, handle in self._agents.items():
@@ -1031,6 +1042,11 @@ class Session:
                 time.monotonic(),
             )
 
+    @staticmethod
+    def _elapsed_ms(t0: float) -> int:
+        """Milliseconds elapsed since *t0* (from ``time.monotonic()``)."""
+        return int((time.monotonic() - t0) * 1000)
+
     def _emit_event(self, event: ProgressEvent) -> None:
         """Emit a progress event to the registered callback.
 
@@ -1045,6 +1061,22 @@ class Session:
         except Exception:
             logger.warning("Event callback failed; progress output disabled", exc_info=True)
             self._on_event = None
+
+    def _emit(
+        self,
+        kind: str,
+        role: str,
+        detail: str = "",
+        duration_ms: int = 0,
+        status: str = "",
+        depth: int = 0,
+    ) -> None:
+        """Construct a :class:`ProgressEvent` with an auto-generated timestamp and emit it."""
+        self._emit_event(ProgressEvent(
+            kind=kind, role=role, detail=detail,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            duration_ms=duration_ms, status=status, depth=depth,
+        ))
 
     def _handle_delegate(
         self, request: denden_pb2.DenDenRequest
@@ -1083,23 +1115,32 @@ class Session:
         )
 
         # --- Max delegations check (before cache — cache hits count too) ---
+        _denied_for_limit = False
         with self._delegation_lock:
             max_del = self.config.max_num_delegations
             if max_del > 0 and self._delegation_count >= max_del:
-                reason = "DENY_DELEGATIONS_LIMIT"
-                if self._tracer is not None:
-                    self._tracer.delegate_denied(
-                        role=delegate_req.role_slug,
-                        parent_span=requester_span,
-                        reason=reason,
-                        depth=delegate_req.depth,
-                    )
-                return denied_response(
-                    request.request_id,
-                    reason,
-                    f"Session delegation limit reached ({max_del})",
+                _denied_for_limit = True
+            else:
+                self._delegation_count += 1
+        if _denied_for_limit:
+            reason = "DENY_DELEGATIONS_LIMIT"
+            if self._tracer is not None:
+                self._tracer.delegate_denied(
+                    role=delegate_req.role_slug,
+                    parent_span=requester_span,
+                    reason=reason,
+                    depth=delegate_req.depth,
                 )
-            self._delegation_count += 1
+            self._emit(
+                "delegate_denied", delegate_req.role_slug,
+                detail="DENY_DELEGATIONS_LIMIT", status="denied",
+                depth=delegate_req.depth,
+            )
+            return denied_response(
+                request.request_id,
+                reason,
+                f"Session delegation limit reached ({max_del})",
+            )
 
         # --- Cache check (fast path) ---
         cache_key: str | None = None
@@ -1137,6 +1178,10 @@ class Session:
                         role=delegate_req.role_slug,
                         cache_hit=True,
                     )
+                self._emit(
+                    "delegate_cached", delegate_req.role_slug,
+                    status="cached", depth=delegate_req.depth,
+                )
                 return ok_response(
                     request.request_id,
                     delegate_result=cached_delegate_res,
@@ -1152,6 +1197,7 @@ class Session:
         if key_lock is not None:
             key_lock.acquire()
         try:
+            t0 = time.monotonic()
             # Re-check cache after acquiring per-key lock (another
             # thread may have populated it while we were waiting).
             if cache_key is not None:
@@ -1179,11 +1225,19 @@ class Session:
                             role=delegate_req.role_slug,
                             cache_hit=True,
                         )
+                    self._emit(
+                        "delegate_cached", delegate_req.role_slug,
+                        status="cached", depth=delegate_req.depth,
+                    )
                     return ok_response(
                         request.request_id,
                         delegate_result=cached_delegate_res,
                     )
 
+            self._emit(
+                "delegate_start", delegate_req.role_slug,
+                detail=delegate_req.task_text[:60], depth=delegate_req.depth,
+            )
             result = handle_delegate(
                 request=delegate_req,
                 config=self.config,
@@ -1202,6 +1256,11 @@ class Session:
                 group_id=self._group_id,
             )
             if result.exit_code != 0:
+                self._emit(
+                    "delegate_end", delegate_req.role_slug,
+                    duration_ms=self._elapsed_ms(t0), status="error",
+                    depth=delegate_req.depth,
+                )
                 msg = f"Sub-agent exited with code {result.exit_code}"
                 if result.output:
                     tail = result.output[-2000:] if len(result.output) > 2000 else result.output
@@ -1218,6 +1277,11 @@ class Session:
             # Cache successful results with non-empty output
             if cache_key is not None and result.output:
                 self._cache_store(cache_key, result.output, delegate_res)
+            self._emit(
+                "delegate_end", delegate_req.role_slug,
+                duration_ms=self._elapsed_ms(t0), status="ok",
+                depth=delegate_req.depth,
+            )
             return ok_response(
                 request.request_id,
                 delegate_result=delegate_res,
@@ -1230,11 +1294,21 @@ class Session:
                     reason=exc.reason,
                     depth=delegate_req.depth,
                 )
+            self._emit(
+                "delegate_denied", delegate_req.role_slug,
+                detail=exc.reason, duration_ms=self._elapsed_ms(t0),
+                status="denied", depth=delegate_req.depth,
+            )
             return denied_response(
                 request.request_id, exc.reason, str(exc)
             )
         except Exception as exc:
             logger.exception("Delegation failed for %s", request.request_id)
+            self._emit(
+                "delegate_end", delegate_req.role_slug,
+                detail=str(exc), duration_ms=self._elapsed_ms(t0),
+                status="error", depth=delegate_req.depth,
+            )
             return error_response(
                 request.request_id,
                 "ERR_SUBAGENT_FAILURE",
@@ -1283,21 +1357,29 @@ class Session:
                 session_id=self._run_id,
             )
         t0 = time.monotonic()
+        depth = self._agent_depth(agent_id)
+        self._emit(
+            "ask_user_start", role,
+            detail=ask.question[:60], depth=depth,
+        )
 
         try:
             resp = self._ask_user_handler(req)
         except Exception as exc:
             if self._tracer is not None and ask_span is not None:
-                duration_ms = int((time.monotonic() - t0) * 1000)
                 self._tracer.ask_user_end(
                     span_id=ask_span,
                     request_id=request.request_id,
                     answer=f"ERROR: {exc}",
-                    duration_ms=duration_ms,
+                    duration_ms=self._elapsed_ms(t0),
                     agent_id=agent_id,
                     role=role,
                     session_id=self._run_id,
                 )
+            self._emit(
+                "ask_user_end", role, detail=str(exc),
+                duration_ms=self._elapsed_ms(t0), status="error", depth=depth,
+            )
             logger.exception("ask_user handler failed")
             return error_response(
                 request.request_id,
@@ -1306,16 +1388,19 @@ class Session:
             )
 
         if self._tracer is not None and ask_span is not None:
-            duration_ms = int((time.monotonic() - t0) * 1000)
             self._tracer.ask_user_end(
                 span_id=ask_span,
                 request_id=request.request_id,
                 answer=resp.text,
-                duration_ms=duration_ms,
+                duration_ms=self._elapsed_ms(t0),
                 agent_id=agent_id,
                 role=role,
                 session_id=self._run_id,
             )
+        self._emit(
+            "ask_user_end", role,
+            duration_ms=self._elapsed_ms(t0), status="ok", depth=depth,
+        )
 
         result = denden_pb2.AskUserResult(text=resp.text)
         if resp.json:

--- a/cli/tests/test_progress.py
+++ b/cli/tests/test_progress.py
@@ -1,7 +1,7 @@
 """Tests for progress event types and Session event emission."""
 
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from strawpot.progress import ProgressEvent
 
@@ -153,3 +153,244 @@ class TestEmitEvent:
         for _ in range(5):
             session._emit_event(_sample_event())
         assert callback.call_count == 5
+
+
+# ---------------------------------------------------------------------------
+# Event emission integration tests — _handle_delegate, _handle_ask_user,
+# start(), stop()
+# ---------------------------------------------------------------------------
+
+
+def _make_delegate_session(tmp_path, on_event):
+    """Create a Session wired for delegation testing with on_event."""
+    from strawpot.config import StrawPotConfig
+    from strawpot.isolation.protocol import IsolatedEnv
+
+    config = StrawPotConfig(memory="")
+    session = _make_session(
+        config=config,
+        on_event=on_event,
+    )
+    session._env = IsolatedEnv(path=str(tmp_path))
+    session._working_dir = str(tmp_path)
+    session._run_id = "run_test"
+    session._denden_addr = "127.0.0.1:9700"
+    session._register_agent("agent_orch", role="orchestrator", parent_id=None)
+    return session
+
+
+def _make_denden_request(
+    delegate_to="implementer",
+    task_text="Do something",
+    agent_id="agent_orch",
+    run_id="run_test",
+):
+    request = MagicMock()
+    request.request_id = "req_123"
+    request.delegate.delegate_to = delegate_to
+    request.delegate.task.text = task_text
+    request.delegate.task.return_format = 0  # TEXT
+    request.trace.agent_instance_id = agent_id
+    request.trace.run_id = run_id
+    request.WhichOneof.return_value = "delegate"
+    return request
+
+
+class TestDelegateEventEmission:
+    """Verify _handle_delegate emits the right ProgressEvents."""
+
+    @patch("strawpot.session.handle_delegate")
+    @patch("strawpot.session.ok_response", return_value="ok")
+    def test_success_emits_start_and_end_ok(self, _ok, mock_handle, tmp_path):
+        from strawpot.delegation import DelegateResult
+
+        mock_handle.return_value = DelegateResult(output="done", exit_code=0)
+        events = []
+        session = _make_delegate_session(tmp_path, on_event=events.append)
+        session._handle_delegate(_make_denden_request())
+
+        kinds = [e.kind for e in events]
+        assert kinds == ["delegate_start", "delegate_end"]
+        assert events[0].role == "implementer"
+        assert events[0].status == ""
+        assert events[0].depth == 0  # orchestrator depth is 0
+        assert events[1].status == "ok"
+        assert events[1].duration_ms >= 0
+
+    @patch("strawpot.session.handle_delegate")
+    @patch("strawpot.session.error_response", return_value="error")
+    def test_nonzero_exit_emits_start_and_end_error(self, _err, mock_handle, tmp_path):
+        from strawpot.delegation import DelegateResult
+
+        mock_handle.return_value = DelegateResult(output="fail", exit_code=1)
+        events = []
+        session = _make_delegate_session(tmp_path, on_event=events.append)
+        session._handle_delegate(_make_denden_request())
+
+        kinds = [e.kind for e in events]
+        assert kinds == ["delegate_start", "delegate_end"]
+        assert events[1].status == "error"
+
+    @patch("strawpot.session.handle_delegate")
+    @patch("strawpot.session.denied_response", return_value="denied")
+    def test_policy_denied_emits_start_and_denied(self, _denied, mock_handle, tmp_path):
+        from strawpot.delegation import PolicyDenied
+
+        mock_handle.side_effect = PolicyDenied("DENY_ROLE_NOT_ALLOWED")
+        events = []
+        session = _make_delegate_session(tmp_path, on_event=events.append)
+        session._handle_delegate(_make_denden_request())
+
+        kinds = [e.kind for e in events]
+        assert kinds == ["delegate_start", "delegate_denied"]
+        assert events[1].status == "denied"
+        assert events[1].detail == "DENY_ROLE_NOT_ALLOWED"
+
+    @patch("strawpot.session.handle_delegate")
+    @patch("strawpot.session.error_response", return_value="error")
+    def test_exception_emits_start_and_end_error(self, _err, mock_handle, tmp_path):
+        mock_handle.side_effect = RuntimeError("kaboom")
+        events = []
+        session = _make_delegate_session(tmp_path, on_event=events.append)
+        session._handle_delegate(_make_denden_request())
+
+        kinds = [e.kind for e in events]
+        assert kinds == ["delegate_start", "delegate_end"]
+        assert events[1].status == "error"
+        assert "kaboom" in events[1].detail
+
+    def test_max_delegations_emits_denied(self, tmp_path):
+        from strawpot.config import StrawPotConfig
+
+        config = StrawPotConfig(memory="", max_num_delegations=1)
+        events = []
+        session = _make_session(config=config, on_event=events.append)
+
+        from strawpot.isolation.protocol import IsolatedEnv
+
+        session._env = IsolatedEnv(path=str(tmp_path))
+        session._working_dir = str(tmp_path)
+        session._run_id = "run_test"
+        session._denden_addr = "127.0.0.1:9700"
+        session._register_agent("agent_orch", role="orchestrator", parent_id=None)
+        session._delegation_count = 1  # already at limit
+
+        session._handle_delegate(_make_denden_request())
+
+        assert len(events) == 1
+        assert events[0].kind == "delegate_denied"
+        assert events[0].detail == "DENY_DELEGATIONS_LIMIT"
+
+    @patch("strawpot.session.handle_delegate")
+    @patch("strawpot.session.ok_response", return_value="ok")
+    def test_cache_hit_emits_cached_only(self, _ok, mock_handle, tmp_path):
+        """Cache hits emit delegate_cached, not delegate_start/delegate_end."""
+        from strawpot.config import StrawPotConfig
+        from strawpot.delegation import DelegateResult
+        from strawpot.isolation.protocol import IsolatedEnv
+
+        config = StrawPotConfig(memory="", cache_delegations=True)
+        events = []
+        session = _make_session(config=config, on_event=events.append)
+        session._env = IsolatedEnv(path=str(tmp_path))
+        session._working_dir = str(tmp_path)
+        session._run_id = "run_test"
+        session._denden_addr = "127.0.0.1:9700"
+        session._register_agent("agent_orch", role="orchestrator", parent_id=None)
+
+        # First call: real delegation
+        mock_handle.return_value = DelegateResult(output="done", exit_code=0)
+        session._handle_delegate(_make_denden_request())
+
+        # Second call: should hit cache
+        events.clear()
+        session._handle_delegate(_make_denden_request())
+
+        kinds = [e.kind for e in events]
+        assert "delegate_cached" in kinds
+        assert "delegate_start" not in kinds
+        assert "delegate_end" not in kinds
+
+    @patch("strawpot.session.handle_delegate")
+    @patch("strawpot.session.ok_response", return_value="ok")
+    def test_depth_matches_agent_depth(self, _ok, mock_handle, tmp_path):
+        from strawpot.delegation import DelegateResult
+
+        mock_handle.return_value = DelegateResult(output="done", exit_code=0)
+        events = []
+        session = _make_delegate_session(tmp_path, on_event=events.append)
+        # Register a sub-agent at depth 2
+        session._register_agent(
+            "agent_sub", role="implementer", parent_id="agent_orch"
+        )
+        req = _make_denden_request(agent_id="agent_sub")
+        session._handle_delegate(req)
+
+        assert events[0].depth == 1  # sub-agent of orchestrator is depth 1
+
+
+class TestAskUserEventEmission:
+    """Verify _handle_ask_user emits ask_user_start + ask_user_end."""
+
+    def _make_ask_request(self, question="What color?", agent_id="agent_orch"):
+        request = MagicMock()
+        request.request_id = "req_ask_1"
+        request.ask_user.question = question
+        request.ask_user.choices = []
+        request.ask_user.default_value = ""
+        request.ask_user.why = ""
+        request.ask_user.response_format = 0
+        request.trace.agent_instance_id = agent_id
+        request.trace.run_id = "run_test"
+        request.WhichOneof.return_value = "ask_user"
+        return request
+
+    def test_success_emits_start_and_end(self, tmp_path):
+        from strawpot.session import AskUserResponse
+
+        events = []
+        handler = MagicMock(return_value=AskUserResponse(text="blue"))
+        session = _make_delegate_session(tmp_path, on_event=events.append)
+        session._ask_user_handler = handler
+
+        session._handle_ask_user(self._make_ask_request())
+
+        kinds = [e.kind for e in events]
+        assert kinds == ["ask_user_start", "ask_user_end"]
+        assert events[0].detail == "What color?"
+        assert events[1].status == "ok"
+        assert events[1].duration_ms >= 0
+
+    def test_error_emits_start_and_end_error(self, tmp_path):
+        events = []
+
+        def failing_handler(req):
+            raise RuntimeError("handler failed")
+
+        session = _make_delegate_session(tmp_path, on_event=events.append)
+        session._ask_user_handler = failing_handler
+
+        session._handle_ask_user(self._make_ask_request())
+
+        kinds = [e.kind for e in events]
+        assert kinds == ["ask_user_start", "ask_user_end"]
+        assert events[1].status == "error"
+
+
+class TestSessionLifecycleEvents:
+    """Verify start() and stop() emit session_start and session_end."""
+
+    def test_stop_emits_session_end(self, tmp_path):
+        """stop() emits session_end with duration."""
+        import time
+
+        events = []
+        session = _make_delegate_session(tmp_path, on_event=events.append)
+        session._session_start_time = time.monotonic() - 1.0  # 1s ago
+
+        session.stop()
+
+        end_events = [e for e in events if e.kind == "session_end"]
+        assert len(end_events) == 1
+        assert end_events[0].status == "ok"
+        assert end_events[0].duration_ms >= 1000


### PR DESCRIPTION
## Summary

- Adds `_emit_event()` calls at all 13 Session lifecycle points:
  - All 7 `_handle_delegate` exit paths (denied, 2 cache hits, start+success, start+error, start+PolicyDenied, start+exception)
  - `_handle_ask_user`: ask_user_start + ask_user_end (success and error)
  - `start()`: session_start after orchestrator spawn
  - `stop()`: session_end with duration, files changed, and correct status
- Extracted `_emit()` convenience method and `_elapsed_ms()` helper
- Fixed: `t0` moved before cache re-check to prevent `UnboundLocalError`
- Fixed: `_session_start_time` set unconditionally (not only when tracing)
- Fixed: `_emit` moved outside `_delegation_lock` to prevent liveness risk
- Fixed: `session_end` status derived from orchestrator exit code (not always "ok")

Depends on: #500 (sub-issue #495)
Closes #496

## Test plan

- [x] 10 new integration tests in `test_progress.py` (19 total)
- [x] All 750 tests pass (`pytest cli/tests/`)
- [x] All 7 delegate paths verified with correct event sequences
- [x] Cache hits emit `delegate_cached` only (no start/end)
- [x] Depth values match actual agent depth
- [x] Duration computed correctly with `_elapsed_ms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)