### PR TITLE
feat: add `strawpot run` command as alias for `start --task`

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _COMMAND_GROUPS: list[tuple[str, list[str]]] = [
-    ("Getting Started", ["start", "quickstart", "doctor", "gui"]),
+    ("Getting Started", ["start", "run", "quickstart", "doctor", "gui"]),
     ("Sessions", ["sessions", "agents", "config"]),
     ("Package Management", ["install", "uninstall", "update", "init", "install-tools"]),
     ("Discovery", ["search", "list", "info", "resolve"]),
@@ -157,7 +157,7 @@ _QUICKSTART_TEXT = """\
    or Codex), install it, and start an interactive session.
 
 {step3}  Run a task non-interactively
-   Pass a task string to skip the interactive prompt:
+   Use the shorthand {run_cmd} or the full form:
    {task_example}
 
 {step4}  Open the web dashboard
@@ -190,6 +190,7 @@ def quickstart():
             step6=click.style("6.", bold=True),
             doctor=click.style("strawpot doctor", bold=True),
             start=click.style("strawpot start", bold=True),
+            run_cmd=click.style('strawpot run "Fix the login bug"', bold=True),
             task_example=click.style('strawpot start --task "Fix the login bug"', bold=True),
             gui=click.style("strawpot gui", bold=True),
             search_example=click.style("strawpot search role", bold=True),
@@ -798,50 +799,60 @@ def _resolve_progress_renderer(progress_mode: str, task: str | None):
     return None
 
 
+def _shared_session_options(func):
+    """Apply session options shared by ``start`` and ``run``."""
+    options = [
+        click.option("--role", default=None, help="Orchestrator role slug from strawhub."),
+        click.option("--runtime", default=None, help="Agent runtime (any registry-resolvable name)."),
+        click.option(
+            "--isolation",
+            default=None,
+            type=click.Choice(["none", "worktree", "docker"]),
+            help="Isolation method.",
+        ),
+        click.option(
+            "--pull",
+            default=None,
+            type=click.Choice(["auto", "always", "never", "prompt"]),
+            help="Whether to pull latest before creating a session.",
+        ),
+        click.option("--host", default=None, help="Denden server host."),
+        click.option("--port", default=None, type=int, help="Denden server port."),
+        click.option(
+            "--headless",
+            is_flag=True,
+            default=False,
+            help="Run detached with output to log file (requires --task).",
+        ),
+        click.option("--run-id", "run_id", default=None, help="Pre-assigned run ID (used by GUI)."),
+        click.option("--system-prompt", "system_prompt", default=None, help="Custom system prompt appended to role instructions."),
+        click.option("--no-cache-delegations", "no_cache_delegations", is_flag=True, default=False, help="Disable caching of delegation results within the session."),
+        click.option("--cache-max-entries", "cache_max_entries", type=int, default=None, help="Max cached delegation results (0 = unlimited)."),
+        click.option("--cache-ttl-seconds", "cache_ttl_seconds", type=int, default=None, help="Max age in seconds for cached results (0 = unlimited)."),
+        click.option("--memory", "memory_override", default=None, help="Memory provider to use (overrides config)."),
+        click.option("--max-num-delegations", "max_num_delegations", type=int, default=None, help="Max delegation calls per session (0 = unlimited)."),
+        click.option("--memory-task", "memory_task", default=None, help="Original task string for memory scoring (defaults to --task if not set)."),
+        click.option("--group-id", "group_id", default=None, help="Group ID for memory scoping (e.g. conversation ID from the GUI)."),
+        click.option("--skip-update-check", "skip_update_check", is_flag=True, default=False, help="Skip the automatic update check on startup."),
+        click.option("--keep-branch", "keep_branch", is_flag=True, default=False, help="Keep the session branch after teardown (overrides cleanup_branches config)."),
+        click.option("--no-tools", "no_tools", is_flag=True, default=False, help="Skip tool dependency installation entirely."),
+        click.option(
+            "--progress",
+            "progress_mode",
+            type=click.Choice(["auto", "json", "off"], case_sensitive=False),
+            default="auto",
+            help="Progress output mode (auto=terminal for --task, json=JSONL, off=disabled).",
+        ),
+    ]
+    for option in reversed(options):
+        func = option(func)
+    return func
+
+
 @cli.command()
-@click.option("--role", default=None, help="Orchestrator role slug from strawhub.")
-@click.option("--runtime", default=None, help="Agent runtime (any registry-resolvable name).")
-@click.option(
-    "--isolation",
-    default=None,
-    type=click.Choice(["none", "worktree", "docker"]),
-    help="Isolation method.",
-)
-@click.option(
-    "--pull",
-    default=None,
-    type=click.Choice(["auto", "always", "never", "prompt"]),
-    help="Whether to pull latest before creating a session.",
-)
-@click.option("--host", default=None, help="Denden server host.")
-@click.option("--port", default=None, type=int, help="Denden server port.")
+@_shared_session_options
 @click.option("--task", default=None, help="Run noninteractively with a task string.")
-@click.option(
-    "--headless",
-    is_flag=True,
-    default=False,
-    help="Run detached with output to log file (requires --task).",
-)
-@click.option("--run-id", "run_id", default=None, help="Pre-assigned run ID (used by GUI).")
-@click.option("--system-prompt", "system_prompt", default=None, help="Custom system prompt appended to role instructions.")
-@click.option("--no-cache-delegations", "no_cache_delegations", is_flag=True, default=False, help="Disable caching of delegation results within the session.")
-@click.option("--cache-max-entries", "cache_max_entries", type=int, default=None, help="Max cached delegation results (0 = unlimited).")
-@click.option("--cache-ttl-seconds", "cache_ttl_seconds", type=int, default=None, help="Max age in seconds for cached results (0 = unlimited).")
-@click.option("--memory", "memory_override", default=None, help="Memory provider to use (overrides config).")
-@click.option("--max-num-delegations", "max_num_delegations", type=int, default=None, help="Max delegation calls per session (0 = unlimited).")
-@click.option("--memory-task", "memory_task", default=None, help="Original task string for memory scoring (defaults to --task if not set).")
-@click.option("--group-id", "group_id", default=None, help="Group ID for memory scoping (e.g. conversation ID from the GUI).")
-@click.option("--skip-update-check", "skip_update_check", is_flag=True, default=False, help="Skip the automatic update check on startup.")
-@click.option("--keep-branch", "keep_branch", is_flag=True, default=False, help="Keep the session branch after teardown (overrides cleanup_branches config).")
 @click.option("--yes", "-y", "yes_flag", is_flag=True, default=False, help="Auto-accept all install prompts (tools, agents, etc.).")
-@click.option("--no-tools", "no_tools", is_flag=True, default=False, help="Skip tool dependency installation entirely.")
-@click.option(
-    "--progress",
-    "progress_mode",
-    type=click.Choice(["auto", "json", "off"], case_sensitive=False),
-    default="auto",
-    help="Progress output mode (auto=terminal for --task, json=JSONL, off=disabled).",
-)
 def start(role, runtime, isolation, pull, host, port, task, headless, run_id, system_prompt, no_cache_delegations, cache_max_entries, cache_ttl_seconds, memory_override, max_num_delegations, memory_task, group_id, skip_update_check, keep_branch, yes_flag, no_tools, progress_mode):
     """Start an orchestration session.
 
@@ -1141,6 +1152,20 @@ def start(role, runtime, isolation, pull, host, port, task, headless, run_id, sy
         on_event=on_event,
     )
     session.start(working_dir)
+
+
+@cli.command()
+@click.argument("task")
+@_shared_session_options
+@click.pass_context
+def run(ctx, task, **kwargs):
+    """Run a task non-interactively (shorthand for ``start --task``).
+
+    Equivalent to ``strawpot start --task TASK --yes``.  Accepts the same
+    options as ``start`` except ``--task`` (positional) and ``--yes``
+    (implied).
+    """
+    ctx.invoke(start, task=task, yes_flag=True, **kwargs)
 
 
 @cli.command(name="config")

--- a/cli/tests/test_cli_run.py
+++ b/cli/tests/test_cli_run.py
@@ -1,0 +1,154 @@
+"""Tests for the ``strawpot run`` command (alias for ``start --task``)."""
+
+from unittest.mock import patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from strawpot.cli import _COMMAND_GROUPS, cli
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _suppress_first_run(tmp_path):
+    """Suppress the first-run banner so it doesn't pollute test output."""
+    marker_dir = tmp_path / "home"
+    marker_dir.mkdir()
+    (marker_dir / ".first_run_done").touch()
+    with patch("strawpot.cli.get_strawpot_home", return_value=marker_dir):
+        yield
+
+
+@pytest.fixture()
+def start_spy():
+    """Intercept ``ctx.invoke(start, ...)`` and record the kwargs."""
+    invocations: list[dict] = []
+    original_invoke = click.Context.invoke
+
+    def spy_invoke(self, callback, **kwargs):
+        from strawpot.cli import start as start_cmd
+
+        if callback is start_cmd:
+            invocations.append(kwargs)
+            return  # don't actually run start
+        return original_invoke(self, callback, **kwargs)
+
+    with patch.object(click.Context, "invoke", spy_invoke):
+        yield invocations
+
+
+# ---------------------------------------------------------------------------
+# Command registration
+# ---------------------------------------------------------------------------
+
+
+def test_run_command_exists():
+    """The ``run`` command is registered on the CLI group."""
+    assert "run" in cli.commands
+
+
+def test_run_option_parity_with_start():
+    """``run`` exposes the same options as ``start`` minus --task and --yes."""
+    from strawpot.cli import run as run_cmd, start as start_cmd
+
+    start_names = {p.name for p in start_cmd.params}
+    run_names = {p.name for p in run_cmd.params}
+    # Both have "task" (start as --task option, run as positional argument).
+    # start additionally has --yes/yes_flag which run always implies.
+    assert start_names - run_names == {"yes_flag"}
+    assert run_names - start_names == set()
+
+
+def test_run_in_getting_started_group():
+    """``run`` appears in the Getting Started command group."""
+    getting_started = dict(_COMMAND_GROUPS)["Getting Started"]
+    assert "run" in getting_started
+
+
+def test_run_appears_in_help(runner):
+    """``strawpot --help`` lists the run command."""
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "run" in result.output
+
+
+def test_run_help_shows_task_argument(runner):
+    """``strawpot run --help`` shows the positional TASK argument."""
+    result = runner.invoke(cli, ["run", "--help"])
+    assert result.exit_code == 0
+    assert "TASK" in result.output
+
+
+def test_run_help_shows_options(runner):
+    """``strawpot run --help`` lists pass-through options."""
+    result = runner.invoke(cli, ["run", "--help"])
+    assert result.exit_code == 0
+    for opt in ("--role", "--runtime", "--progress", "--headless"):
+        assert opt in result.output
+
+
+def test_run_help_omits_task_and_yes_options(runner):
+    """``strawpot run --help`` does NOT show --task or --yes (they are implicit)."""
+    result = runner.invoke(cli, ["run", "--help"])
+    option_lines = [l for l in result.output.splitlines() if l.strip().startswith("--")]
+    # --memory-task is expected; only a bare --task option should be absent.
+    assert not any("--task " in l and "--memory-task" not in l for l in option_lines)
+    assert not any("--yes" in l for l in option_lines)
+
+
+def test_run_without_task_shows_usage_error(runner):
+    """``strawpot run`` without a task argument shows a usage error."""
+    result = runner.invoke(cli, ["run"])
+    assert result.exit_code != 0
+    assert "Missing argument" in result.output or "Usage" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Delegation to start
+# ---------------------------------------------------------------------------
+
+
+def test_run_invokes_start_with_task_and_yes(runner, start_spy):
+    """``run`` delegates to ``start`` with task= and yes_flag=True."""
+    runner.invoke(cli, ["run", "Add dark mode toggle"])
+
+    assert len(start_spy) == 1
+    assert start_spy[0]["task"] == "Add dark mode toggle"
+    assert start_spy[0]["yes_flag"] is True
+
+
+def test_run_passes_options_through(runner, start_spy):
+    """``run`` passes --role, --runtime, and other options to start."""
+    runner.invoke(cli, [
+        "run", "--role", "my-ceo", "--runtime", "claude",
+        "--progress", "json", "Build a feature",
+    ])
+
+    assert len(start_spy) == 1
+    assert start_spy[0]["task"] == "Build a feature"
+    assert start_spy[0]["role"] == "my-ceo"
+    assert start_spy[0]["runtime"] == "claude"
+    assert start_spy[0]["progress_mode"] == "json"
+    assert start_spy[0]["yes_flag"] is True
+
+
+# ---------------------------------------------------------------------------
+# Quickstart text
+# ---------------------------------------------------------------------------
+
+
+def test_quickstart_mentions_run(runner):
+    """The quickstart guide mentions ``strawpot run``."""
+    result = runner.invoke(cli, ["quickstart"])
+    assert result.exit_code == 0
+    assert "strawpot run" in result.output


### PR DESCRIPTION
## Summary

- Add `strawpot run` command that takes a positional TASK argument and delegates to `start` with `--task` and `--yes` implied via `ctx.invoke`
- Extract 20 shared session options into `_shared_session_options` decorator so `start` and `run` stay in sync
- Add `run` to the "Getting Started" command group in `--help`
- Update quickstart text to mention `strawpot run` as the shorthand

Closes #509

## Test plan

- [x] 11 new tests in `cli/tests/test_cli_run.py` (registration, help output, option parity, delegation spy, quickstart)
- [x] All 826 existing + new tests pass
- [x] `strawpot run --help` shows TASK argument and all relevant options
- [x] `strawpot run` without args shows usage error
- [x] Option parity test guards against future drift between `run` and `start` params

🤖 Generated with [Claude Code](https://claude.com/claude-code)