### PR TITLE
Add standalone memory access helper

### DIFF
--- a/cli/src/strawpot/memory/standalone.py
+++ b/cli/src/strawpot/memory/standalone.py
@@ -1,0 +1,71 @@
+"""Standalone memory access — use a MemoryProvider without a Session."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import click
+
+from strawpot.config import load_config
+from strawpot.memory.registry import load_provider, resolve_memory
+from strawpot_memory.memory_protocol import MemoryProvider
+
+log = logging.getLogger(__name__)
+
+# Synthetic context for CLI-originated memory calls.
+CLI_SESSION_ID = "cli-standalone"
+CLI_AGENT_ID = "cli-user"
+CLI_ROLE = "user"
+
+_PROJECT_MARKERS = ("strawpot.toml", ".strawpot")
+
+
+def detect_project_dir(start: str | None = None) -> str:
+    """Walk up from *start* (or CWD) to find the project root.
+
+    A project root is a directory containing ``strawpot.toml`` or a
+    ``.strawpot/`` directory.
+
+    Returns:
+        Absolute path to the project root.
+
+    Raises:
+        click.ClickException: If no project root is found.
+    """
+    current = Path(start or ".").resolve()
+    for directory in (current, *current.parents):
+        for marker in _PROJECT_MARKERS:
+            if (directory / marker).exists():
+                return str(directory)
+    raise click.ClickException(
+        f"No StrawPot project found (searched from {current} to /).\n"
+        "Run 'strawpot init' to create one, or pass --project-dir explicitly."
+    )
+
+
+def get_standalone_provider(
+    project_dir: str | None = None,
+    memory_name: str | None = None,
+) -> MemoryProvider:
+    """Instantiate a memory provider for standalone CLI use.
+
+    Args:
+        project_dir: Project root. Auto-detected from CWD if None.
+        memory_name: Provider name. Read from strawpot.toml if None.
+
+    Returns:
+        Ready-to-use MemoryProvider instance.
+
+    Raises:
+        FileNotFoundError: If no memory provider found.
+        click.ClickException: If project detection fails.
+    """
+    proj = project_dir or detect_project_dir()
+    config = load_config(Path(proj))
+
+    name = memory_name or config.memory or "dial"
+    user_config = dict(config.memory_config) if config.memory_config else {}
+
+    spec = resolve_memory(name, proj, user_config)
+    return load_provider(spec)

--- a/cli/tests/test_memory_standalone.py
+++ b/cli/tests/test_memory_standalone.py
@@ -1,0 +1,177 @@
+"""Tests for strawpot.memory.standalone."""
+
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from strawpot.memory.standalone import (
+    CLI_AGENT_ID,
+    CLI_ROLE,
+    CLI_SESSION_ID,
+    detect_project_dir,
+    get_standalone_provider,
+)
+
+
+# -- CLI constants ------------------------------------------------------------
+
+
+class TestCLIConstants:
+    def test_cli_session_id_defined(self):
+        assert CLI_SESSION_ID == "cli-standalone"
+
+    def test_cli_agent_id_defined(self):
+        assert CLI_AGENT_ID == "cli-user"
+
+    def test_cli_role_defined(self):
+        assert CLI_ROLE == "user"
+
+
+# -- detect_project_dir -------------------------------------------------------
+
+
+class TestDetectProjectDir:
+    def test_finds_strawpot_toml(self, tmp_path):
+        (tmp_path / "strawpot.toml").touch()
+        subdir = tmp_path / "a" / "b"
+        subdir.mkdir(parents=True)
+        result = detect_project_dir(str(subdir))
+        assert result == str(tmp_path)
+
+    def test_finds_dot_strawpot_dir(self, tmp_path):
+        (tmp_path / ".strawpot").mkdir()
+        subdir = tmp_path / "nested"
+        subdir.mkdir()
+        result = detect_project_dir(str(subdir))
+        assert result == str(tmp_path)
+
+    def test_prefers_closest_marker(self, tmp_path):
+        """Closest project root wins (child over parent)."""
+        (tmp_path / "strawpot.toml").touch()
+        child = tmp_path / "sub"
+        child.mkdir()
+        (child / "strawpot.toml").touch()
+        result = detect_project_dir(str(child))
+        assert result == str(child)
+
+    def test_raises_when_not_found(self, tmp_path):
+        # tmp_path is a clean dir with no markers
+        with pytest.raises(click.ClickException, match="No StrawPot project found"):
+            detect_project_dir(str(tmp_path))
+
+    def test_defaults_to_cwd(self, tmp_path, monkeypatch):
+        (tmp_path / ".strawpot").mkdir()
+        monkeypatch.chdir(tmp_path)
+        result = detect_project_dir()
+        assert result == str(tmp_path)
+
+
+# -- get_standalone_provider --------------------------------------------------
+
+
+class TestGetStandaloneProvider:
+    @patch("strawpot.memory.standalone.load_provider")
+    @patch("strawpot.memory.standalone.resolve_memory")
+    @patch("strawpot.memory.standalone.load_config")
+    def test_returns_provider(self, mock_config, mock_resolve, mock_load, tmp_path):
+        (tmp_path / "strawpot.toml").touch()
+        mock_cfg = MagicMock()
+        mock_cfg.memory = "dial"
+        mock_cfg.memory_config = {}
+        mock_config.return_value = mock_cfg
+
+        mock_spec = MagicMock()
+        mock_resolve.return_value = mock_spec
+
+        mock_provider = MagicMock()
+        mock_load.return_value = mock_provider
+
+        result = get_standalone_provider(project_dir=str(tmp_path))
+        assert result is mock_provider
+        mock_resolve.assert_called_once_with("dial", str(tmp_path), {})
+        mock_load.assert_called_once_with(mock_spec)
+
+    @patch("strawpot.memory.standalone.load_provider")
+    @patch("strawpot.memory.standalone.resolve_memory")
+    @patch("strawpot.memory.standalone.load_config")
+    def test_uses_custom_memory_name(self, mock_config, mock_resolve, mock_load, tmp_path):
+        (tmp_path / "strawpot.toml").touch()
+        mock_cfg = MagicMock()
+        mock_cfg.memory = "dial"
+        mock_cfg.memory_config = {}
+        mock_config.return_value = mock_cfg
+
+        mock_resolve.return_value = MagicMock()
+        mock_load.return_value = MagicMock()
+
+        get_standalone_provider(project_dir=str(tmp_path), memory_name="custom")
+        mock_resolve.assert_called_once_with("custom", str(tmp_path), {})
+
+    @patch("strawpot.memory.standalone.load_provider")
+    @patch("strawpot.memory.standalone.resolve_memory")
+    @patch("strawpot.memory.standalone.load_config")
+    def test_reads_memory_config_from_toml(self, mock_config, mock_resolve, mock_load, tmp_path):
+        (tmp_path / "strawpot.toml").touch()
+        mock_cfg = MagicMock()
+        mock_cfg.memory = "dial"
+        mock_cfg.memory_config = {"storage_dir": "/custom/path"}
+        mock_config.return_value = mock_cfg
+
+        mock_resolve.return_value = MagicMock()
+        mock_load.return_value = MagicMock()
+
+        get_standalone_provider(project_dir=str(tmp_path))
+        mock_resolve.assert_called_once_with(
+            "dial", str(tmp_path), {"storage_dir": "/custom/path"}
+        )
+
+    @patch("strawpot.memory.standalone.load_provider")
+    @patch("strawpot.memory.standalone.resolve_memory")
+    @patch("strawpot.memory.standalone.load_config")
+    def test_defaults_to_dial_when_no_config(self, mock_config, mock_resolve, mock_load, tmp_path):
+        (tmp_path / "strawpot.toml").touch()
+        mock_cfg = MagicMock()
+        mock_cfg.memory = ""
+        mock_cfg.memory_config = {}
+        mock_config.return_value = mock_cfg
+
+        mock_resolve.return_value = MagicMock()
+        mock_load.return_value = MagicMock()
+
+        get_standalone_provider(project_dir=str(tmp_path))
+        mock_resolve.assert_called_once_with("dial", str(tmp_path), {})
+
+    @patch("strawpot.memory.standalone.detect_project_dir")
+    @patch("strawpot.memory.standalone.load_provider")
+    @patch("strawpot.memory.standalone.resolve_memory")
+    @patch("strawpot.memory.standalone.load_config")
+    def test_auto_detects_project_dir(self, mock_config, mock_resolve, mock_load, mock_detect, tmp_path):
+        mock_detect.return_value = str(tmp_path)
+        mock_cfg = MagicMock()
+        mock_cfg.memory = "dial"
+        mock_cfg.memory_config = {}
+        mock_config.return_value = mock_cfg
+
+        mock_resolve.return_value = MagicMock()
+        mock_load.return_value = MagicMock()
+
+        get_standalone_provider()  # no project_dir
+        mock_detect.assert_called_once()
+
+
+# -- No forbidden imports -----------------------------------------------------
+
+
+class TestModuleImports:
+    def test_no_session_import(self):
+        """standalone.py must not import Session or denden."""
+        import inspect
+        import strawpot.memory.standalone as mod
+
+        source = inspect.getsource(mod)
+        assert "from strawpot.session" not in source
+        assert "import strawpot.session" not in source
+        assert "denden" not in source


### PR DESCRIPTION
## Summary

- Add `cli/src/strawpot/memory/standalone.py` with `detect_project_dir()` and `get_standalone_provider()`
- Project root detection walks up from CWD looking for `strawpot.toml` or `.strawpot/`
- Standalone provider instantiation via existing `resolve_memory()` + `load_provider()` — no Session/gRPC needed
- CLI constants: `CLI_SESSION_ID`, `CLI_AGENT_ID`, `CLI_ROLE` for standalone memory calls
- 14 unit tests with mocked filesystem

Closes #515

## Context

Sub-issue 3 of 11 for the memory-first wedge implementation (#514). This enables the upcoming `strawpot remember`, `recall`, `forget`, and `memory list` CLI commands (sub-issues 4 and 5).

## Test plan

- [x] `detect_project_dir()` finds project root via `strawpot.toml` and `.strawpot/`
- [x] Raises helpful `ClickException` when no project found
- [x] `get_standalone_provider()` returns working provider with defaults
- [x] Custom memory name and config from TOML respected
- [x] No import of Session or denden anywhere in module
- [x] All 14 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)