### PR TITLE
Add breadcrumb hints and MCP status check

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -1650,13 +1650,12 @@ def remember(fact, scope, keywords):
         click.echo(click.style("✅ Remembered: ", fg="green") + f'"{fact}"')
         click.echo(f"   ID: {result.entry_id}")
         click.echo(f"   Scope: {scope}")
-    click.echo()
-    click.echo(
-        click.style("💡 Tip: ", fg="cyan")
-        + "Run "
-        + click.style("strawpot mcp setup", bold=True)
-        + " to make Claude Code see your memories automatically."
-    )
+
+    from strawpot.mcp.status import check_mcp_status
+    from strawpot.memory.breadcrumbs import remember_breadcrumb
+
+    mcp_configured, _ = check_mcp_status()
+    remember_breadcrumb(mcp_configured)
 
 
 @cli.command()
@@ -1721,6 +1720,10 @@ def recall(query, scope, max_results, as_json):
         if i < len(result.entries):
             click.echo()
 
+    from strawpot.memory.breadcrumbs import recall_breadcrumb
+
+    recall_breadcrumb()
+
 
 @cli.command()
 @click.argument("entry_id")
@@ -1732,6 +1735,10 @@ def forget(entry_id):
     result = provider.forget(entry_id=entry_id)
     if result.status == "deleted":
         click.echo(f"🗑️  Deleted memory {entry_id}")
+
+        from strawpot.memory.breadcrumbs import forget_breadcrumb
+
+        forget_breadcrumb()
     else:
         click.echo(click.style(f"❌ Memory {entry_id} not found", fg="red"), err=True)
         raise SystemExit(1)
@@ -1807,6 +1814,10 @@ def memory_list(scope, show_all, as_json):
         if not show_all:
             msg += " Use --all to see all."
         click.echo(msg)
+
+    from strawpot.memory.breadcrumbs import list_breadcrumb
+
+    list_breadcrumb()
 
 
 def _strawhub(*args: str) -> None:

--- a/cli/src/strawpot/mcp/status.py
+++ b/cli/src/strawpot/mcp/status.py
@@ -1,0 +1,41 @@
+"""MCP configuration status detection."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from strawpot.mcp.setup import _SERVER_NAME, _global_config_candidates, _project_config_path
+
+log = logging.getLogger(__name__)
+
+
+def check_mcp_status() -> tuple[bool, str]:
+    """Check if StrawPot MCP memory server is configured for Claude Code.
+
+    Returns:
+        (is_configured, config_path_str)
+    """
+    # Check project-level first
+    project_path = _project_config_path()
+    if _has_server_entry(project_path):
+        return True, str(project_path)
+
+    # Check global config candidates
+    for candidate in _global_config_candidates():
+        if _has_server_entry(candidate):
+            return True, str(candidate)
+
+    return False, ""
+
+
+def _has_server_entry(path: Path) -> bool:
+    """Check if a config file has the strawpot-memory MCP entry."""
+    if not path.is_file():
+        return False
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return _SERVER_NAME in data.get("mcpServers", {})
+    except (json.JSONDecodeError, OSError):
+        return False

--- a/cli/src/strawpot/memory/breadcrumbs.py
+++ b/cli/src/strawpot/memory/breadcrumbs.py
@@ -1,0 +1,65 @@
+"""Breadcrumb hints for memory CLI commands.
+
+Every CLI command prints a contextual hint to guide users toward
+MCP setup, scheduling, and memory management. Hints use dim styling
+so they're visually secondary to the primary output.
+"""
+
+from __future__ import annotations
+
+import click
+
+
+def remember_breadcrumb(mcp_configured: bool) -> None:
+    """Print breadcrumb after a remember command."""
+    click.echo()
+    if not mcp_configured:
+        click.echo(
+            click.style(
+                "⚠️  MCP not configured. Run "
+                + click.style("strawpot mcp setup", bold=True)
+                + " so Claude Code sees this automatically.",
+                dim=True,
+            )
+        )
+    else:
+        click.echo(
+            click.style("✅ Claude Code will see this next session.", dim=True)
+        )
+
+
+def recall_breadcrumb() -> None:
+    """Print breadcrumb after a recall command."""
+    click.echo()
+    click.echo(
+        click.style(
+            "💡 Tip: Try "
+            + click.style("strawpot memory list", bold=True)
+            + " to see all stored memories.",
+            dim=True,
+        )
+    )
+
+
+def forget_breadcrumb() -> None:
+    """Print breadcrumb after a forget command."""
+    click.echo()
+    click.echo(
+        click.style(
+            "💡 Claude Code will no longer see this memory in future sessions.",
+            dim=True,
+        )
+    )
+
+
+def list_breadcrumb() -> None:
+    """Print breadcrumb after a memory list command."""
+    click.echo()
+    click.echo(
+        click.style(
+            "💡 Tip: Use "
+            + click.style("strawpot forget <id>", bold=True)
+            + " to remove outdated memories.",
+            dim=True,
+        )
+    )

--- a/cli/tests/test_breadcrumbs.py
+++ b/cli/tests/test_breadcrumbs.py
@@ -1,0 +1,152 @@
+"""Tests for breadcrumbs and MCP status check."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+from strawpot_memory.memory_protocol import (
+    ForgetResult,
+    ListEntry,
+    ListResult,
+    RecallEntry,
+    RecallResult,
+    RememberResult,
+)
+
+from strawpot.mcp.setup import _SERVER_NAME
+from strawpot.mcp.status import check_mcp_status
+
+
+# -- MCP status ---------------------------------------------------------------
+
+
+class TestCheckMcpStatus:
+    def test_not_configured(self, tmp_path):
+        with patch("strawpot.mcp.status._global_config_candidates", return_value=[tmp_path / "config.json"]):
+            with patch("strawpot.mcp.status._project_config_path", return_value=tmp_path / ".claude" / "mcp.json"):
+                configured, path = check_mcp_status()
+                assert configured is False
+                assert path == ""
+
+    def test_configured_globally(self, tmp_path):
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "mcpServers": {_SERVER_NAME: {"command": "strawpot"}}
+        }))
+        with patch("strawpot.mcp.status._global_config_candidates", return_value=[config_path]):
+            with patch("strawpot.mcp.status._project_config_path", return_value=tmp_path / ".claude" / "mcp.json"):
+                configured, path = check_mcp_status()
+                assert configured is True
+                assert str(config_path) == path
+
+    def test_configured_project_level(self, tmp_path):
+        project_config = tmp_path / ".claude" / "mcp.json"
+        project_config.parent.mkdir(parents=True)
+        project_config.write_text(json.dumps({
+            "mcpServers": {_SERVER_NAME: {"command": "strawpot"}}
+        }))
+        with patch("strawpot.mcp.status._project_config_path", return_value=project_config):
+            configured, path = check_mcp_status()
+            assert configured is True
+
+    def test_corrupt_config_returns_false(self, tmp_path):
+        config_path = tmp_path / "config.json"
+        config_path.write_text("not json")
+        with patch("strawpot.mcp.status._global_config_candidates", return_value=[config_path]):
+            with patch("strawpot.mcp.status._project_config_path", return_value=tmp_path / "no"):
+                configured, _ = check_mcp_status()
+                assert configured is False
+
+
+# -- Breadcrumb output in CLI commands ----------------------------------------
+
+
+def _invoke(args, *, provider=None):
+    """Invoke CLI with a mocked standalone provider."""
+    from strawpot.cli import cli
+
+    if provider is None:
+        provider = MagicMock()
+
+    with patch(
+        "strawpot.memory.standalone.get_standalone_provider",
+        return_value=provider,
+    ):
+        runner = CliRunner()
+        return runner.invoke(cli, args)
+
+
+class TestRememberBreadcrumb:
+    @patch("strawpot.mcp.status.check_mcp_status", return_value=(False, ""))
+    def test_shows_mcp_warning_when_not_configured(self, mock_status):
+        provider = MagicMock()
+        provider.remember.return_value = RememberResult(
+            status="accepted", entry_id="k_test1234"
+        )
+        result = _invoke(["remember", "Test fact"], provider=provider)
+        assert "MCP not configured" in result.output
+        assert "strawpot mcp setup" in result.output
+
+    @patch("strawpot.mcp.status.check_mcp_status", return_value=(True, "/some/path"))
+    def test_shows_claude_confirmation_when_configured(self, mock_status):
+        provider = MagicMock()
+        provider.remember.return_value = RememberResult(
+            status="accepted", entry_id="k_test1234"
+        )
+        result = _invoke(["remember", "Test fact"], provider=provider)
+        assert "Claude Code will see this" in result.output
+
+
+class TestRecallBreadcrumb:
+    def test_shows_memory_list_hint(self):
+        provider = MagicMock()
+        provider.recall.return_value = RecallResult(
+            entries=[
+                RecallEntry(
+                    entry_id="k_r1", content="Test", keywords=[],
+                    scope="project", score=1.0,
+                ),
+            ]
+        )
+        result = _invoke(["recall", "test"], provider=provider)
+        assert "strawpot memory list" in result.output
+
+    def test_json_output_no_breadcrumbs(self):
+        provider = MagicMock()
+        provider.recall.return_value = RecallResult(entries=[])
+        result = _invoke(["recall", "--json", "test"], provider=provider)
+        assert "strawpot memory list" not in result.output
+
+
+class TestForgetBreadcrumb:
+    def test_shows_breadcrumb_on_success(self):
+        provider = MagicMock()
+        provider.forget.return_value = ForgetResult(
+            status="deleted", entry_id="k_del12345"
+        )
+        result = _invoke(["forget", "k_del12345"], provider=provider)
+        assert "no longer see this" in result.output
+
+
+class TestListBreadcrumb:
+    def test_shows_forget_hint(self):
+        provider = MagicMock()
+        provider.list_entries.return_value = ListResult(
+            entries=[
+                ListEntry(
+                    entry_id="k_l1", content="Fact", keywords=[],
+                    scope="project", ts="2026-03-26T12:00:00Z",
+                ),
+            ],
+            total_count=1,
+        )
+        result = _invoke(["memory", "list"], provider=provider)
+        assert "strawpot forget" in result.output
+
+    def test_json_output_no_breadcrumbs(self):
+        provider = MagicMock()
+        provider.list_entries.return_value = ListResult(entries=[], total_count=0)
+        result = _invoke(["memory", "list", "--json"], provider=provider)
+        assert "strawpot forget" not in result.output


### PR DESCRIPTION
## Summary

- Add `cli/src/strawpot/mcp/status.py` — detects if MCP is configured for Claude Code
- Add `cli/src/strawpot/memory/breadcrumbs.py` — contextual hints for all memory commands
- Update remember/recall/forget/memory list to show breadcrumbs (dim styling, skipped on --json)

Closes #520

## Context

Sub-issue 8/11 for #514. Implements designed upgrade-path hints from the design doc.

## Test plan

- [x] 11 tests pass (MCP status: 4, breadcrumbs: 7 across all commands)
- [x] JSON output modes verified to not include breadcrumbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)