### PR TITLE
Package 3 pre-built scheduled workflows

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -1618,14 +1618,45 @@ def schedule():
 
 
 @schedule.command(name="create")
-@click.argument("task")
+@click.argument("task", required=False, default="")
 @click.option("--name", default="", help="Schedule name (defaults to task text).")
-@click.option("--cron", required=True, help="Cron expression (e.g. '0 8 * * *').")
+@click.option("--cron", default="", help="Cron expression (e.g. '0 8 * * *').")
 @click.option("--role", default="", help="Role to execute as.")
 @click.option("--description", default="", help="Optional description.")
-def schedule_create(task, name, cron, role, description):
-    """Create a new scheduled workflow."""
+@click.option("--template", "-t", default="", help="Use a pre-built workflow template.")
+def schedule_create(task, name, cron, role, description, template):
+    """Create a new scheduled workflow (or install from --template)."""
     from strawpot.scheduler.store import ScheduleStore
+
+    if template:
+        from strawpot.scheduler.templates import (
+            load_template,
+            validate_prerequisites,
+        )
+
+        tpl = load_template(template)
+        if tpl is None:
+            raise click.ClickException(
+                f"Template '{template}' not found. "
+                "Run 'strawpot schedule templates' to see available templates."
+            )
+        issues = validate_prerequisites(tpl)
+        if issues:
+            click.echo(click.style("⚠️  Prerequisites:", fg="yellow"))
+            for issue in issues:
+                click.echo(f"   - {issue}")
+            click.echo()
+
+        task = task or tpl.task
+        cron = cron or tpl.default_cron
+        role = role or tpl.role
+        name = name or tpl.name
+        description = description or tpl.description
+
+    if not task:
+        raise click.ClickException("Task is required. Provide a task argument or use --template.")
+    if not cron:
+        raise click.ClickException("--cron is required. Provide a cron expression or use --template.")
 
     store = ScheduleStore()
     try:
@@ -1641,15 +1672,46 @@ def schedule_create(task, name, cron, role, description):
 
     click.echo(click.style("✅ Schedule created!", fg="green"))
     click.echo(f"   ID: {sched.schedule_id}")
-    click.echo(f"   Task: {sched.task}")
+    click.echo(f"   Task: {sched.task[:80]}")
     click.echo(f"   Cron: {sched.cron}")
     click.echo(f"   Next run: {sched.next_run()}")
+    if role:
+        click.echo(f"   Role: {role}")
     click.echo()
     click.echo(
         click.style("💡 Tip: ", fg="cyan")
         + "Run "
         + click.style("strawpot schedule list", bold=True)
         + " to see all schedules."
+    )
+
+
+@schedule.command(name="templates")
+def schedule_templates():
+    """List available pre-built workflow templates."""
+    from strawpot.scheduler.templates import list_templates
+
+    templates = list_templates()
+    if not templates:
+        click.echo("No templates available.")
+        return
+
+    click.echo(click.style("📋 Available workflow templates:", fg="cyan"))
+    click.echo()
+    for tpl in templates:
+        click.echo(
+            "  "
+            + click.style(tpl.slug, bold=True)
+            + click.style(f" — {tpl.description}", dim=True)
+        )
+        click.echo(f"     Cron: {tpl.default_cron}")
+        if tpl.role:
+            click.echo(f"     Role: {tpl.role}")
+        click.echo()
+    click.echo(
+        "Use: "
+        + click.style("strawpot schedule create --template <name>", bold=True)
+        + " to install."
     )
 
 

--- a/cli/src/strawpot/scheduler/templates/__init__.py
+++ b/cli/src/strawpot/scheduler/templates/__init__.py
@@ -1,0 +1,67 @@
+"""Workflow templates — pre-built scheduled workflows."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+_TEMPLATE_DIR = Path(__file__).parent
+
+
+@dataclass
+class WorkflowTemplate:
+    """A pre-built workflow template definition."""
+
+    slug: str = ""
+    name: str = ""
+    description: str = ""
+    default_cron: str = ""
+    role: str = ""
+    task: str = ""
+    requires_tools: list[str] = field(default_factory=list)
+    requires_env: list[str] = field(default_factory=list)
+
+
+def list_templates() -> list[WorkflowTemplate]:
+    """List all available workflow templates."""
+    templates = []
+    for path in sorted(_TEMPLATE_DIR.glob("*.yaml")):
+        tpl = load_template(path.stem)
+        if tpl:
+            templates.append(tpl)
+    return templates
+
+
+def load_template(slug: str) -> WorkflowTemplate | None:
+    """Load a workflow template by slug name."""
+    path = _TEMPLATE_DIR / f"{slug}.yaml"
+    if not path.is_file():
+        return None
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    requires = data.get("requires", {})
+    return WorkflowTemplate(
+        slug=slug,
+        name=data.get("name", slug),
+        description=data.get("description", ""),
+        default_cron=data.get("default_cron", ""),
+        role=data.get("role", ""),
+        task=data.get("task", ""),
+        requires_tools=requires.get("tools", []) if isinstance(requires, dict) else [],
+        requires_env=requires.get("env", []) if isinstance(requires, dict) else [],
+    )
+
+
+def validate_prerequisites(template: WorkflowTemplate) -> list[str]:
+    """Check if template prerequisites are met. Returns list of issues."""
+    issues = []
+    for tool in template.requires_tools:
+        if not shutil.which(tool):
+            issues.append(f"Required tool '{tool}' not found in PATH")
+    for env_var in template.requires_env:
+        if not os.environ.get(env_var):
+            issues.append(f"Required environment variable '{env_var}' not set")
+    return issues

--- a/cli/src/strawpot/scheduler/templates/issue-triage.yaml
+++ b/cli/src/strawpot/scheduler/templates/issue-triage.yaml
@@ -1,0 +1,16 @@
+name: Weekly Issue Triage
+description: Scans untriaged issues and applies priority/type labels
+default_cron: "0 9 * * 1"
+role: github-triager
+task: |
+  Triage all open issues without labels in this repository.
+  For each issue:
+  1. Read the issue title and body
+  2. Apply type label (bug, feature, enhancement, question)
+  3. Apply priority label (critical, high, medium, low)
+  4. Post a triage summary comment
+requires:
+  tools:
+    - gh
+  env:
+    - GITHUB_TOKEN

--- a/cli/src/strawpot/scheduler/templates/pr-review.yaml
+++ b/cli/src/strawpot/scheduler/templates/pr-review.yaml
@@ -1,0 +1,13 @@
+name: Daily PR Review
+description: Reviews all open pull requests and posts feedback
+default_cron: "0 8 * * *"
+role: pr-reviewer
+task: |
+  Review all open pull requests in this repository.
+  For each PR, post a review comment with findings.
+  Focus on: bugs, code quality, test coverage, and style.
+requires:
+  tools:
+    - gh
+  env:
+    - GITHUB_TOKEN

--- a/cli/src/strawpot/scheduler/templates/test-coverage.yaml
+++ b/cli/src/strawpot/scheduler/templates/test-coverage.yaml
@@ -1,0 +1,17 @@
+name: Nightly Test Coverage
+description: Runs test suite with coverage and reports uncovered areas
+default_cron: "0 2 * * *"
+role: ""
+task: |
+  Run the project's test suite with coverage reporting.
+  Detect the test framework (pytest preferred).
+  Report:
+  1. Overall coverage percentage
+  2. Files with lowest coverage
+  3. Uncovered functions/methods
+  If coverage dropped since last run, create a GitHub issue.
+  Note: Currently supports pytest projects only.
+requires:
+  tools:
+    - pytest
+  env: []

--- a/cli/tests/test_workflow_templates.py
+++ b/cli/tests/test_workflow_templates.py
@@ -1,0 +1,152 @@
+"""Tests for workflow templates and template-based scheduling."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from strawpot.cli import cli
+from strawpot.scheduler.templates import (
+    WorkflowTemplate,
+    list_templates,
+    load_template,
+    validate_prerequisites,
+)
+
+
+# -- Template loading ---------------------------------------------------------
+
+
+class TestTemplateLoading:
+    def test_list_templates_returns_3(self):
+        templates = list_templates()
+        assert len(templates) == 3
+        slugs = {t.slug for t in templates}
+        assert slugs == {"pr-review", "issue-triage", "test-coverage"}
+
+    def test_load_pr_review(self):
+        tpl = load_template("pr-review")
+        assert tpl is not None
+        assert tpl.name == "Daily PR Review"
+        assert tpl.default_cron == "0 8 * * *"
+        assert tpl.role == "pr-reviewer"
+        assert "pull request" in tpl.task.lower()
+        assert "gh" in tpl.requires_tools
+
+    def test_load_issue_triage(self):
+        tpl = load_template("issue-triage")
+        assert tpl is not None
+        assert tpl.role == "github-triager"
+        assert "0 9 * * 1" in tpl.default_cron
+
+    def test_load_test_coverage(self):
+        tpl = load_template("test-coverage")
+        assert tpl is not None
+        assert "pytest" in tpl.requires_tools
+        assert tpl.role == ""
+
+    def test_load_nonexistent(self):
+        assert load_template("nonexistent") is None
+
+
+# -- Prerequisite validation --------------------------------------------------
+
+
+class TestValidatePrerequisites:
+    @patch("strawpot.scheduler.templates.shutil.which", return_value="/usr/bin/gh")
+    @patch.dict("os.environ", {"GITHUB_TOKEN": "test-token"})
+    def test_all_met(self, mock_which):
+        tpl = load_template("pr-review")
+        issues = validate_prerequisites(tpl)
+        assert issues == []
+
+    @patch("strawpot.scheduler.templates.shutil.which", return_value=None)
+    def test_missing_tool(self, mock_which):
+        tpl = load_template("pr-review")
+        issues = validate_prerequisites(tpl)
+        assert any("gh" in i for i in issues)
+
+    @patch("strawpot.scheduler.templates.shutil.which", return_value="/usr/bin/gh")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_missing_env(self, mock_which):
+        tpl = load_template("pr-review")
+        issues = validate_prerequisites(tpl)
+        assert any("GITHUB_TOKEN" in i for i in issues)
+
+
+# -- CLI template commands ----------------------------------------------------
+
+
+class TestTemplateCLI:
+    def test_templates_command(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["schedule", "templates"])
+        assert result.exit_code == 0
+        assert "pr-review" in result.output
+        assert "issue-triage" in result.output
+        assert "test-coverage" in result.output
+
+    def test_create_from_template(self, tmp_path):
+        with patch(
+            "strawpot.memory.standalone.detect_project_dir",
+            return_value=str(tmp_path),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["schedule", "create", "--template", "pr-review"]
+            )
+            assert result.exit_code == 0
+            assert "Schedule created" in result.output
+            assert "pr-reviewer" in result.output
+
+    def test_create_from_template_with_custom_cron(self, tmp_path):
+        with patch(
+            "strawpot.memory.standalone.detect_project_dir",
+            return_value=str(tmp_path),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["schedule", "create", "--template", "pr-review", "--cron", "0 10 * * *"],
+            )
+            assert result.exit_code == 0
+            assert "0 10 * * *" in result.output
+
+    def test_create_from_nonexistent_template(self, tmp_path):
+        with patch(
+            "strawpot.memory.standalone.detect_project_dir",
+            return_value=str(tmp_path),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["schedule", "create", "--template", "nonexistent"]
+            )
+            assert result.exit_code != 0
+            assert "not found" in result.output
+
+    def test_create_without_task_or_template(self, tmp_path):
+        with patch(
+            "strawpot.memory.standalone.detect_project_dir",
+            return_value=str(tmp_path),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["schedule", "create", "--cron", "0 8 * * *"]
+            )
+            assert result.exit_code != 0
+
+    def test_integration_template_to_list(self, tmp_path):
+        """Install template → verify it appears in schedule list."""
+        with patch(
+            "strawpot.memory.standalone.detect_project_dir",
+            return_value=str(tmp_path),
+        ):
+            runner = CliRunner()
+            runner.invoke(
+                cli, ["schedule", "create", "--template", "issue-triage"]
+            )
+            result = runner.invoke(cli, ["schedule", "list", "--json"])
+            data = json.loads(result.output)
+            assert len(data) == 1
+            assert data[0]["name"] == "Weekly Issue Triage"


### PR DESCRIPTION
## Summary

- Add 3 YAML workflow templates: `pr-review`, `issue-triage`, `test-coverage`
- Template loader with prerequisite validation (tools, env vars)
- `strawpot schedule templates` command to list available workflows
- `--template` flag on `schedule create` to install from template
- Templates are repo-agnostic — work on any project

Closes #523

## Context

Sub-issue 11/11 (FINAL) for #514. Makes the "overnight AI team" demo possible.

## Test plan

- [x] 14 tests pass (5 template loading, 3 validation, 6 CLI integration)
- [x] Integration test: install template → verify in schedule list

🤖 Generated with [Claude Code](https://claude.com/claude-code)