### PR TITLE
fix: use duck-type check for memory provider loading

### DIFF
--- a/cli/src/strawpot/memory/registry.py
+++ b/cli/src/strawpot/memory/registry.py
@@ -296,7 +296,10 @@ def load_provider(spec: MemorySpec) -> MemoryProvider:
                     instance = attr()
                 except TypeError:
                     continue
-            if isinstance(instance, MemoryProvider):
+            if all(
+                hasattr(instance, a)
+                for a in ("name", "get", "dump", "remember", "recall")
+            ):
                 return instance
 
     raise ValueError(

--- a/cli/tests/test_memory_protocol.py
+++ b/cli/tests/test_memory_protocol.py
@@ -4,7 +4,9 @@ from strawpot_memory.memory_protocol import (
     ContextCard,
     ControlSignal,
     DumpReceipt,
+    ForgetResult,
     GetResult,
+    ListResult,
     MemoryKind,
     MemoryProvider,
     RecallEntry,
@@ -219,6 +221,24 @@ class _MinimalProvider:
         max_results: int = 10,
     ) -> RecallResult:
         return RecallResult()
+
+    def forget(
+        self,
+        *,
+        entry_id: str,
+        scope: str = "",
+    ) -> ForgetResult:
+        return ForgetResult()
+
+    def list_entries(
+        self,
+        *,
+        scope: str = "",
+        role: str = "",
+        limit: int = 100,
+        offset: int = 0,
+    ) -> ListResult:
+        return ListResult()
 
 
 def test_provider_protocol_satisfied():

--- a/cli/tests/test_memory_registry.py
+++ b/cli/tests/test_memory_registry.py
@@ -287,7 +287,7 @@ def test_memory_spec_pip():
 
 def test_load_provider(tmp_path):
     provider_code = dedent("""\
-        from strawpot_memory.memory_protocol import DumpReceipt, GetResult, RecallResult, RememberResult
+        from strawpot_memory.memory_protocol import DumpReceipt, ForgetResult, GetResult, ListResult, RecallResult, RememberResult
 
         class MyProvider:
             name = "test"
@@ -308,6 +308,12 @@ def test_load_provider(tmp_path):
             def recall(self, *, session_id, agent_id, role, query,
                        keywords=None, scope="", max_results=10):
                 return RecallResult()
+
+            def forget(self, *, entry_id, scope=""):
+                return ForgetResult()
+
+            def list_entries(self, *, scope="", role="", limit=100, offset=0):
+                return ListResult()
     """)
     script = tmp_path / "provider.py"
     script.write_text(provider_code)
@@ -326,7 +332,7 @@ def test_load_provider(tmp_path):
 def test_load_provider_passes_config(tmp_path):
     """load_provider passes spec.config to the provider constructor."""
     provider_code = dedent("""\
-        from strawpot_memory.memory_protocol import DumpReceipt, GetResult, RecallResult, RememberResult
+        from strawpot_memory.memory_protocol import DumpReceipt, ForgetResult, GetResult, ListResult, RecallResult, RememberResult
 
         class ConfigProvider:
             name = "test-config"
@@ -350,6 +356,12 @@ def test_load_provider_passes_config(tmp_path):
             def recall(self, *, session_id, agent_id, role, query,
                        keywords=None, scope="", max_results=10):
                 return RecallResult()
+
+            def forget(self, *, entry_id, scope=""):
+                return ForgetResult()
+
+            def list_entries(self, *, scope="", role="", limit=100, offset=0):
+                return ListResult()
     """)
     script = tmp_path / "provider.py"
     script.write_text(provider_code)
@@ -411,7 +423,7 @@ def test_load_provider_pip(tmp_path, monkeypatch):
     fake_pkg.mkdir()
     (fake_pkg / "__init__.py").write_text("")
     (fake_pkg / "provider.py").write_text(dedent("""\
-        from strawpot_memory.memory_protocol import DumpReceipt, GetResult, RecallResult, RememberResult
+        from strawpot_memory.memory_protocol import DumpReceipt, ForgetResult, GetResult, ListResult, RecallResult, RememberResult
 
         class DialMemoryProvider:
             name = "dial"
@@ -432,6 +444,12 @@ def test_load_provider_pip(tmp_path, monkeypatch):
             def recall(self, *, session_id, agent_id, role, query,
                        keywords=None, scope="", max_results=10):
                 return RecallResult()
+
+            def forget(self, *, entry_id, scope=""):
+                return ForgetResult()
+
+            def list_entries(self, *, scope="", role="", limit=100, offset=0):
+                return ListResult()
     """))
 
     # Add temp dir to sys.path so importlib can find it


### PR DESCRIPTION
## Summary
- **Replaced `isinstance(instance, MemoryProvider)` with duck-type attribute check** in `load_provider()` (`registry.py`). The `MemoryProvider` Protocol was extended with `forget()` and `list_entries()`, but existing providers only implement the original 4 methods — so `isinstance()` returned `False` for every provider, breaking all provider loading at runtime.
- **Updated test providers** in `test_memory_protocol.py` and `test_memory_registry.py` to implement the full Protocol interface (`forget()` and `list_entries()`).
- The duck-type check verifies 5 core attributes (`name`, `get`, `dump`, `remember`, `recall`), making loading backward-compatible with providers that haven't yet added the new methods.

## Test plan
- [x] All 43 tests in `test_memory_protocol.py` and `test_memory_registry.py` pass (4 were previously failing)
- [ ] CI passes on this branch
- [ ] Runtime provider loading works with installed memory providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)