### PR TITLE
Add AgentState enum and cancel types to session tracking

### DIFF
--- a/cli/src/strawpot/cancel.py
+++ b/cli/src/strawpot/cancel.py
@@ -1,0 +1,22 @@
+"""Agent cancellation types and tree traversal utilities."""
+
+from enum import StrEnum
+
+
+class AgentState(StrEnum):
+    """Lifecycle state of an agent in a session."""
+
+    RUNNING = "running"
+    CANCELLING = "cancelling"
+    CANCELLED = "cancelled"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class CancelReason(StrEnum):
+    """Why an agent was cancelled."""
+
+    USER = "user"  # Explicit user cancel (CLI/GUI)
+    PARENT = "parent"  # Parent was cancelled
+    ANCESTOR = "ancestor"  # Ancestor was cancelled (grandparent+)
+    TIMEOUT = "timeout"  # Delegation timeout

--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -1259,9 +1259,13 @@ def agents(session_id):
         role = info.get("role", "?")
         runtime = info.get("runtime", "?")
         parent = info.get("parent") or "-"
-        pid = info.get("pid")
-        alive = is_pid_alive(pid) if pid else False
-        status = "running" if alive else "exited"
+        # Prefer explicit state field; fall back to PID liveness for
+        # old session files that lack it.
+        status = info.get("state")
+        if not status:
+            pid = info.get("pid")
+            alive = is_pid_alive(pid) if pid else False
+            status = "running" if alive else "exited"
         click.echo(f"{agent_id:<20} {role:<16} {runtime:<14} {parent:<20} {status:<8}")
 
 

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -27,6 +27,7 @@ from denden.gen import denden_pb2
 
 from strawpot.agents.protocol import AgentHandle
 from strawpot.agents.wrapper import WrapperRuntime
+from strawpot.cancel import AgentState, CancelReason
 from strawpot.config import StrawPotConfig
 from strawpot.context import build_prompt
 from strawpot.delegation import (
@@ -1238,6 +1239,18 @@ class Session:
                 "delegate_start", delegate_req.role_slug,
                 detail=delegate_req.task_text[:60], depth=delegate_req.depth,
             )
+
+            # Wrap register_agent to capture the spawned agent_id so
+            # we can update its state when delegation completes.
+            delegate_agent_id: str | None = None
+
+            def _register_and_capture(
+                agent_id: str, role: str, parent_id: str | None, pid: int | None = None,
+            ) -> None:
+                nonlocal delegate_agent_id
+                delegate_agent_id = agent_id
+                self._register_agent(agent_id, role, parent_id, pid)
+
             result = handle_delegate(
                 request=delegate_req,
                 config=self.config,
@@ -1251,10 +1264,19 @@ class Session:
                 tracer=self._tracer,
                 parent_span=requester_span,
                 agent_spans=self._agent_spans,
-                register_agent=self._register_agent,
+                register_agent=_register_and_capture,
                 files_dirs=self._files_dirs,
                 group_id=self._group_id,
             )
+
+            # Update agent state based on completion result.
+            if delegate_agent_id is not None:
+                end_state = (
+                    AgentState.FAILED if result.exit_code != 0
+                    else AgentState.COMPLETED
+                )
+                self._update_agent_state(delegate_agent_id, end_state)
+
             if result.exit_code != 0:
                 self._emit(
                     "delegate_end", delegate_req.role_slug,
@@ -1687,7 +1709,28 @@ class Session:
             "parent": parent_id,
             "started_at": datetime.now(timezone.utc).isoformat(),
             "pid": pid,
+            "state": AgentState.RUNNING,
         }
+
+    def _update_agent_state(
+        self,
+        agent_id: str,
+        state: AgentState,
+        cancel_reason: CancelReason | None = None,
+    ) -> None:
+        """Update the state of a registered agent (in-memory and on-disk).
+
+        Thread-safe: acquires ``_delegation_lock`` to avoid races with
+        the DenDen handler thread that may be registering new agents.
+        """
+        with self._delegation_lock:
+            info = self._agent_info.get(agent_id)
+            if info is None:
+                return
+            info["state"] = state
+            if cancel_reason is not None:
+                info["cancel_reason"] = cancel_reason
+            self._write_session_file()
 
     def _agent_role(self, agent_id: str) -> str:
         """Return the role of a registered agent."""

--- a/cli/tests/test_cancel.py
+++ b/cli/tests/test_cancel.py
@@ -1,0 +1,211 @@
+"""Tests for strawpot.cancel — enums and state model."""
+
+import json
+import os
+import tempfile
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from strawpot.cancel import AgentState, CancelReason
+
+
+# ---------------------------------------------------------------------------
+# Enum basics
+# ---------------------------------------------------------------------------
+
+
+class TestAgentState:
+    """AgentState enum values and serialization."""
+
+    def test_values(self):
+        assert AgentState.RUNNING == "running"
+        assert AgentState.CANCELLING == "cancelling"
+        assert AgentState.CANCELLED == "cancelled"
+        assert AgentState.COMPLETED == "completed"
+        assert AgentState.FAILED == "failed"
+
+    def test_str_serialization(self):
+        """StrEnum values serialize naturally to JSON strings."""
+        data = {"state": AgentState.RUNNING}
+        encoded = json.dumps(data)
+        decoded = json.loads(encoded)
+        assert decoded["state"] == "running"
+
+    def test_membership(self):
+        assert "running" in [s.value for s in AgentState]
+        assert "cancelled" in [s.value for s in AgentState]
+
+    def test_all_states_present(self):
+        assert len(AgentState) == 5
+
+
+class TestCancelReason:
+    """CancelReason enum values and serialization."""
+
+    def test_values(self):
+        assert CancelReason.USER == "user"
+        assert CancelReason.PARENT == "parent"
+        assert CancelReason.ANCESTOR == "ancestor"
+        assert CancelReason.TIMEOUT == "timeout"
+
+    def test_str_serialization(self):
+        data = {"cancel_reason": CancelReason.PARENT}
+        encoded = json.dumps(data)
+        decoded = json.loads(encoded)
+        assert decoded["cancel_reason"] == "parent"
+
+    def test_all_reasons_present(self):
+        assert len(CancelReason) == 4
+
+
+# ---------------------------------------------------------------------------
+# State integration with session agent tracking
+# ---------------------------------------------------------------------------
+
+
+class TestAgentStateInSession:
+    """Verify state field integration with session._agent_info."""
+
+    def _make_session(self, tmp_path):
+        """Create a minimal Session for testing agent state tracking."""
+        from strawpot.agents.protocol import AgentHandle, AgentResult
+        from strawpot.config import StrawPotConfig
+        from strawpot.isolation.protocol import IsolatedEnv, NoneIsolator
+        from strawpot.session import Session
+
+        config = StrawPotConfig(memory="")
+        runtime = MagicMock()
+        runtime.name = "mock_runtime"
+        runtime.spawn.return_value = AgentHandle(
+            agent_id="orch", runtime_name="mock_runtime", pid=999
+        )
+        runtime.wait.return_value = AgentResult(summary="Done")
+        wrapper = MagicMock()
+        wrapper.name = "mock_wrapper"
+
+        session = Session(
+            config=config,
+            runtime=runtime,
+            wrapper=wrapper,
+            isolator=NoneIsolator(),
+            resolve_role=MagicMock(return_value={}),
+            resolve_role_dirs=MagicMock(return_value=None),
+            task="test task",
+        )
+        # Set up minimal internal state so _register_agent and
+        # _write_session_file work.
+        session._run_id = "test-run-id"
+        session._working_dir = str(tmp_path)
+        os.makedirs(
+            os.path.join(str(tmp_path), ".strawpot", "sessions", "test-run-id"),
+            exist_ok=True,
+        )
+        return session
+
+    def test_register_sets_running_state(self, tmp_path):
+        session = self._make_session(tmp_path)
+        session._register_agent("agent-1", "worker", parent_id=None)
+        info = session._agent_info["agent-1"]
+        assert info["state"] == AgentState.RUNNING
+        assert info["state"] == "running"
+
+    def test_update_agent_state(self, tmp_path):
+        session = self._make_session(tmp_path)
+        session._register_agent("agent-1", "worker", parent_id=None)
+
+        session._update_agent_state("agent-1", AgentState.COMPLETED)
+        assert session._agent_info["agent-1"]["state"] == AgentState.COMPLETED
+        assert "cancel_reason" not in session._agent_info["agent-1"]
+
+    def test_update_agent_state_with_cancel_reason(self, tmp_path):
+        session = self._make_session(tmp_path)
+        session._register_agent("agent-1", "worker", parent_id=None)
+
+        session._update_agent_state(
+            "agent-1", AgentState.CANCELLED, cancel_reason=CancelReason.USER
+        )
+        info = session._agent_info["agent-1"]
+        assert info["state"] == AgentState.CANCELLED
+        assert info["cancel_reason"] == CancelReason.USER
+
+    def test_update_unknown_agent_is_noop(self, tmp_path):
+        session = self._make_session(tmp_path)
+        # Should not raise
+        session._update_agent_state("nonexistent", AgentState.CANCELLED)
+
+    def test_state_transitions(self, tmp_path):
+        """Verify typical state machine transitions."""
+        session = self._make_session(tmp_path)
+        session._register_agent("agent-1", "worker", parent_id=None)
+
+        # RUNNING -> CANCELLING -> CANCELLED
+        assert session._agent_info["agent-1"]["state"] == AgentState.RUNNING
+        session._update_agent_state(
+            "agent-1", AgentState.CANCELLING, cancel_reason=CancelReason.USER
+        )
+        assert session._agent_info["agent-1"]["state"] == AgentState.CANCELLING
+        session._update_agent_state("agent-1", AgentState.CANCELLED)
+        assert session._agent_info["agent-1"]["state"] == AgentState.CANCELLED
+
+    def test_state_persisted_to_session_json(self, tmp_path):
+        session = self._make_session(tmp_path)
+        session._register_agent("agent-1", "worker", parent_id=None)
+        session._write_session_file()
+
+        session_file = os.path.join(
+            str(tmp_path), ".strawpot", "sessions", "test-run-id", "session.json"
+        )
+        with open(session_file) as f:
+            data = json.load(f)
+
+        agent_data = data["agents"]["agent-1"]
+        assert agent_data["state"] == "running"
+
+    def test_state_update_writes_to_disk(self, tmp_path):
+        session = self._make_session(tmp_path)
+        session._register_agent("agent-1", "worker", parent_id=None)
+        session._write_session_file()
+
+        session._update_agent_state("agent-1", AgentState.COMPLETED)
+
+        session_file = os.path.join(
+            str(tmp_path), ".strawpot", "sessions", "test-run-id", "session.json"
+        )
+        with open(session_file) as f:
+            data = json.load(f)
+
+        assert data["agents"]["agent-1"]["state"] == "completed"
+
+    def test_failed_state_on_nonzero_exit(self, tmp_path):
+        """Verify FAILED state is set for non-zero exit code."""
+        session = self._make_session(tmp_path)
+        session._register_agent("agent-1", "worker", parent_id=None)
+
+        # Simulate delegation completion with non-zero exit
+        session._update_agent_state("agent-1", AgentState.FAILED)
+        assert session._agent_info["agent-1"]["state"] == AgentState.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompat:
+    """CLI agents command should handle old session files without state field."""
+
+    def test_missing_state_field_falls_back_to_pid(self):
+        """Agent info without 'state' key should not break display logic."""
+        # Old-style agent info (no state field)
+        old_info = {
+            "role": "worker",
+            "runtime": "claude_code",
+            "parent": None,
+            "started_at": "2026-01-01T00:00:00Z",
+            "pid": None,
+        }
+        # The CLI uses info.get("state") — should be None for old format
+        status = old_info.get("state")
+        assert status is None  # Falls back to PID check in CLI code


### PR DESCRIPTION
## Summary

- Introduces `AgentState` and `CancelReason` StrEnum types in new `cancel.py` module — the state model that all subsequent cascading cancellation sub-issues build on
- Integrates state tracking into session agent lifecycle: agents start as `RUNNING`, transition to `COMPLETED`/`FAILED` on delegation completion
- Updates `strawpot agents` CLI to display state from session.json with backward-compatible PID fallback for old session files
- Thread-safe `_update_agent_state()` method writes state changes to both memory and disk

Closes #535

## Test plan

- [x] 16 new tests covering enum values, JSON serialization, state transitions, disk persistence, and backward compatibility
- [x] All 962 existing tests pass without modification
- [ ] Manual: run `strawpot start`, check session.json includes `state: "running"` for agents
- [ ] Manual: after delegation completes, verify state shows `completed` or `failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)