### PR TITLE
Add agent tree traversal utilities for cascading cancel

### DIFF
--- a/cli/src/strawpot/cancel.py
+++ b/cli/src/strawpot/cancel.py
@@ -1,5 +1,6 @@
 """Agent cancellation types and tree traversal utilities."""
 
+from collections import deque
 from enum import StrEnum
 
 
@@ -20,3 +21,74 @@ class CancelReason(StrEnum):
     PARENT = "parent"  # Parent was cancelled
     ANCESTOR = "ancestor"  # Ancestor was cancelled (grandparent+)
     TIMEOUT = "timeout"  # Delegation timeout
+
+
+# ------------------------------------------------------------------
+# Agent tree traversal utilities
+# ------------------------------------------------------------------
+# Pure functions that operate on the ``agent_info`` dict (same
+# structure as ``Session._agent_info``).  Keeping them as free
+# functions rather than Session methods makes them easy to test
+# without session machinery.
+
+_MAX_ITERATIONS = 100  # Defensive cap to prevent infinite loops on cycles
+
+
+def get_children(agent_id: str, agent_info: dict[str, dict]) -> list[str]:
+    """Return direct children of *agent_id*."""
+    return [
+        aid for aid, info in agent_info.items()
+        if info.get("parent") == agent_id
+    ]
+
+
+def get_descendants(agent_id: str, agent_info: dict[str, dict]) -> list[str]:
+    """Return all descendants of *agent_id* in BFS (top-down) order.
+
+    Does **not** include *agent_id* itself.
+    """
+    result: list[str] = []
+    queue: deque[str] = deque(get_children(agent_id, agent_info))
+    seen: set[str] = set()
+    iterations = 0
+    while queue and iterations < _MAX_ITERATIONS:
+        iterations += 1
+        current = queue.popleft()
+        if current in seen:
+            continue
+        seen.add(current)
+        result.append(current)
+        queue.extend(get_children(current, agent_info))
+    return result
+
+
+def get_subtree_bottom_up(agent_id: str, agent_info: dict[str, dict]) -> list[str]:
+    """Return descendants in bottom-up order (leaves first) for cascading cancel.
+
+    Does **not** include *agent_id* itself.  This is the order in which
+    agents should be cancelled to avoid orphans.
+    """
+    top_down = get_descendants(agent_id, agent_info)
+    return list(reversed(top_down))
+
+
+def is_ancestor_of(
+    candidate: str, agent_id: str, agent_info: dict[str, dict]
+) -> bool:
+    """Check if *candidate* is an ancestor of *agent_id*.
+
+    Traverses the parent chain from *agent_id* upward.  Returns
+    ``False`` if *candidate* == *agent_id*.
+    """
+    current = agent_id
+    iterations = 0
+    while iterations < _MAX_ITERATIONS:
+        iterations += 1
+        info = agent_info.get(current, {})
+        parent = info.get("parent")
+        if not parent:
+            return False
+        if parent == candidate:
+            return True
+        current = parent
+    return False

--- a/cli/tests/test_cancel.py
+++ b/cli/tests/test_cancel.py
@@ -1,4 +1,4 @@
-"""Tests for strawpot.cancel — enums and state model."""
+"""Tests for strawpot.cancel — enums, state model, and tree traversal."""
 
 import json
 import os
@@ -8,7 +8,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from strawpot.cancel import AgentState, CancelReason
+from strawpot.cancel import (
+    AgentState,
+    CancelReason,
+    get_children,
+    get_descendants,
+    get_subtree_bottom_up,
+    is_ancestor_of,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -209,3 +216,193 @@ class TestBackwardCompat:
         # The CLI uses info.get("state") — should be None for old format
         status = old_info.get("state")
         assert status is None  # Falls back to PID check in CLI code
+
+
+# ---------------------------------------------------------------------------
+# Tree traversal utilities
+# ---------------------------------------------------------------------------
+
+# Test tree shapes:
+#
+# LINEAR:      A -> B -> C -> D
+# WIDE:        A -> {B, C, D}
+# MIXED:       A -> {B -> {D, E}, C -> F}
+# SINGLE:      A (no children)
+# EMPTY:       {} (empty dict)
+
+
+def _linear_tree():
+    """A -> B -> C -> D"""
+    return {
+        "A": {"parent": None},
+        "B": {"parent": "A"},
+        "C": {"parent": "B"},
+        "D": {"parent": "C"},
+    }
+
+
+def _wide_tree():
+    """A -> {B, C, D}"""
+    return {
+        "A": {"parent": None},
+        "B": {"parent": "A"},
+        "C": {"parent": "A"},
+        "D": {"parent": "A"},
+    }
+
+
+def _mixed_tree():
+    """A -> {B -> {D, E}, C -> F}"""
+    return {
+        "A": {"parent": None},
+        "B": {"parent": "A"},
+        "C": {"parent": "A"},
+        "D": {"parent": "B"},
+        "E": {"parent": "B"},
+        "F": {"parent": "C"},
+    }
+
+
+class TestGetChildren:
+    def test_linear_chain(self):
+        tree = _linear_tree()
+        assert get_children("A", tree) == ["B"]
+        assert get_children("B", tree) == ["C"]
+        assert get_children("D", tree) == []
+
+    def test_wide_tree(self):
+        tree = _wide_tree()
+        children = get_children("A", tree)
+        assert set(children) == {"B", "C", "D"}
+
+    def test_mixed_tree(self):
+        tree = _mixed_tree()
+        assert set(get_children("B", tree)) == {"D", "E"}
+        assert get_children("C", tree) == ["F"]
+
+    def test_no_children(self):
+        tree = _linear_tree()
+        assert get_children("D", tree) == []
+
+    def test_missing_agent(self):
+        tree = _linear_tree()
+        assert get_children("NONEXISTENT", tree) == []
+
+    def test_empty_tree(self):
+        assert get_children("A", {}) == []
+
+
+class TestGetDescendants:
+    def test_linear_chain(self):
+        tree = _linear_tree()
+        desc = get_descendants("A", tree)
+        assert desc == ["B", "C", "D"]
+
+    def test_wide_tree(self):
+        tree = _wide_tree()
+        desc = get_descendants("A", tree)
+        assert set(desc) == {"B", "C", "D"}
+
+    def test_mixed_tree(self):
+        tree = _mixed_tree()
+        desc = get_descendants("A", tree)
+        assert set(desc) == {"B", "C", "D", "E", "F"}
+        # BFS order: level 1 (B, C) before level 2 (D, E, F)
+        b_idx = desc.index("B")
+        d_idx = desc.index("D")
+        assert b_idx < d_idx  # Parent before child in BFS
+
+    def test_leaf_node(self):
+        tree = _linear_tree()
+        assert get_descendants("D", tree) == []
+
+    def test_missing_agent(self):
+        tree = _linear_tree()
+        assert get_descendants("NONEXISTENT", tree) == []
+
+    def test_subtree(self):
+        tree = _mixed_tree()
+        assert set(get_descendants("B", tree)) == {"D", "E"}
+
+    def test_empty_tree(self):
+        assert get_descendants("A", {}) == []
+
+
+class TestGetSubtreeBottomUp:
+    def test_linear_chain(self):
+        tree = _linear_tree()
+        bottom_up = get_subtree_bottom_up("A", tree)
+        assert bottom_up == ["D", "C", "B"]
+
+    def test_mixed_tree_leaves_first(self):
+        tree = _mixed_tree()
+        bottom_up = get_subtree_bottom_up("A", tree)
+        # Leaves (D, E, F) must come before their parents (B, C)
+        assert set(bottom_up) == {"B", "C", "D", "E", "F"}
+        for leaf in ["D", "E"]:
+            assert bottom_up.index(leaf) < bottom_up.index("B")
+        assert bottom_up.index("F") < bottom_up.index("C")
+
+    def test_wide_tree(self):
+        tree = _wide_tree()
+        bottom_up = get_subtree_bottom_up("A", tree)
+        assert set(bottom_up) == {"B", "C", "D"}
+
+    def test_does_not_include_root(self):
+        tree = _linear_tree()
+        bottom_up = get_subtree_bottom_up("A", tree)
+        assert "A" not in bottom_up
+
+    def test_leaf_returns_empty(self):
+        tree = _linear_tree()
+        assert get_subtree_bottom_up("D", tree) == []
+
+
+class TestIsAncestorOf:
+    def test_direct_parent(self):
+        tree = _linear_tree()
+        assert is_ancestor_of("A", "B", tree) is True
+
+    def test_grandparent(self):
+        tree = _linear_tree()
+        assert is_ancestor_of("A", "D", tree) is True
+
+    def test_not_ancestor(self):
+        tree = _linear_tree()
+        assert is_ancestor_of("D", "A", tree) is False
+
+    def test_self_is_not_ancestor(self):
+        tree = _linear_tree()
+        assert is_ancestor_of("A", "A", tree) is False
+
+    def test_sibling_not_ancestor(self):
+        tree = _wide_tree()
+        assert is_ancestor_of("B", "C", tree) is False
+
+    def test_missing_agent(self):
+        tree = _linear_tree()
+        assert is_ancestor_of("NONEXISTENT", "A", tree) is False
+        assert is_ancestor_of("A", "NONEXISTENT", tree) is False
+
+    def test_mixed_tree(self):
+        tree = _mixed_tree()
+        assert is_ancestor_of("A", "F", tree) is True
+        assert is_ancestor_of("C", "F", tree) is True
+        assert is_ancestor_of("B", "F", tree) is False
+
+    def test_cycle_protection(self):
+        """Cycles in parent chain should not cause infinite loops."""
+        cyclic = {
+            "A": {"parent": "B"},
+            "B": {"parent": "A"},
+        }
+        # Should terminate (return False) rather than loop forever
+        assert is_ancestor_of("C", "A", cyclic) is False
+
+    def test_missing_parent_ref(self):
+        """Missing parent reference should be treated as root."""
+        tree = {
+            "A": {},  # No 'parent' key at all
+            "B": {"parent": "A"},
+        }
+        assert is_ancestor_of("A", "B", tree) is True


### PR DESCRIPTION
## Summary

- Adds pure tree traversal functions to `cancel.py` for walking the agent parent-child hierarchy
- `get_subtree_bottom_up()` returns leaves-first order — the exact order needed for cascading cancellation to prevent orphaned agents
- All functions are pure (take `agent_info` dict as parameter), making them testable without Session machinery
- Defensive cycle detection with iteration cap prevents infinite loops on malformed parent chains

Depends on: #546 (sub-issue 1)
Closes #536

## Test plan

- [x] 27 new tests covering 4 tree shapes: linear chain, wide tree, mixed tree, single node
- [x] Edge cases: missing agents, empty trees, cycles in parent chain, missing parent refs
- [x] All 989 existing tests pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)