### PR TITLE
Implement core cancel_agent() with cascading cancellation

### DIFF
--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -27,7 +27,12 @@ from denden.gen import denden_pb2
 
 from strawpot.agents.protocol import AgentHandle
 from strawpot.agents.wrapper import WrapperRuntime
-from strawpot.cancel import AgentState, CancelReason
+from strawpot.cancel import (
+    AgentState,
+    CancelReason,
+    get_children,
+    get_subtree_bottom_up,
+)
 from strawpot.config import StrawPotConfig
 from strawpot.context import build_prompt
 from strawpot.delegation import (
@@ -44,6 +49,7 @@ from strawpot.delegation import (
 )
 from strawpot_memory.memory_protocol import MemoryProvider
 from strawpot.memory.registry import MemorySpec, load_provider, resolve_memory
+from strawpot._process import is_pid_alive, kill_process_tree
 from strawpot.isolation.protocol import IsolatedEnv, Isolator, NoneIsolator
 from strawpot.isolation.worktree import WorktreeIsolator, _git
 from strawpot.progress import ProgressEvent
@@ -94,8 +100,6 @@ def recover_stale_sessions(
     Returns:
         List of recovered ``run_id`` strings.
     """
-    from strawpot._process import is_pid_alive
-
     strawpot_dir = os.path.join(working_dir, ".strawpot")
     sessions_dir = os.path.join(strawpot_dir, "sessions")
     running_dir = os.path.join(strawpot_dir, "running")
@@ -1731,6 +1735,92 @@ class Session:
             if cancel_reason is not None:
                 info["cancel_reason"] = cancel_reason
             self._write_session_file()
+
+    def cancel_agent(
+        self,
+        agent_id: str,
+        *,
+        reason: CancelReason = CancelReason.USER,
+        force: bool = False,
+        timeout: float = 10.0,
+    ) -> list[str]:
+        """Cancel an agent and all its descendants (cascading).
+
+        Descendants are cancelled in bottom-up order (leaves first) to
+        prevent orphaned sub-agents.  Each agent goes through a graceful
+        phase (SIGINT) followed by a force kill (SIGKILL) if it does not
+        exit within *timeout* seconds.
+
+        Args:
+            agent_id: The agent to cancel.
+            reason: Why the agent is being cancelled.
+            force: Skip graceful interrupt and kill immediately.
+            timeout: Seconds to wait for graceful shutdown before force kill.
+
+        Returns:
+            List of agent IDs that were cancelled (including *agent_id*).
+        """
+        # Build the cancel order: descendants bottom-up, then the target.
+        subtree = get_subtree_bottom_up(agent_id, self._agent_info)
+        cancel_order = subtree + [agent_id]
+
+        cancelled: list[str] = []
+        for i, aid in enumerate(cancel_order):
+            info = self._agent_info.get(aid)
+            if info is None:
+                continue
+
+            # Determine the cancel reason for this agent.
+            if aid == agent_id:
+                agent_reason = reason
+            elif info.get("parent") == agent_id:
+                agent_reason = CancelReason.PARENT
+            else:
+                agent_reason = CancelReason.ANCESTOR
+
+            # Skip agents that already finished.
+            current_state = info.get("state")
+            if current_state in (
+                AgentState.COMPLETED,
+                AgentState.FAILED,
+                AgentState.CANCELLED,
+            ):
+                cancelled.append(aid)
+                continue
+
+            # Mark as CANCELLING.
+            self._update_agent_state(aid, AgentState.CANCELLING, agent_reason)
+
+            pid = info.get("pid")
+            if pid is None or not is_pid_alive(pid):
+                # No live process — just mark as cancelled.
+                self._update_agent_state(aid, AgentState.CANCELLED, agent_reason)
+                cancelled.append(aid)
+                continue
+
+            if not force:
+                # Graceful interrupt: send SIGINT.
+                try:
+                    os.kill(pid, signal.SIGINT)
+                except (ProcessLookupError, PermissionError, OSError):
+                    pass
+
+                # Wait for graceful shutdown.
+                deadline = time.monotonic() + timeout
+                while time.monotonic() < deadline and is_pid_alive(pid):
+                    time.sleep(0.1)
+
+            # Force kill if still alive (or if force=True).
+            if is_pid_alive(pid):
+                try:
+                    kill_process_tree(pid)
+                except Exception:
+                    logger.debug("Failed to kill agent %s (pid=%s)", aid, pid)
+
+            self._update_agent_state(aid, AgentState.CANCELLED, agent_reason)
+            cancelled.append(aid)
+
+        return cancelled
 
     def _agent_role(self, agent_id: str) -> str:
         """Return the role of a registered agent."""

--- a/cli/tests/test_cancel.py
+++ b/cli/tests/test_cancel.py
@@ -2,9 +2,10 @@
 
 import json
 import os
+import signal
 import tempfile
 import threading
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -216,6 +217,189 @@ class TestBackwardCompat:
         # The CLI uses info.get("state") — should be None for old format
         status = old_info.get("state")
         assert status is None  # Falls back to PID check in CLI code
+
+
+# ---------------------------------------------------------------------------
+# cancel_agent() — cascading cancellation
+# ---------------------------------------------------------------------------
+
+
+class TestCancelAgent:
+    """Tests for Session.cancel_agent() cascading cancel."""
+
+    def _make_session(self, tmp_path):
+        """Create a minimal Session for testing cancel."""
+        from strawpot.agents.protocol import AgentHandle, AgentResult
+        from strawpot.config import StrawPotConfig
+        from strawpot.isolation.protocol import NoneIsolator
+        from strawpot.session import Session
+
+        config = StrawPotConfig(memory="")
+        runtime = MagicMock()
+        runtime.name = "mock_runtime"
+        runtime.spawn.return_value = AgentHandle(
+            agent_id="orch", runtime_name="mock_runtime", pid=999
+        )
+        runtime.wait.return_value = AgentResult(summary="Done")
+        wrapper = MagicMock()
+        wrapper.name = "mock_wrapper"
+
+        session = Session(
+            config=config,
+            runtime=runtime,
+            wrapper=wrapper,
+            isolator=NoneIsolator(),
+            resolve_role=MagicMock(return_value={}),
+            resolve_role_dirs=MagicMock(return_value=None),
+            task="test task",
+        )
+        session._run_id = "test-run-id"
+        session._working_dir = str(tmp_path)
+        os.makedirs(
+            os.path.join(str(tmp_path), ".strawpot", "sessions", "test-run-id"),
+            exist_ok=True,
+        )
+        return session
+
+    @patch("strawpot.session.is_pid_alive", return_value=False)
+    @patch("strawpot.session.kill_process_tree")
+    def test_cancel_single_agent_no_pid(self, mock_kill, mock_alive, tmp_path):
+        """Cancel an agent that has no live process."""
+        session = self._make_session(tmp_path)
+        session._register_agent("a1", "worker", parent_id=None, pid=None)
+
+        result = session.cancel_agent("a1")
+        assert result == ["a1"]
+        assert session._agent_info["a1"]["state"] == AgentState.CANCELLED
+        assert session._agent_info["a1"]["cancel_reason"] == CancelReason.USER
+        mock_kill.assert_not_called()
+
+    @patch("strawpot.session.is_pid_alive", return_value=True)
+    @patch("strawpot.session.kill_process_tree")
+    def test_cancel_single_agent_force(self, mock_kill, mock_alive, tmp_path):
+        """Force cancel skips graceful interrupt."""
+        session = self._make_session(tmp_path)
+        session._register_agent("a1", "worker", parent_id=None, pid=12345)
+
+        result = session.cancel_agent("a1", force=True)
+        assert result == ["a1"]
+        assert session._agent_info["a1"]["state"] == AgentState.CANCELLED
+        mock_kill.assert_called()
+
+    @patch("strawpot.session.is_pid_alive", return_value=False)
+    @patch("strawpot.session.kill_process_tree")
+    def test_cancel_cascades_to_children(self, mock_kill, mock_alive, tmp_path):
+        """Cancel propagates to all descendants."""
+        session = self._make_session(tmp_path)
+        session._register_agent("a1", "worker", parent_id=None)
+        session._register_agent("a2", "reviewer", parent_id="a1")
+        session._register_agent("a3", "coder", parent_id="a2")
+
+        result = session.cancel_agent("a1")
+        # Bottom-up order: a3 first, then a2, then a1
+        assert result == ["a3", "a2", "a1"]
+        assert session._agent_info["a1"]["state"] == AgentState.CANCELLED
+        assert session._agent_info["a2"]["state"] == AgentState.CANCELLED
+        assert session._agent_info["a3"]["state"] == AgentState.CANCELLED
+
+    @patch("strawpot.session.is_pid_alive", return_value=False)
+    @patch("strawpot.session.kill_process_tree")
+    def test_cancel_reason_propagation(self, mock_kill, mock_alive, tmp_path):
+        """Direct children get PARENT reason, deeper get ANCESTOR."""
+        session = self._make_session(tmp_path)
+        session._register_agent("a1", "worker", parent_id=None)
+        session._register_agent("a2", "reviewer", parent_id="a1")
+        session._register_agent("a3", "coder", parent_id="a2")
+
+        session.cancel_agent("a1", reason=CancelReason.USER)
+        assert session._agent_info["a1"]["cancel_reason"] == CancelReason.USER
+        assert session._agent_info["a2"]["cancel_reason"] == CancelReason.PARENT
+        assert session._agent_info["a3"]["cancel_reason"] == CancelReason.ANCESTOR
+
+    @patch("strawpot.session.is_pid_alive", return_value=False)
+    @patch("strawpot.session.kill_process_tree")
+    def test_already_completed_agent_still_in_result(self, mock_kill, mock_alive, tmp_path):
+        """Agents that already exited are included but not killed."""
+        session = self._make_session(tmp_path)
+        session._register_agent("a1", "worker", parent_id=None, pid=100)
+        session._update_agent_state("a1", AgentState.COMPLETED)
+
+        result = session.cancel_agent("a1")
+        assert result == ["a1"]
+        # State stays COMPLETED (already terminal)
+        mock_kill.assert_not_called()
+
+    @patch("strawpot.session.is_pid_alive")
+    @patch("strawpot.session.kill_process_tree")
+    @patch("os.kill")
+    def test_graceful_then_force(self, mock_os_kill, mock_tree_kill, mock_alive, tmp_path):
+        """Graceful interrupt sent first, then force kill after timeout."""
+        # is_pid_alive returns True consistently (agent doesn't exit gracefully)
+        mock_alive.return_value = True
+        session = self._make_session(tmp_path)
+        session._register_agent("a1", "worker", parent_id=None, pid=12345)
+
+        result = session.cancel_agent("a1", timeout=0.2)
+        assert result == ["a1"]
+        # SIGINT should have been sent
+        mock_os_kill.assert_called_with(12345, signal.SIGINT)
+        # Force kill should follow since agent didn't exit
+        mock_tree_kill.assert_called()
+        assert session._agent_info["a1"]["state"] == AgentState.CANCELLED
+
+    @patch("strawpot.session.is_pid_alive", return_value=False)
+    @patch("strawpot.session.kill_process_tree")
+    def test_cancel_wide_tree(self, mock_kill, mock_alive, tmp_path):
+        """Cancel a parent with multiple children."""
+        session = self._make_session(tmp_path)
+        session._register_agent("root", "orch", parent_id=None)
+        session._register_agent("c1", "worker", parent_id="root")
+        session._register_agent("c2", "worker", parent_id="root")
+        session._register_agent("c3", "worker", parent_id="root")
+
+        result = session.cancel_agent("root")
+        assert set(result) == {"root", "c1", "c2", "c3"}
+        # Root should be last
+        assert result[-1] == "root"
+
+    @patch("strawpot.session.is_pid_alive", return_value=False)
+    @patch("strawpot.session.kill_process_tree")
+    def test_cancel_deep_tree(self, mock_kill, mock_alive, tmp_path):
+        """Cancel a deep tree (4 levels)."""
+        session = self._make_session(tmp_path)
+        session._register_agent("L0", "orch", parent_id=None)
+        session._register_agent("L1", "planner", parent_id="L0")
+        session._register_agent("L2", "executor", parent_id="L1")
+        session._register_agent("L3", "coder", parent_id="L2")
+
+        result = session.cancel_agent("L0")
+        assert result == ["L3", "L2", "L1", "L0"]
+
+    @patch("strawpot.session.is_pid_alive", return_value=False)
+    @patch("strawpot.session.kill_process_tree")
+    def test_cancel_nonexistent_agent(self, mock_kill, mock_alive, tmp_path):
+        """Cancelling a nonexistent agent returns empty list."""
+        session = self._make_session(tmp_path)
+        result = session.cancel_agent("nonexistent")
+        assert result == []
+
+    @patch("strawpot.session.is_pid_alive", return_value=False)
+    @patch("strawpot.session.kill_process_tree")
+    def test_state_persisted_after_cancel(self, mock_kill, mock_alive, tmp_path):
+        """session.json is updated on disk after cancel."""
+        session = self._make_session(tmp_path)
+        session._register_agent("a1", "worker", parent_id=None)
+        session._write_session_file()
+
+        session.cancel_agent("a1")
+
+        session_file = os.path.join(
+            str(tmp_path), ".strawpot", "sessions", "test-run-id", "session.json"
+        )
+        with open(session_file) as f:
+            data = json.load(f)
+        assert data["agents"]["a1"]["state"] == "cancelled"
+        assert data["agents"]["a1"]["cancel_reason"] == "user"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `Session.cancel_agent()` — the core cancel engine that all cancel entrypoints (denden, CLI, GUI) will converge on
- Bottom-up cancel order: walks the agent tree leaves-first using `get_subtree_bottom_up()` to prevent orphaned agents
- Graceful-then-force: sends SIGINT, waits up to configurable timeout, then calls `kill_process_tree()` if still alive
- Cancel reason propagation: target gets USER/TIMEOUT, direct children get PARENT, deeper descendants get ANCESTOR
- Module-level imports for `is_pid_alive`/`kill_process_tree` (previously local imports), enabling clean test mocking

Depends on: #546 (sub-issue 1), #547 (sub-issue 2)
Closes #537

## Test plan

- [x] 10 new tests: single agent, cascading, force mode, graceful timeout, wide/deep trees, nonexistent agent, disk persistence
- [x] All 999 tests pass (including previous sub-issues)
- [ ] Manual: trigger cancel on a running agent and verify graceful → force escalation

🤖 Generated with [Claude Code](https://claude.com/claude-code)