### PR TITLE
Add cancel tracing events and progress rendering

### DIFF
--- a/cli/src/strawpot/progress.py
+++ b/cli/src/strawpot/progress.py
@@ -19,7 +19,9 @@ class ProgressEvent:
 
         session_start, delegate_start, delegate_end,
         delegate_denied, delegate_cached,
-        ask_user_start, ask_user_end, session_end
+        ask_user_start, ask_user_end,
+        cancel_start, cancel_complete,
+        session_end
 
     Valid ``status`` values::
 
@@ -106,6 +108,13 @@ class TerminalProgressRenderer(_BaseRenderer):
         elif kind == "ask_user_end":
             dur = _format_duration(event.duration_ms)
             line = f"{indent}{ok} User responded ({dur})"
+        elif kind == "cancel_start":
+            cancel_sym = "\u2298" if self._is_tty else "[X]"
+            line = f"{indent}{cancel_sym} Cancelling {event.role} {event.detail}..."
+        elif kind == "cancel_complete":
+            cancel_sym = "\u2298" if self._is_tty else "[X]"
+            dur = _format_duration(event.duration_ms)
+            line = f"{indent}{cancel_sym} Cancelled {event.detail} ({dur})"
         elif kind == "session_end":
             dur = _format_duration(event.duration_ms)
             detail_suffix = f" - {event.detail}" if event.detail else ""

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -1806,6 +1806,28 @@ class Session:
         subtree = get_subtree_bottom_up(agent_id, self._agent_info)
         cancel_order = subtree + [agent_id]
 
+        # Emit cancel_start trace event.
+        cancel_start_time = time.monotonic()
+        if self._tracer is not None and self._session_span_id is not None:
+            self._tracer.agent_cancel_start(
+                span_id=self._session_span_id,
+                agent_id=agent_id,
+                reason=str(reason),
+                force=force,
+                descendants=subtree,
+            )
+
+        # Emit cancel_start progress event.
+        info = self._agent_info.get(agent_id)
+        role = info.get("role", "unknown") if info else "unknown"
+        desc_count = len(subtree)
+        desc_detail = f" + {desc_count} descendants" if desc_count > 0 else ""
+        self._emit(
+            "cancel_start", role,
+            detail=f"{agent_id[:8]}{desc_detail}",
+            depth=self._agent_depth(agent_id),
+        )
+
         cancelled: list[str] = []
         for i, aid in enumerate(cancel_order):
             info = self._agent_info.get(aid)
@@ -1861,6 +1883,24 @@ class Session:
 
             self._update_agent_state(aid, AgentState.CANCELLED, agent_reason)
             cancelled.append(aid)
+
+        # Emit cancel_complete trace event.
+        cancel_duration_ms = int((time.monotonic() - cancel_start_time) * 1000)
+        if self._tracer is not None and self._session_span_id is not None:
+            self._tracer.agent_cancel_complete(
+                span_id=self._session_span_id,
+                agent_id=agent_id,
+                cancelled_agents=cancelled,
+                duration_ms=cancel_duration_ms,
+            )
+
+        # Emit cancel_complete progress event.
+        self._emit(
+            "cancel_complete", role,
+            detail=f"{len(cancelled)} agents",
+            duration_ms=cancel_duration_ms,
+            depth=self._agent_depth(agent_id),
+        )
 
         return cancelled
 

--- a/cli/src/strawpot/trace.py
+++ b/cli/src/strawpot/trace.py
@@ -448,3 +448,41 @@ class Tracer:
             role=role,
             session_id=session_id,
         )
+
+    def agent_cancel_start(
+        self,
+        *,
+        span_id: str,
+        agent_id: str,
+        reason: str,
+        force: bool,
+        descendants: list[str],
+    ) -> None:
+        """Emit ``agent_cancel_start`` when a cancel operation begins."""
+        self.emit(
+            "agent_cancel_start",
+            span_id,
+            agent_id=agent_id,
+            reason=reason,
+            force=force,
+            descendants=descendants,
+            descendant_count=len(descendants),
+        )
+
+    def agent_cancel_complete(
+        self,
+        *,
+        span_id: str,
+        agent_id: str,
+        cancelled_agents: list[str],
+        duration_ms: int,
+    ) -> None:
+        """Emit ``agent_cancel_complete`` when a cancel operation finishes."""
+        self.emit(
+            "agent_cancel_complete",
+            span_id,
+            agent_id=agent_id,
+            cancelled_agents=cancelled_agents,
+            cancelled_count=len(cancelled_agents),
+            duration_ms=duration_ms,
+        )

--- a/cli/tests/test_progress.py
+++ b/cli/tests/test_progress.py
@@ -514,6 +514,20 @@ class TestTerminalProgressRenderer:
         )
         assert "[ok] User responded (3s)" in output
 
+    def test_cancel_start_renders(self):
+        r = TerminalProgressRenderer()
+        output = self._capture_stderr(
+            r, _make_event("cancel_start", detail="agent_a + 3 descendants")
+        )
+        assert "[X] Cancelling implementer agent_a + 3 descendants..." in output
+
+    def test_cancel_complete_renders(self):
+        r = TerminalProgressRenderer()
+        output = self._capture_stderr(
+            r, _make_event("cancel_complete", detail="4 agents", duration_ms=2100)
+        )
+        assert "[X] Cancelled 4 agents (2s)" in output
+
     def test_indentation_by_depth(self):
         r = TerminalProgressRenderer()
         # depth=0 → 2 spaces base

--- a/cli/tests/test_trace.py
+++ b/cli/tests/test_trace.py
@@ -558,3 +558,60 @@ class TestIOResilience:
         finally:
             # Restore permissions for cleanup
             os.chmod(session_dir, stat.S_IRWXU)
+
+
+# ---------------------------------------------------------------------------
+# Cancel trace events
+# ---------------------------------------------------------------------------
+
+
+class TestCancelTraceEvents:
+    def test_agent_cancel_start(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.agent_cancel_start(
+            span_id="span_1",
+            agent_id="agent_a",
+            reason="user",
+            force=False,
+            descendants=["agent_b", "agent_c"],
+        )
+        events = _read_events(session_dir)
+        assert len(events) == 1
+        e = events[0]
+        assert e["event"] == "agent_cancel_start"
+        assert e["span_id"] == "span_1"
+        assert e["data"]["agent_id"] == "agent_a"
+        assert e["data"]["reason"] == "user"
+        assert e["data"]["force"] is False
+        assert e["data"]["descendants"] == ["agent_b", "agent_c"]
+        assert e["data"]["descendant_count"] == 2
+
+    def test_agent_cancel_complete(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.agent_cancel_complete(
+            span_id="span_1",
+            agent_id="agent_a",
+            cancelled_agents=["agent_c", "agent_b", "agent_a"],
+            duration_ms=1500,
+        )
+        events = _read_events(session_dir)
+        assert len(events) == 1
+        e = events[0]
+        assert e["event"] == "agent_cancel_complete"
+        assert e["data"]["agent_id"] == "agent_a"
+        assert e["data"]["cancelled_agents"] == ["agent_c", "agent_b", "agent_a"]
+        assert e["data"]["cancelled_count"] == 3
+        assert e["data"]["duration_ms"] == 1500
+
+    def test_cancel_start_empty_descendants(self, tmp_path):
+        tracer, session_dir = _make_tracer(tmp_path)
+        tracer.agent_cancel_start(
+            span_id="span_1",
+            agent_id="agent_a",
+            reason="timeout",
+            force=True,
+            descendants=[],
+        )
+        events = _read_events(session_dir)
+        assert events[0]["data"]["descendant_count"] == 0
+        assert events[0]["data"]["force"] is True

--- a/gui/src/strawpot_gui/sse.py
+++ b/gui/src/strawpot_gui/sse.py
@@ -186,6 +186,20 @@ class TreeState:
                 span_id=span_id or "",
             ))
 
+        elif etype == "agent_cancel_start":
+            agent_id = data.get("agent_id", "")
+            if agent_id in self.nodes:
+                self.nodes[agent_id].status = "cancelling"
+            # Also mark descendants as cancelling.
+            for desc_id in data.get("descendants", []):
+                if desc_id in self.nodes:
+                    self.nodes[desc_id].status = "cancelling"
+
+        elif etype == "agent_cancel_complete":
+            for cancelled_id in data.get("cancelled_agents", []):
+                if cancelled_id in self.nodes:
+                    self.nodes[cancelled_id].status = "cancelled"
+
         elif etype == "session_end":
             self._session_ended = True
             for node in self.nodes.values():

--- a/gui/tests/test_sse_unit.py
+++ b/gui/tests/test_sse_unit.py
@@ -293,3 +293,53 @@ class TestTreeStateFullLifecycle:
         assert result["denied_delegations"][0]["role"] == "admin"
 
         assert state.is_terminal
+
+
+class TestTreeStateCancelEvents:
+    """Tests for cancel event processing in TreeState."""
+
+    def test_cancel_start_sets_cancelling(self):
+        state = TreeState()
+        state.load_session_json({
+            "agents": {
+                "a1": {"role": "orch", "runtime": "cc", "parent": None},
+                "a2": {"role": "worker", "runtime": "cc", "parent": "a1"},
+            }
+        })
+        state.process_event({
+            "event": "agent_cancel_start",
+            "span_id": "s0",
+            "data": {"agent_id": "a1", "descendants": ["a2"]},
+        })
+        assert state.nodes["a1"].status == "cancelling"
+        assert state.nodes["a2"].status == "cancelling"
+
+    def test_cancel_complete_sets_cancelled(self):
+        state = TreeState()
+        state.load_session_json({
+            "agents": {
+                "a1": {"role": "orch", "runtime": "cc", "parent": None},
+                "a2": {"role": "worker", "runtime": "cc", "parent": "a1"},
+            }
+        })
+        state.process_event({
+            "event": "agent_cancel_complete",
+            "span_id": "s0",
+            "data": {"cancelled_agents": ["a2", "a1"]},
+        })
+        assert state.nodes["a1"].status == "cancelled"
+        assert state.nodes["a2"].status == "cancelled"
+
+    def test_cancel_unknown_agents_ignored(self):
+        state = TreeState()
+        # Should not raise on unknown agent IDs
+        state.process_event({
+            "event": "agent_cancel_start",
+            "span_id": "s0",
+            "data": {"agent_id": "unknown", "descendants": ["also_unknown"]},
+        })
+        state.process_event({
+            "event": "agent_cancel_complete",
+            "span_id": "s0",
+            "data": {"cancelled_agents": ["unknown"]},
+        })


### PR DESCRIPTION
## Summary

- Adds `agent_cancel_start`/`agent_cancel_complete` trace events to Tracer with full metadata (reason, force, descendants, duration)
- `cancel_agent()` now emits both trace and progress events around the cancel loop
- Terminal renderer shows `⊘ Cancelling...` and `⊘ Cancelled N agents (Xs)` messages
- GUI TreeState processes cancel events to update node status to "cancelling" → "cancelled"
- Events emitted even on partial cancel (some agents already exited)

Depends on: #548 (sub-issue 3)
Closes #540

## Test plan

- [x] 3 trace event tests (start, complete, empty descendants)
- [x] 2 progress renderer tests (cancel_start, cancel_complete)
- [x] 3 GUI TreeState tests (cancelling status, cancelled status, unknown agents)
- [x] All 1022 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)