### PR TITLE
Add file-based cancel signal protocol and watcher thread

### DIFF
--- a/cli/src/strawpot/cancel.py
+++ b/cli/src/strawpot/cancel.py
@@ -1,7 +1,15 @@
-"""Agent cancellation types and tree traversal utilities."""
+"""Agent cancellation types, tree traversal utilities, and file-based cancel signals."""
 
+import json
+import logging
+import os
+import tempfile
 from collections import deque
+from datetime import datetime, timezone
 from enum import StrEnum
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class AgentState(StrEnum):
@@ -92,3 +100,100 @@ def is_ancestor_of(
             return True
         current = parent
     return False
+
+
+# ------------------------------------------------------------------
+# File-based cancel signal protocol
+# ------------------------------------------------------------------
+# Cancel requests are written as JSON files to
+# ``.strawpot/sessions/<run_id>/cancel/<agent_id>.json``
+# (or ``_run.json`` for run-level cancel).  The session's cancel
+# watcher thread picks them up, triggers ``cancel_agent()``, and
+# renames them to ``.done``.
+
+
+def cancel_dir(session_dir: str) -> str:
+    """Return the cancel signal directory for a session."""
+    return os.path.join(session_dir, "cancel")
+
+
+def write_cancel_signal(
+    session_dir: str,
+    agent_id: str | None,
+    *,
+    force: bool = False,
+    requested_by: str = "cli",
+) -> Path:
+    """Write a cancel signal file for the session watcher to pick up.
+
+    Args:
+        session_dir: Path to ``.strawpot/sessions/<run_id>/``.
+        agent_id: Agent to cancel, or ``None`` to cancel the entire run.
+        force: Skip graceful shutdown.
+        requested_by: Origin of the cancel request (``"cli"`` or ``"gui"``).
+
+    Returns:
+        Path to the written signal file.
+    """
+    cdir = cancel_dir(session_dir)
+    os.makedirs(cdir, exist_ok=True)
+
+    filename = f"{agent_id}.json" if agent_id else "_run.json"
+    signal_path = os.path.join(cdir, filename)
+
+    data = {
+        "agent_id": agent_id,
+        "force": force,
+        "requested_at": datetime.now(timezone.utc).isoformat(),
+        "requested_by": requested_by,
+    }
+
+    # Atomic write: write to temp file, then rename.
+    fd, tmp_path = tempfile.mkstemp(dir=cdir, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        os.replace(tmp_path, signal_path)
+    except Exception:
+        # Clean up temp file on failure.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+    return Path(signal_path)
+
+
+def read_cancel_signals(session_dir: str) -> list[dict]:
+    """Read pending cancel signal files from the cancel directory.
+
+    Returns a list of parsed signal dicts.  Each dict includes
+    ``"_path"`` with the file path for renaming after processing.
+    """
+    cdir = cancel_dir(session_dir)
+    if not os.path.isdir(cdir):
+        return []
+
+    signals: list[dict] = []
+    for entry in os.listdir(cdir):
+        if not entry.endswith(".json"):
+            continue
+        path = os.path.join(cdir, entry)
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            data["_path"] = path
+            signals.append(data)
+        except (json.JSONDecodeError, OSError):
+            logger.debug("Skipping malformed cancel signal: %s", path)
+    return signals
+
+
+def mark_signal_done(signal_path: str) -> None:
+    """Rename a processed signal file to ``.done``."""
+    done_path = signal_path.replace(".json", ".done")
+    try:
+        os.replace(signal_path, done_path)
+    except OSError:
+        logger.debug("Failed to rename signal to .done: %s", signal_path)

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -30,8 +30,11 @@ from strawpot.agents.wrapper import WrapperRuntime
 from strawpot.cancel import (
     AgentState,
     CancelReason,
+    cancel_dir,
     get_children,
     get_subtree_bottom_up,
+    mark_signal_done,
+    read_cancel_signals,
 )
 from strawpot.config import StrawPotConfig
 from strawpot.context import build_prompt
@@ -374,6 +377,7 @@ class Session:
         self._shutting_down: bool = False
         self._interrupted: bool = False
         self._last_sigint_time: float = 0.0
+        self._cancel_watcher_stop = threading.Event()
 
     # ------------------------------------------------------------------
     # Public interface
@@ -564,6 +568,9 @@ class Session:
             # 6. Write session state file
             self._write_session_file()
 
+            # 6a. Start cancel signal watcher
+            self._start_cancel_watcher()
+
             # 7. Install signal handler before blocking attach
             signal.signal(signal.SIGINT, self._handle_sigint)
 
@@ -582,6 +589,9 @@ class Session:
 
     def stop(self) -> None:
         """Clean up the session: kill agents, stop server, merge changes, remove isolation."""
+        # 0. Stop cancel watcher
+        self._cancel_watcher_stop.set()
+
         # 0a. Memory dump for orchestrator agent
         if self._memory_provider is not None and self._run_id is not None:
             orch_agent_id = None
@@ -781,6 +791,75 @@ class Session:
                 self.runtime.kill(self._orchestrator_handle)
             except Exception:
                 pass
+
+    # ------------------------------------------------------------------
+    # Cancel signal watcher
+    # ------------------------------------------------------------------
+
+    _CANCEL_POLL_INTERVAL = 0.5  # seconds
+
+    def _start_cancel_watcher(self) -> None:
+        """Start a daemon thread that polls for cancel signal files."""
+        session_dir = self._session_dir()
+        # Create cancel directory so writers don't need to.
+        os.makedirs(cancel_dir(session_dir), exist_ok=True)
+
+        # Install SIGUSR1 handler to wake the watcher immediately.
+        try:
+            signal.signal(signal.SIGUSR1, self._handle_sigusr1)
+        except (OSError, ValueError):
+            # SIGUSR1 not available on all platforms (e.g., Windows).
+            pass
+
+        t = threading.Thread(
+            target=self._cancel_watcher_loop,
+            name="cancel-watcher",
+            daemon=True,
+        )
+        t.start()
+
+    def _handle_sigusr1(self, signum, frame) -> None:
+        """SIGUSR1 wakes the cancel watcher by interrupting its sleep."""
+        # No-op — the signal itself interrupts Event.wait().
+        pass
+
+    def _cancel_watcher_loop(self) -> None:
+        """Poll for cancel signal files and trigger cancel_agent()."""
+        session_dir = self._session_dir()
+        while not self._cancel_watcher_stop.is_set():
+            try:
+                signals = read_cancel_signals(session_dir)
+                for sig in signals:
+                    self._process_cancel_signal(sig)
+            except Exception:
+                logger.debug("Cancel watcher error", exc_info=True)
+            # Wait for stop or SIGUSR1 wake-up.
+            self._cancel_watcher_stop.wait(timeout=self._CANCEL_POLL_INTERVAL)
+
+    def _process_cancel_signal(self, sig: dict) -> None:
+        """Process a single cancel signal from the watcher."""
+        agent_id = sig.get("agent_id")
+        force = sig.get("force", False)
+        signal_path = sig.get("_path", "")
+
+        try:
+            if agent_id:
+                # Cancel specific agent.
+                self.cancel_agent(agent_id, reason=CancelReason.USER, force=force)
+            else:
+                # Cancel entire run — find the orchestrator.
+                orch_id = None
+                for aid, info in self._agent_info.items():
+                    if info.get("parent") is None:
+                        orch_id = aid
+                        break
+                if orch_id:
+                    self.cancel_agent(orch_id, reason=CancelReason.USER, force=force)
+        except Exception:
+            logger.debug("Failed to process cancel signal: %s", signal_path, exc_info=True)
+        finally:
+            if signal_path:
+                mark_signal_done(signal_path)
 
     # ------------------------------------------------------------------
     # Merge behavior

--- a/cli/tests/test_cancel.py
+++ b/cli/tests/test_cancel.py
@@ -12,10 +12,14 @@ import pytest
 from strawpot.cancel import (
     AgentState,
     CancelReason,
+    cancel_dir,
     get_children,
     get_descendants,
     get_subtree_bottom_up,
     is_ancestor_of,
+    mark_signal_done,
+    read_cancel_signals,
+    write_cancel_signal,
 )
 
 
@@ -724,3 +728,90 @@ class TestIsAncestorOf:
             "B": {"parent": "A"},
         }
         assert is_ancestor_of("A", "B", tree) is True
+
+
+# ---------------------------------------------------------------------------
+# File-based cancel signal protocol
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCancelSignal:
+    def test_writes_agent_cancel(self, tmp_path):
+        session_dir = str(tmp_path / "session")
+        os.makedirs(session_dir)
+        path = write_cancel_signal(session_dir, "agent-abc", force=False)
+        assert path.name == "agent-abc.json"
+        with open(path) as f:
+            data = json.load(f)
+        assert data["agent_id"] == "agent-abc"
+        assert data["force"] is False
+        assert data["requested_by"] == "cli"
+        assert "requested_at" in data
+
+    def test_writes_run_cancel(self, tmp_path):
+        session_dir = str(tmp_path / "session")
+        os.makedirs(session_dir)
+        path = write_cancel_signal(session_dir, None, force=True, requested_by="gui")
+        assert path.name == "_run.json"
+        with open(path) as f:
+            data = json.load(f)
+        assert data["agent_id"] is None
+        assert data["force"] is True
+        assert data["requested_by"] == "gui"
+
+    def test_atomic_write(self, tmp_path):
+        """No partial files left behind."""
+        session_dir = str(tmp_path / "session")
+        os.makedirs(session_dir)
+        write_cancel_signal(session_dir, "a1")
+        cdir = cancel_dir(session_dir)
+        files = os.listdir(cdir)
+        assert all(not f.endswith(".tmp") for f in files)
+
+
+class TestReadCancelSignals:
+    def test_reads_pending_signals(self, tmp_path):
+        session_dir = str(tmp_path / "session")
+        write_cancel_signal(session_dir, "a1", force=False)
+        write_cancel_signal(session_dir, "a2", force=True)
+        signals = read_cancel_signals(session_dir)
+        assert len(signals) == 2
+        agent_ids = {s["agent_id"] for s in signals}
+        assert agent_ids == {"a1", "a2"}
+        # Each signal should have _path
+        assert all("_path" in s for s in signals)
+
+    def test_empty_dir_returns_empty(self, tmp_path):
+        session_dir = str(tmp_path / "session")
+        os.makedirs(cancel_dir(session_dir))
+        assert read_cancel_signals(session_dir) == []
+
+    def test_missing_dir_returns_empty(self, tmp_path):
+        assert read_cancel_signals(str(tmp_path / "nonexistent")) == []
+
+    def test_skips_done_files(self, tmp_path):
+        session_dir = str(tmp_path / "session")
+        path = write_cancel_signal(session_dir, "a1")
+        mark_signal_done(str(path))
+        # .done file should not be read
+        signals = read_cancel_signals(session_dir)
+        assert len(signals) == 0
+
+    def test_skips_malformed_files(self, tmp_path):
+        session_dir = str(tmp_path / "session")
+        cdir = cancel_dir(session_dir)
+        os.makedirs(cdir)
+        with open(os.path.join(cdir, "bad.json"), "w") as f:
+            f.write("not valid json{{{")
+        signals = read_cancel_signals(session_dir)
+        assert len(signals) == 0
+
+
+class TestMarkSignalDone:
+    def test_renames_to_done(self, tmp_path):
+        session_dir = str(tmp_path / "session")
+        path = write_cancel_signal(session_dir, "a1")
+        mark_signal_done(str(path))
+        assert not path.exists()
+        done_path = str(path).replace(".json", ".done")
+        assert os.path.exists(done_path)


### PR DESCRIPTION
## Summary

- File-based cancel signal protocol: CLI/GUI write JSON signal files to `.strawpot/sessions/<run_id>/cancel/`, session watcher picks them up
- Atomic file writes (temp + rename) prevent partial reads
- Daemon watcher thread polls every 0.5s, SIGUSR1 wakes it immediately for low-latency cancellation
- Run-level cancel (`_run.json`) cancels all agents via orchestrator
- Processed signals renamed to `.done` to prevent re-processing

This is the bridge between external processes (CLI, GUI) and the session's `cancel_agent()` engine.

Depends on: #548 (sub-issue 3)
Closes #541

## Test plan

- [x] 9 new tests: write (agent/run/atomic), read (pending/empty/missing/done/malformed), done marking
- [x] All 1008 tests pass
- [ ] Manual: write signal file, verify agent cancelled within 0.5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)