### PR TITLE
Add strawpot cancel agent and strawpot cancel run CLI commands

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -4,9 +4,11 @@ import json
 import logging
 import os
 import re
+import signal
 import shutil
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -1426,6 +1428,158 @@ def agents(session_id, session_opt, status_csv, role_filter, parent_filter, as_t
                 f"{agent['agent_id']:<20} {agent['role']:<16} "
                 f"{agent['runtime']:<14} {agent['parent']:<20} {agent['status']:<10}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Cancel
+# ---------------------------------------------------------------------------
+
+
+@cli.group()
+def cancel():
+    """Cancel running agents or sessions."""
+    pass
+
+
+def _wait_for_cancel(session_file: Path, agent_ids: set[str], timeout: float = 30.0) -> bool:
+    """Poll session.json until all specified agents are in a terminal state."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        data = _load_session(session_file)
+        if data is None:
+            return False
+        agents_map = data.get("agents", {})
+        all_done = True
+        for aid in agent_ids:
+            info = agents_map.get(aid, {})
+            state = info.get("state", "")
+            if state not in ("cancelled", "completed", "failed"):
+                all_done = False
+                break
+        if all_done:
+            return True
+        time.sleep(0.5)
+    return False
+
+
+@cancel.command("agent")
+@click.argument("agent_id")
+@click.option("--run", "run_id", required=True, help="Session run ID.")
+@click.option("--force", is_flag=True, help="Force-kill without graceful shutdown.")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
+def cancel_agent_cmd(agent_id, run_id, force, yes):
+    """Cancel a specific agent and its descendants."""
+    from strawpot.cancel import get_descendants, write_cancel_signal
+
+    sessions_path = _sessions_dir()
+    session_dir = sessions_path / run_id
+    session_file = session_dir / "session.json"
+
+    if not session_file.is_file():
+        click.echo(f"Session not found: {run_id}")
+        sys.exit(1)
+
+    data = _load_session(session_file)
+    if data is None:
+        click.echo(f"Failed to read session: {run_id}")
+        sys.exit(1)
+
+    # Verify session is alive
+    pid = data.get("pid")
+    if not (pid and is_pid_alive(pid)):
+        click.echo(f"Session {run_id} is not running (stale).")
+        sys.exit(1)
+
+    agents_map = data.get("agents", {})
+    if agent_id not in agents_map:
+        click.echo(f"Agent not found: {agent_id}")
+        sys.exit(1)
+
+    # Show affected agents
+    descendants = get_descendants(agent_id, agents_map)
+    affected = [agent_id] + descendants
+    force_label = " (force)" if force else ""
+
+    if not yes:
+        click.echo(f"Will cancel {len(affected)} agent(s){force_label}:")
+        for aid in affected:
+            info = agents_map.get(aid, {})
+            role = info.get("role", "?")
+            state = info.get("state", "?")
+            click.echo(f"  {aid} ({role}) — {state}")
+        if not click.confirm("Proceed?", default=False):
+            click.echo("Cancelled.")
+            return
+
+    write_cancel_signal(str(session_dir), agent_id, force=force)
+
+    # Send SIGUSR1 to wake watcher immediately
+    try:
+        os.kill(pid, signal.SIGUSR1)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+    click.echo(f"Cancel signal sent for {agent_id}. Waiting...")
+    if _wait_for_cancel(session_file, set(affected)):
+        click.echo(f"Cancelled {len(affected)} agent(s).")
+    else:
+        click.echo("Cancel timed out — check session status.", err=True)
+        sys.exit(1)
+
+
+@cancel.command("run")
+@click.argument("run_id")
+@click.option("--force", is_flag=True, help="Force-kill without graceful shutdown.")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt.")
+def cancel_run_cmd(run_id, force, yes):
+    """Cancel all agents in a session."""
+    from strawpot.cancel import write_cancel_signal
+
+    sessions_path = _sessions_dir()
+    session_dir = sessions_path / run_id
+    session_file = session_dir / "session.json"
+
+    if not session_file.is_file():
+        click.echo(f"Session not found: {run_id}")
+        sys.exit(1)
+
+    data = _load_session(session_file)
+    if data is None:
+        click.echo(f"Failed to read session: {run_id}")
+        sys.exit(1)
+
+    pid = data.get("pid")
+    if not (pid and is_pid_alive(pid)):
+        click.echo(f"Session {run_id} is not running (stale).")
+        sys.exit(1)
+
+    agents_map = data.get("agents", {})
+    force_label = " (force)" if force else ""
+
+    if not yes:
+        click.echo(f"Will cancel {len(agents_map)} agent(s) in session {run_id}{force_label}:")
+        for aid, info in agents_map.items():
+            role = info.get("role", "?")
+            state = info.get("state", "?")
+            click.echo(f"  {aid} ({role}) — {state}")
+        if not click.confirm("Proceed?", default=False):
+            click.echo("Cancelled.")
+            return
+
+    write_cancel_signal(str(session_dir), None, force=force)
+
+    # Send SIGUSR1 to wake watcher
+    try:
+        os.kill(pid, signal.SIGUSR1)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+    click.echo(f"Cancel signal sent for session {run_id}. Waiting...")
+    if _wait_for_cancel(session_file, set(agents_map.keys())):
+        click.echo(f"Cancelled {len(agents_map)} agent(s).")
+    else:
+        click.echo("Cancel timed out — check session status.", err=True)
+        sys.exit(1)
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/test_cli_cancel.py
+++ b/cli/tests/test_cli_cancel.py
@@ -1,0 +1,194 @@
+"""Tests for strawpot cancel agent and strawpot cancel run CLI commands."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from strawpot.cli import cli
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session(tmp_path, run_id, *, pid=99999, agents=None):
+    """Create a mock session directory."""
+    session_dir = tmp_path / ".strawpot" / "sessions" / run_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    data = {
+        "run_id": run_id,
+        "working_dir": str(tmp_path),
+        "pid": pid,
+        "isolation": "none",
+        "runtime": "cc",
+        "agents": agents or {},
+    }
+    with open(session_dir / "session.json", "w") as f:
+        json.dump(data, f)
+    return session_dir
+
+
+def _sample_agents():
+    return {
+        "orch": {"role": "orchestrator", "parent": None, "state": "running", "pid": 100},
+        "impl": {"role": "implementer", "parent": "orch", "state": "running", "pid": 200},
+        "rev": {"role": "reviewer", "parent": "orch", "state": "running", "pid": 300},
+    }
+
+
+# ---------------------------------------------------------------------------
+# cancel agent
+# ---------------------------------------------------------------------------
+
+
+class TestCancelAgent:
+    @patch("strawpot.cli.is_pid_alive", return_value=True)
+    @patch("strawpot.cli.os.kill")
+    def test_cancel_agent_writes_signal_file(self, mock_kill, mock_alive, tmp_path):
+        _make_session(tmp_path, "run_abc", agents=_sample_agents())
+        runner = CliRunner()
+        with patch("strawpot.cli._sessions_dir", return_value=tmp_path / ".strawpot" / "sessions"):
+            with patch("strawpot.cli._wait_for_cancel", return_value=True):
+                result = runner.invoke(cli, [
+                    "cancel", "agent", "impl", "--run", "run_abc", "--yes"
+                ])
+        assert result.exit_code == 0
+        assert "Cancel signal sent" in result.output
+        # Signal file should exist
+        signal_file = tmp_path / ".strawpot" / "sessions" / "run_abc" / "cancel" / "impl.json"
+        assert signal_file.is_file()
+        data = json.loads(signal_file.read_text())
+        assert data["agent_id"] == "impl"
+        assert data["force"] is False
+
+    @patch("strawpot.cli.is_pid_alive", return_value=True)
+    @patch("strawpot.cli.os.kill")
+    def test_cancel_agent_force_flag(self, mock_kill, mock_alive, tmp_path):
+        _make_session(tmp_path, "run_abc", agents=_sample_agents())
+        runner = CliRunner()
+        with patch("strawpot.cli._sessions_dir", return_value=tmp_path / ".strawpot" / "sessions"):
+            with patch("strawpot.cli._wait_for_cancel", return_value=True):
+                result = runner.invoke(cli, [
+                    "cancel", "agent", "impl", "--run", "run_abc", "--force", "--yes"
+                ])
+        assert result.exit_code == 0
+        signal_file = tmp_path / ".strawpot" / "sessions" / "run_abc" / "cancel" / "impl.json"
+        data = json.loads(signal_file.read_text())
+        assert data["force"] is True
+
+    @patch("strawpot.cli.is_pid_alive", return_value=True)
+    def test_cancel_agent_not_found(self, mock_alive, tmp_path):
+        _make_session(tmp_path, "run_abc", agents=_sample_agents())
+        runner = CliRunner()
+        with patch("strawpot.cli._sessions_dir", return_value=tmp_path / ".strawpot" / "sessions"):
+            result = runner.invoke(cli, [
+                "cancel", "agent", "nonexistent", "--run", "run_abc", "--yes"
+            ])
+        assert result.exit_code != 0
+        assert "Agent not found" in result.output
+
+    @patch("strawpot.cli.is_pid_alive", return_value=False)
+    def test_cancel_agent_stale_session(self, mock_alive, tmp_path):
+        _make_session(tmp_path, "run_abc", agents=_sample_agents())
+        runner = CliRunner()
+        with patch("strawpot.cli._sessions_dir", return_value=tmp_path / ".strawpot" / "sessions"):
+            result = runner.invoke(cli, [
+                "cancel", "agent", "impl", "--run", "run_abc", "--yes"
+            ])
+        assert result.exit_code != 0
+        assert "not running" in result.output
+
+    def test_cancel_agent_session_not_found(self, tmp_path):
+        runner = CliRunner()
+        with patch("strawpot.cli._sessions_dir", return_value=tmp_path / ".strawpot" / "sessions"):
+            result = runner.invoke(cli, [
+                "cancel", "agent", "impl", "--run", "run_nonexistent", "--yes"
+            ])
+        assert result.exit_code != 0
+        assert "Session not found" in result.output
+
+    @patch("strawpot.cli.is_pid_alive", return_value=True)
+    def test_cancel_agent_confirmation_declined(self, mock_alive, tmp_path):
+        _make_session(tmp_path, "run_abc", agents=_sample_agents())
+        runner = CliRunner()
+        with patch("strawpot.cli._sessions_dir", return_value=tmp_path / ".strawpot" / "sessions"):
+            result = runner.invoke(cli, [
+                "cancel", "agent", "impl", "--run", "run_abc"
+            ], input="n\n")
+        assert result.exit_code == 0
+        assert "Cancelled." in result.output
+
+    @patch("strawpot.cli.is_pid_alive", return_value=True)
+    def test_cancel_agent_run_required(self, mock_alive, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cancel", "agent", "impl"])
+        assert result.exit_code != 0
+        assert "--run" in result.output
+
+
+# ---------------------------------------------------------------------------
+# cancel run
+# ---------------------------------------------------------------------------
+
+
+class TestCancelRun:
+    @patch("strawpot.cli.is_pid_alive", return_value=True)
+    @patch("strawpot.cli.os.kill")
+    def test_cancel_run_writes_signal(self, mock_kill, mock_alive, tmp_path):
+        _make_session(tmp_path, "run_abc", agents=_sample_agents())
+        runner = CliRunner()
+        with patch("strawpot.cli._sessions_dir", return_value=tmp_path / ".strawpot" / "sessions"):
+            with patch("strawpot.cli._wait_for_cancel", return_value=True):
+                result = runner.invoke(cli, ["cancel", "run", "run_abc", "--yes"])
+        assert result.exit_code == 0
+        signal_file = tmp_path / ".strawpot" / "sessions" / "run_abc" / "cancel" / "_run.json"
+        assert signal_file.is_file()
+        data = json.loads(signal_file.read_text())
+        assert data["agent_id"] is None
+
+    @patch("strawpot.cli.is_pid_alive", return_value=True)
+    @patch("strawpot.cli.os.kill")
+    def test_cancel_run_timeout(self, mock_kill, mock_alive, tmp_path):
+        _make_session(tmp_path, "run_abc", agents=_sample_agents())
+        runner = CliRunner()
+        with patch("strawpot.cli._sessions_dir", return_value=tmp_path / ".strawpot" / "sessions"):
+            with patch("strawpot.cli._wait_for_cancel", return_value=False):
+                result = runner.invoke(cli, ["cancel", "run", "run_abc", "--yes"])
+        assert result.exit_code != 0
+        assert "timed out" in result.output
+
+    @patch("strawpot.cli.is_pid_alive", return_value=False)
+    def test_cancel_run_stale_session(self, mock_alive, tmp_path):
+        _make_session(tmp_path, "run_abc", agents=_sample_agents())
+        runner = CliRunner()
+        with patch("strawpot.cli._sessions_dir", return_value=tmp_path / ".strawpot" / "sessions"):
+            result = runner.invoke(cli, ["cancel", "run", "run_abc", "--yes"])
+        assert result.exit_code != 0
+        assert "not running" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Help output
+# ---------------------------------------------------------------------------
+
+
+class TestCancelHelp:
+    def test_cancel_in_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cancel", "--help"])
+        assert result.exit_code == 0
+        assert "agent" in result.output
+        assert "run" in result.output
+
+    def test_cancel_agent_help(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["cancel", "agent", "--help"])
+        assert result.exit_code == 0
+        assert "--run" in result.output
+        assert "--force" in result.output
+        assert "--yes" in result.output


### PR DESCRIPTION
## Summary

- `strawpot cancel agent <id> --run <run_id>` cancels a specific agent and its descendants
- `strawpot cancel run <run_id>` cancels all agents in a session
- Confirmation dialog shows affected agent tree before proceeding
- Writes file-based cancel signals for the session watcher; sends SIGUSR1 to wake watcher immediately
- Polls session.json for state changes to confirm cancel completed

Depends on: #552 (sub-issue 7), #551 (sub-issue 8)
Closes #543

## Test plan

- [x] 12 new tests: signal writing, force flag, agent/session validation, confirmation, help output
- [x] All 1020 tests pass
- [ ] Manual: `strawpot cancel agent <id> --run <run_id> --yes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)