### PR TITLE
feat(gui): add cancelling/cancelled agent states

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -75,7 +75,7 @@ export interface TreeNode {
   agent_id: string;
   role: string;
   runtime: string;
-  status: "running" | "completed" | "failed";
+  status: "running" | "completed" | "failed" | "cancelling" | "cancelled";
   exit_code: number | null;
   started_at: string | null;
   duration_ms: number | null;

--- a/gui/frontend/src/components/AgentTreeFlow.tsx
+++ b/gui/frontend/src/components/AgentTreeFlow.tsx
@@ -12,7 +12,19 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
-import { statusColor, formatDuration } from "@/components/SessionTable";
+import { statusColor as statusVariant, formatDuration } from "@/components/SessionTable";
+
+/** Map agent status to CSS class for tree nodes (distinct from badge variants). */
+function nodeStatusClass(status: string): string {
+  switch (status) {
+    case "cancelling":
+      return "cancelling";
+    case "cancelled":
+      return "cancelled";
+    default:
+      return statusVariant(status);
+  }
+}
 import type { TreeData, TreeNode, PendingDelegation, DeniedDelegation } from "@/api/types";
 
 const NODE_WIDTH = 180;
@@ -35,7 +47,7 @@ type AgentNodeData = {
 function AgentFlowNode({ data }: NodeProps<Node<AgentNodeData>>) {
   const cls = data.pending
     ? "agent-flow-node pending"
-    : `agent-flow-node ${statusColor(data.status)}`;
+    : `agent-flow-node ${nodeStatusClass(data.status)}`;
 
   return (
     <div className={cls}>
@@ -45,7 +57,7 @@ function AgentFlowNode({ data }: NodeProps<Node<AgentNodeData>>) {
       </div>
       {!data.pending && (
         <div className="agent-flow-meta">
-          <span className={`status-dot ${statusColor(data.status)}`} />
+          <span className={`status-dot ${nodeStatusClass(data.status)}`} />
           <span>{data.status}</span>
           {data.duration_ms != null && (
             <span>{formatDuration(data.duration_ms)}</span>

--- a/gui/frontend/src/components/SessionTable.tsx
+++ b/gui/frontend/src/components/SessionTable.tsx
@@ -96,6 +96,8 @@ function StatusBadge({ status }: { status: string }) {
           "border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400",
         variant === "error" &&
           "border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-400",
+        variant === "cancelling" &&
+          "animate-pulse border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-400",
         variant === "warning" &&
           "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-400",
         variant === "default" &&
@@ -104,6 +106,9 @@ function StatusBadge({ status }: { status: string }) {
     >
       {status === "running" && (
         <span className="mr-1.5 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-green-500" />
+      )}
+      {status === "cancelling" && (
+        <span className="mr-1.5 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-orange-500" />
       )}
       {status}
     </Badge>
@@ -123,7 +128,10 @@ export function statusVariant(status: string): string {
     case "failed":
       return "error";
     case "stopped":
+    case "cancelled":
       return "warning";
+    case "cancelling":
+      return "cancelling";
     default:
       return "default";
   }

--- a/gui/frontend/src/index.css
+++ b/gui/frontend/src/index.css
@@ -154,6 +154,16 @@
   border-left-color: #e65100;
 }
 
+.agent-flow-node.cancelling {
+  border-left-color: #e65100;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.agent-flow-node.cancelled {
+  border-left-color: #e65100;
+  opacity: 0.6;
+}
+
 .agent-flow-node.pending {
   border: 1px dashed hsl(var(--border));
   border-left: 3px dashed hsl(var(--border));
@@ -197,6 +207,16 @@
 
 .status-dot.warning {
   background: #e65100;
+}
+
+.status-dot.cancelling {
+  background: #e65100;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.status-dot.cancelled {
+  background: #e65100;
+  opacity: 0.6;
 }
 
 .denied-list {

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -313,6 +313,8 @@ function StatusBadge({ status }: { status: string }) {
         variant === "running" && "border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400",
         variant === "success" && "border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950 dark:text-green-400",
         variant === "error" && "border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-400",
+        variant === "cancelling" &&
+          "animate-pulse border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-400",
         variant === "warning" &&
           "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-950 dark:text-orange-400",
         variant === "default" && "border-muted bg-muted text-muted-foreground",
@@ -320,6 +322,9 @@ function StatusBadge({ status }: { status: string }) {
     >
       {status === "running" && (
         <span className="mr-1.5 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-green-500" />
+      )}
+      {status === "cancelling" && (
+        <span className="mr-1.5 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-orange-500" />
       )}
       {status}
     </Badge>
@@ -336,7 +341,10 @@ function statusVariant(status: string): string {
     case "failed":
       return "error";
     case "stopped":
+    case "cancelled":
       return "warning";
+    case "cancelling":
+      return "cancelling";
     default:
       return "default";
   }


### PR DESCRIPTION
## Summary
- Update `TreeNode.status` type union to include `cancelling` and `cancelled`
- Add `cancelling` variant (animated pulse, orange) to `StatusBadge` in both `SessionTable` and `SessionDetail`
- Add CSS classes for `.agent-flow-node.cancelling` (animated) and `.agent-flow-node.cancelled` (dimmed)
- Add `nodeStatusClass` helper in `AgentTreeFlow` for tree-specific CSS mapping

## Test plan
- [ ] Verify TypeScript compiles (`tsc --noEmit`)
- [ ] Verify existing status displays render correctly (no regressions)
- [ ] Manually test with a cancelling/cancelled agent to see orange pulse badge and dimmed node

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)