### PR TITLE
fix(gui): always show cancel button on running agents

### DIFF
--- a/gui/frontend/src/components/AgentTreeFlow.tsx
+++ b/gui/frontend/src/components/AgentTreeFlow.tsx
@@ -64,7 +64,7 @@ function AgentFlowNode({ data }: NodeProps<Node<AgentNodeData>>) {
     : `agent-flow-node ${nodeStatusClass(data.status)}`;
 
   return (
-    <div className={`${cls} group relative`}>
+    <div className={`${cls} relative`}>
       <Handle type="target" position={Position.Top} />
       <div className="agent-flow-role">
         {data.pending ? `[pending: ${data.role}]` : data.role}


### PR DESCRIPTION
## Summary
- Remove hover-to-reveal (`hidden` + `group-hover:flex`) behavior from the cancel (✕) button on `AgentFlowNode`
- The button now uses `flex` directly, making it always visible when an agent is running
- No functional change — the button still only renders when `status === "running"` and `onCancel` is provided

## Why
The cancel button was hard to discover because users had to hover over a running agent node to see it. Making it always visible improves usability and makes the cancel action immediately accessible.

## Test plan
- [ ] Run the GUI with an active agent tree and verify the cancel button is visible on running agent nodes without hovering
- [ ] Verify the button does not appear on agents with non-running statuses
- [ ] Verify clicking the button still triggers the cancel confirmation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>