### PR TITLE
fix(gui): enable pointer-events on ReactFlow nodes for cancel button

### DIFF
--- a/gui/frontend/src/components/AgentTreeFlow.tsx
+++ b/gui/frontend/src/components/AgentTreeFlow.tsx
@@ -368,6 +368,7 @@ function AgentTreeFlowInner({
           nodesDraggable={false}
           nodesConnectable={false}
           elementsSelectable={false}
+          onNodeClick={() => {}}
           proOptions={{ hideAttribution: true }}
         />
         <button className="tree-reset-btn" onClick={handleReset}>


### PR DESCRIPTION
## Summary

- Fix cancel (✕) button on running sub-agents being visible but not clickable
- Add no-op `onNodeClick` handler to `<ReactFlow>` component in AgentTreeFlow

## Root Cause

ReactFlow v12's `NodeWrapper` sets inline `pointer-events: none` on every node wrapper div when `onNodeClick`, `elementsSelectable`, and `nodesDraggable` are all falsy — which they were in our config. This prevented all click events (including the cancel button) from reaching the custom node content.

Adding `onNodeClick={() => {}}` makes ReactFlow set `pointer-events: all` instead, restoring normal click behavior on nodes.

## Test plan

- [ ] Open the GUI, start a session with sub-agents
- [ ] Verify the cancel (✕) button on running agents is clickable
- [ ] Verify clicking it opens the cancel confirmation dialog
- [ ] Verify node dragging is still disabled
- [ ] Verify no unintended selection behavior on node click

🤖 Generated with [Claude Code](https://claude.com/claude-code)