### PR TITLE
Remove isolation selector from GUI frontend

### DIFF
--- a/gui/frontend/src/api/types.ts
+++ b/gui/frontend/src/api/types.ts
@@ -11,7 +11,6 @@ export interface Session {
   project_id: number;
   role: string;
   runtime: string;
-  isolation: string;
   status: string;
   started_at: string;
   ended_at: string | null;

--- a/gui/frontend/src/components/ConfigForm.tsx
+++ b/gui/frontend/src/components/ConfigForm.tsx
@@ -24,7 +24,6 @@ interface ConfigFormProps {
 
 interface FlatState {
   runtime: string;
-  isolation: string;
   memory: string;
   orchestrator_role: string;
   orchestrator_permission_mode: string;
@@ -46,7 +45,6 @@ function toFlat(v: Record<string, unknown>): FlatState {
   const trace = (v.trace ?? {}) as Record<string, unknown>;
   return {
     runtime: str(v.runtime),
-    isolation: str(v.isolation),
     memory: str(v.memory),
     orchestrator_role: str(orch.role),
     orchestrator_permission_mode: str(orch.permission_mode),
@@ -71,7 +69,6 @@ function toNested(flat: FlatState): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
   if (flat.runtime) result.runtime = flat.runtime;
-  if (flat.isolation) result.isolation = flat.isolation;
   if (flat.memory) result.memory = flat.memory;
 
   const orch: Record<string, unknown> = {};
@@ -111,7 +108,6 @@ function toNested(flat: FlatState): Record<string, unknown> {
 
 // --- select field options ---
 
-const ISOLATION_OPTIONS = ["none", "worktree"];
 const PERMISSION_OPTIONS = ["default", "plan", "bypassPermissions"];
 
 const PULL_OPTIONS = ["prompt", "always", "never"];
@@ -173,7 +169,7 @@ export default function ConfigForm({
       <section className="flex flex-col gap-3">
         <h3 className="text-sm font-semibold">General</h3>
         <Separator />
-        <div className="grid gap-4 sm:grid-cols-3">
+        <div className="grid gap-4 sm:grid-cols-2">
           <Field label="Runtime">
             <Input
               list="cfg-dl-runtime"
@@ -192,15 +188,6 @@ export default function ConfigForm({
             {runtimeError && (
               <p className="text-xs text-destructive">{runtimeError}</p>
             )}
-          </Field>
-          <Field label="Isolation">
-            <SelectField
-              value={state.isolation}
-              onChange={set("isolation")}
-              options={ISOLATION_OPTIONS}
-              placeholder={ph?.isolation || "none"}
-              allowEmpty
-            />
           </Field>
           <Field label="Memory">
             <Input

--- a/gui/frontend/src/pages/ProjectList.tsx
+++ b/gui/frontend/src/pages/ProjectList.tsx
@@ -1,23 +1,13 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useProjects } from "@/hooks/queries/use-projects";
-import { useGlobalConfig } from "@/hooks/queries/use-config";
 import { useCreateProject, useDeleteProject } from "@/hooks/mutations/use-projects";
-import { useSaveProjectConfig } from "@/hooks/mutations/use-config";
-import { api } from "@/api/client";
 import DirBrowser from "@/components/DirBrowser";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Table,
@@ -143,57 +133,17 @@ function RegisterForm({
 }) {
   const [displayName, setDisplayName] = useState("");
   const [workingDir, setWorkingDir] = useState("");
-  const [isolation, setIsolation] = useState("");
   const [showBrowser, setShowBrowser] = useState(false);
-  const [gitInitPrompt, setGitInitPrompt] = useState(false);
   const createProject = useCreateProject();
-  const saveConfig = useSaveProjectConfig();
-  const globalConfig = useGlobalConfig();
-
-  const globalDefaults = globalConfig.data?.defaults as
-    | { isolation?: string }
-    | undefined;
-  const defaultIsolation = globalDefaults?.isolation ?? "none";
-
-  const effectiveIsolation = isolation || defaultIsolation;
-
-  const doCreate = async () => {
-    const project = await createProject.mutateAsync({
-      display_name: displayName.trim(),
-      working_dir: workingDir.trim(),
-    });
-    const configData: Record<string, unknown> = {};
-    configData.isolation = effectiveIsolation;
-    await saveConfig.mutateAsync({
-      projectId: (project as { id: number }).id,
-      data: configData,
-    });
-    onDone();
-  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      if (effectiveIsolation === "worktree" && workingDir.trim()) {
-        const res = await api.get<{ is_git: boolean }>(
-          `/fs/git-check?path=${encodeURIComponent(workingDir.trim())}`,
-        );
-        if (!res.is_git) {
-          setGitInitPrompt(true);
-          return;
-        }
-      }
-      await doCreate();
-    } catch {
-      // error state handled by mutation
-    }
-  };
-
-  const handleGitInitConfirm = async () => {
-    try {
-      await api.post("/fs/git-init", { path: workingDir.trim() });
-      setGitInitPrompt(false);
-      await doCreate();
+      await createProject.mutateAsync({
+        display_name: displayName.trim(),
+        working_dir: workingDir.trim(),
+      });
+      onDone();
     } catch {
       // error state handled by mutation
     }
@@ -245,52 +195,14 @@ function RegisterForm({
               onCancel={() => setShowBrowser(false)}
             />
           )}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="isolation">Isolation</Label>
-              <Select
-                value={isolation || defaultIsolation}
-                onValueChange={setIsolation}
-              >
-                <SelectTrigger id="isolation">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">none</SelectItem>
-                  <SelectItem value="worktree">worktree</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-          {gitInitPrompt && (
-            <div className="rounded-md border border-orange-200 bg-orange-50 p-3 dark:border-orange-800 dark:bg-orange-950">
-              <p className="text-sm">
-                The selected directory is not a git repository. Worktree isolation requires git.
-                Initialize a git repository with <code className="text-xs bg-muted px-1 py-0.5 rounded">git init</code>?
-              </p>
-              <div className="mt-2 flex gap-2">
-                <Button type="button" size="sm" onClick={handleGitInitConfirm}>
-                  Yes, initialize
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setGitInitPrompt(false)}
-                >
-                  Cancel
-                </Button>
-              </div>
-            </div>
-          )}
-          {(createProject.error || saveConfig.error) && (
+          {createProject.error && (
             <p className="text-sm text-destructive">
-              {(createProject.error || saveConfig.error)?.message}
+              {createProject.error.message}
             </p>
           )}
           <div className="flex gap-2">
-            <Button type="submit" disabled={createProject.isPending || saveConfig.isPending}>
-              {createProject.isPending || saveConfig.isPending ? "Adding..." : "Add"}
+            <Button type="submit" disabled={createProject.isPending}>
+              {createProject.isPending ? "Adding..." : "Add"}
             </Button>
             <Button type="button" variant="outline" onClick={onCancel}>
               Cancel

--- a/gui/frontend/src/pages/SessionDetail.tsx
+++ b/gui/frontend/src/pages/SessionDetail.tsx
@@ -363,8 +363,6 @@ function SessionMetadata({ session }: { session: SessionDetailType }) {
           <dd>{session.role}</dd>
           <dt className="font-medium text-muted-foreground">Runtime</dt>
           <dd>{session.runtime}</dd>
-          <dt className="font-medium text-muted-foreground">Isolation</dt>
-          <dd>{session.isolation}</dd>
           <dt className="font-medium text-muted-foreground">Started</dt>
           <dd>{formatTime(session.started_at)}</dd>
           {session.ended_at && (


### PR DESCRIPTION
## Summary
- Remove isolation dropdown from `ConfigForm` (global settings) and update grid layout from 3 to 2 columns
- Remove isolation selector, git-init prompt, and related config save logic from project registration form (`ProjectList.tsx`)
- Remove isolation field from `SessionDetail` metadata display
- Remove `isolation` property from `Session` TypeScript interface

Closes #575

## Context
Part of the worktree isolation migration (epic #568). Isolation is now agent-controlled via the worktree skill, so user-facing isolation configuration is no longer needed. The backend changes were already merged in PR #580.

## Test plan
- [x] TypeScript compiles with no errors (`tsc --noEmit` passes)
- [x] No remaining `isolation` references in frontend source
- [ ] Verify ConfigForm renders correctly with Runtime and Memory fields
- [ ] Verify project registration form works without isolation selector
- [ ] Verify session detail page displays correctly without isolation row

🤖 Generated with [Claude Code](https://claude.com/claude-code)