### PR TITLE
Remove isolation from Session API and database schema

### DIFF
--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -35,7 +35,6 @@ CREATE TABLE IF NOT EXISTS sessions (
     project_id  INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
     role        TEXT NOT NULL,
     runtime     TEXT NOT NULL,
-    isolation   TEXT NOT NULL,
     status      TEXT NOT NULL DEFAULT 'starting',
     started_at  TEXT NOT NULL,
     ended_at    TEXT,
@@ -456,6 +455,15 @@ def _migrate(conn: sqlite3.Connection) -> None:
             PRAGMA foreign_keys=ON;
         """)
 
+    # Drop isolation column from sessions (added 2026-03-27).
+    # Isolation is now agent-controlled via the worktree skill.
+    cols = {
+        row[1]
+        for row in conn.execute("PRAGMA table_info(sessions)").fetchall()
+    }
+    if "isolation" in cols:
+        conn.execute("ALTER TABLE sessions DROP COLUMN isolation")
+
 
 @contextmanager
 def get_db(db_path: str):
@@ -693,7 +701,6 @@ def _upsert_session(
         role = first_agent.get("role", "unknown")
 
     runtime = data.get("runtime", "unknown")
-    isolation = data.get("isolation", "none")
     started_at = data.get("started_at", "")
 
     # Determine status and parse trace
@@ -722,15 +729,14 @@ def _upsert_session(
 
     conn.execute(
         """INSERT INTO sessions
-           (run_id, project_id, role, runtime, isolation, status,
+           (run_id, project_id, role, runtime, status,
             started_at, ended_at, duration_ms, exit_code, session_dir,
             task, summary, files_changed, interactive)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(run_id) DO UPDATE SET
              project_id  = excluded.project_id,
              role        = excluded.role,
              runtime     = excluded.runtime,
-             isolation   = excluded.isolation,
              status      = CASE WHEN sessions.status IN ('stopped', 'completed', 'failed') THEN sessions.status ELSE excluded.status END,
              started_at  = excluded.started_at,
              ended_at    = excluded.ended_at,
@@ -747,7 +753,6 @@ def _upsert_session(
             project_id,
             role,
             runtime,
-            isolation,
             status,
             started_at,
             trace_info.get("ended_at"),

--- a/gui/src/strawpot_gui/routers/schedules.py
+++ b/gui/src/strawpot_gui/routers/schedules.py
@@ -446,7 +446,7 @@ def schedule_history(schedule_id: int, conn=Depends(get_db_conn)):
         raise HTTPException(404, "Schedule not found")
 
     rows = conn.execute(
-        "SELECT run_id, project_id, role, runtime, isolation, status,"
+        "SELECT run_id, project_id, role, runtime, status,"
         "       started_at, ended_at, duration_ms, exit_code, task"
         "  FROM sessions WHERE schedule_id = ? ORDER BY started_at DESC"
         "  LIMIT 50",

--- a/gui/src/strawpot_gui/routers/sessions.py
+++ b/gui/src/strawpot_gui/routers/sessions.py
@@ -276,8 +276,6 @@ def launch_session_subprocess(
     # Load project config for defaults
     config = load_config(Path(working_dir))
     resolved_role = role or config.orchestrator_role
-    isolation = "none"
-
     # Resolve runtime: explicit override > explicit config > role default_agent > config default
     runtime = runtime_override
     if not runtime:
@@ -307,10 +305,10 @@ def launch_session_subprocess(
 
     conn.execute(
         """INSERT INTO sessions
-           (run_id, project_id, role, runtime, isolation, status,
+           (run_id, project_id, role, runtime, status,
             started_at, session_dir, task, user_task, schedule_id, interactive, conversation_id)
-           VALUES (?, ?, ?, ?, ?, 'starting', ?, ?, ?, ?, ?, ?, ?)""",
-        (run_id, project_id, resolved_role, runtime, isolation, now,
+           VALUES (?, ?, ?, ?, 'starting', ?, ?, ?, ?, ?, ?, ?)""",
+        (run_id, project_id, resolved_role, runtime, now,
          session_dir, task, user_task,
          schedule_id, 1 if interactive else 0, conversation_id),
     )
@@ -493,7 +491,7 @@ def list_all_sessions(
 
     offset = (page - 1) * per_page
     rows = conn.execute(
-        f"SELECT run_id, project_id, role, runtime, isolation, status,"
+        f"SELECT run_id, project_id, role, runtime, status,"
         f"       started_at, ended_at, duration_ms, exit_code, task, user_task"
         f"  FROM sessions{where} ORDER BY started_at DESC"
         f"  LIMIT ? OFFSET ?",
@@ -535,7 +533,7 @@ def list_sessions(
 
     offset = (page - 1) * per_page
     rows = conn.execute(
-        "SELECT run_id, project_id, role, runtime, isolation, status,"
+        "SELECT run_id, project_id, role, runtime, status,"
         "       started_at, ended_at, duration_ms, exit_code, task, user_task"
         "  FROM sessions WHERE project_id = ? ORDER BY started_at DESC"
         "  LIMIT ? OFFSET ?",
@@ -556,7 +554,7 @@ def get_session(project_id: int, run_id: str, conn=Depends(get_db_conn)):
     _refresh_session_status(conn, run_id)
 
     row = conn.execute(
-        "SELECT run_id, project_id, role, runtime, isolation, status,"
+        "SELECT run_id, project_id, role, runtime, status,"
         "       started_at, ended_at, duration_ms, exit_code, task, user_task,"
         "       session_dir, interactive"
         "  FROM sessions WHERE project_id = ? AND run_id = ?",

--- a/gui/tests/test_config.py
+++ b/gui/tests/test_config.py
@@ -16,7 +16,7 @@ class TestGlobalConfig:
 
     def test_put_and_get_global_config(self, client, tmp_path, monkeypatch):
         monkeypatch.setenv("STRAWPOT_HOME", str(tmp_path / "home"))
-        data = {"runtime": "codex", "isolation": "docker"}
+        data = {"runtime": "codex"}
 
         resp = client.put("/api/config/global", json=data)
         assert resp.status_code == 200

--- a/gui/tests/test_conversations.py
+++ b/gui/tests/test_conversations.py
@@ -395,11 +395,11 @@ def _insert_completed_session(
     fc_json = _json.dumps(files_changed) if files_changed else None
     conn.execute(
         "INSERT INTO sessions "
-        "(run_id, project_id, role, runtime, isolation, status, task, user_task, "
+        "(run_id, project_id, role, runtime, status, task, user_task, "
         "summary, exit_code, conversation_id, started_at, session_dir, "
         "files_changed, interactive) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        (run_id, project_id, "default", "claude-code", "none", status, task,
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (run_id, project_id, "default", "claude-code", status, task,
          user_task, summary, exit_code, conversation_id, started_at,
          session_dir, fc_json, int(interactive)),
     )

--- a/gui/tests/test_scheduler.py
+++ b/gui/tests/test_scheduler.py
@@ -164,10 +164,10 @@ class TestCheckAndFire:
             conn.execute(
                 "INSERT INTO sessions "
                 "(run_id, project_id, schedule_id, status, role, runtime, "
-                " isolation, started_at, session_dir) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " started_at, session_dir) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 ("run-active", project_id, sid, "running",
-                 "test", "test", "none", "2025-01-01T00:00:00", "/tmp"),
+                 "test", "test", "2025-01-01T00:00:00", "/tmp"),
             )
 
         launch_fn = MagicMock()
@@ -187,10 +187,10 @@ class TestCheckAndFire:
             conn.execute(
                 "INSERT INTO sessions "
                 "(run_id, project_id, schedule_id, status, role, runtime, "
-                " isolation, started_at, session_dir) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " started_at, session_dir) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 ("run-active", project_id, sid, "running",
-                 "test", "test", "none", "2025-01-01T00:00:00", "/tmp"),
+                 "test", "test", "2025-01-01T00:00:00", "/tmp"),
             )
 
         launch_fn = MagicMock(return_value="run-new")
@@ -305,10 +305,10 @@ class TestOneTimeScheduleFire:
             conn.execute(
                 "INSERT INTO sessions "
                 "(run_id, project_id, schedule_id, status, role, runtime, "
-                " isolation, started_at, session_dir) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " started_at, session_dir) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 ("run-block", project_id, sid, "running",
-                 "test", "test", "none", "2025-01-01T00:00:00", "/tmp"),
+                 "test", "test", "2025-01-01T00:00:00", "/tmp"),
             )
 
         launch_fn = MagicMock()
@@ -436,10 +436,10 @@ class TestConversationTargeting:
             conn.execute(
                 "INSERT INTO sessions "
                 "(run_id, project_id, conversation_id, status, role, runtime, "
-                " isolation, started_at, session_dir, task, summary, exit_code) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " started_at, session_dir, task, summary, exit_code) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 ("run-prior", project_id, conv_id, "completed",
-                 "test", "test", "none", "2025-01-01T00:00:00", "/tmp",
+                 "test", "test", "2025-01-01T00:00:00", "/tmp",
                  "earlier task", "did stuff", 0),
             )
 
@@ -520,10 +520,10 @@ class TestFireSchedule:
             conn.execute(
                 "INSERT INTO sessions "
                 "(run_id, project_id, conversation_id, status, role, runtime, "
-                " isolation, started_at, session_dir) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " started_at, session_dir) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 ("run-busy", project_id, conv_id, "running",
-                 "test", "test", "none", "2025-01-01T00:00:00", "/tmp"),
+                 "test", "test", "2025-01-01T00:00:00", "/tmp"),
             )
 
         launch_fn = MagicMock()
@@ -552,10 +552,10 @@ class TestRefreshActiveSessions:
             conn.execute(
                 "INSERT INTO sessions "
                 "(run_id, project_id, status, role, runtime, "
-                " isolation, started_at, session_dir) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                " started_at, session_dir) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
                 ("run-stale", project_id, "starting",
-                 "test", "test", "none", stale_time, session_dir),
+                 "test", "test", stale_time, session_dir),
             )
 
         scheduler = Scheduler(db_path, MagicMock())
@@ -578,10 +578,10 @@ class TestRefreshActiveSessions:
             conn.execute(
                 "INSERT INTO sessions "
                 "(run_id, project_id, status, role, runtime, "
-                " isolation, started_at, session_dir) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                " started_at, session_dir) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
                 ("run-recent", project_id, "starting",
-                 "test", "test", "none", recent_time, session_dir),
+                 "test", "test", recent_time, session_dir),
             )
 
         scheduler = Scheduler(db_path, MagicMock())
@@ -600,10 +600,10 @@ class TestRefreshActiveSessions:
             conn.execute(
                 "INSERT INTO sessions "
                 "(run_id, project_id, status, role, runtime, "
-                " isolation, started_at, session_dir) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                " started_at, session_dir) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
                 ("run-nodir", project_id, "starting",
-                 "test", "test", "none", stale_time, "/nonexistent/path"),
+                 "test", "test", stale_time, "/nonexistent/path"),
             )
 
         scheduler = Scheduler(db_path, MagicMock())

--- a/gui/tests/test_schedules.py
+++ b/gui/tests/test_schedules.py
@@ -544,10 +544,10 @@ class TestScheduleRuns:
             conn.execute(
                 "INSERT INTO sessions "
                 "(run_id, project_id, schedule_id, status, role, runtime, "
-                " isolation, started_at, session_dir) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " started_at, session_dir) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 ("run-1", project_id, sid, "completed",
-                 "test", "test", "none", "2025-01-01T00:00:00", "/tmp"),
+                 "test", "test", "2025-01-01T00:00:00", "/tmp"),
             )
 
         resp = client.get("/api/schedules/runs")
@@ -630,10 +630,10 @@ class TestRerunScheduleRun:
             conn.execute(
                 "INSERT INTO sessions "
                 "(run_id, project_id, schedule_id, status, role, runtime, "
-                " isolation, started_at, session_dir, task, user_task) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " started_at, session_dir, task, user_task) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 ("run-orig", project_id, sid, "completed",
-                 "test", "test", "none", "2025-01-01T00:00:00", "/tmp",
+                 "test", "test", "2025-01-01T00:00:00", "/tmp",
                  "context\n---\noriginal task", "original task"),
             )
 
@@ -659,10 +659,10 @@ class TestRerunScheduleRun:
             conn.execute(
                 "INSERT INTO sessions "
                 "(run_id, project_id, status, role, runtime, "
-                " isolation, started_at, session_dir, task) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " started_at, session_dir, task) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 ("run-manual", project_id, "completed",
-                 "test", "test", "none", "2025-01-01T00:00:00", "/tmp",
+                 "test", "test", "2025-01-01T00:00:00", "/tmp",
                  "manual task"),
             )
         resp = client.post("/api/schedules/runs/run-manual/rerun")

--- a/gui/tests/test_sessions_sync.py
+++ b/gui/tests/test_sessions_sync.py
@@ -29,7 +29,6 @@ def _write_session(base_dir, run_id, *, archived=False, **overrides):
     data = {
         "run_id": run_id,
         "working_dir": str(base_dir),
-        "isolation": "none",
         "runtime": "strawpot-claude-code",
         "denden_addr": "127.0.0.1:9700",
         "started_at": "2026-01-01T12:00:00+00:00",
@@ -156,7 +155,6 @@ class TestSyncSessions:
         assert row["project_id"] == pid
         assert row["role"] == "orchestrator"
         assert row["runtime"] == "strawpot-claude-code"
-        assert row["isolation"] == "none"
         assert row["status"] == "failed"  # no trace → failed
 
     def test_archived_session_with_trace(self, client, tmp_path):
@@ -173,7 +171,7 @@ class TestSyncSessions:
                 "trace_id": "run_traced",
                 "span_id": "s1",
                 "data": {"run_id": "run_traced", "role": "orchestrator",
-                         "runtime": "strawpot-claude-code", "isolation": "none"},
+                         "runtime": "strawpot-claude-code"},
             },
             {
                 "ts": "2026-01-01T12:05:01+00:00",

--- a/gui/tests/test_stats.py
+++ b/gui/tests/test_stats.py
@@ -190,10 +190,10 @@ class TestStatsEndpoint:
                 exit_code = 0 if status == "completed" else 1
                 conn.execute(
                     "INSERT INTO sessions "
-                    "(run_id, project_id, role, runtime, isolation, status, task, "
+                    "(run_id, project_id, role, runtime, status, task, "
                     "exit_code, started_at, duration_ms, session_dir) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                    (run_id, pid, "default", "claude-code", "none", status,
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (run_id, pid, "default", "claude-code", status,
                      "test task", exit_code, today, duration_ms, str(tmp_path)),
                 )
 


### PR DESCRIPTION
## Summary
- Drops the `isolation TEXT NOT NULL` column from the sessions table schema and adds a database migration (`ALTER TABLE sessions DROP COLUMN isolation`) for existing databases
- Removes isolation from all session INSERT/UPSERT operations in `db.py` and `sessions.py`
- Removes isolation from all SELECT queries in `sessions.py` and `schedules.py`
- Updates 6 test files to remove isolation from test fixture INSERT statements

Part of the worktree isolation migration (epic #568). Isolation is now agent-controlled via the worktree skill, so it no longer needs to be stored in the database or exposed through the API.

Closes #577

## Test plan
- [x] All 542 existing tests pass
- [x] No TypeScript errors in frontend
- [x] Migration handles existing databases (checks column existence before dropping)
- [ ] Verify new sessions can be created without isolation field
- [ ] Verify existing databases with isolation column are migrated cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)