### PR TITLE
docs: update documentation for worktree isolation migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ StrawPot lets agents figure out how to solve the task.
 
 - Agents compose other agents dynamically, with no fixed pipelines
   or hardcoded flows
-- Concurrent execution with isolation, memory, and full traceability
+- Concurrent execution with memory and full traceability
 - Outputs vary. Infrastructure does not.
 
 ## Example: how agents coordinate
@@ -64,7 +64,7 @@ Workflows improve over time as roles are reused and refined.
 
 - Python 3.11 or later
 - [Node.js 18+](https://nodejs.org) (required by Claude Code agent)
-- [Git](https://git-scm.com) (required for worktree isolation)
+- [Git](https://git-scm.com) (required for worktree skill)
 - [GitHub CLI](https://cli.github.com) (`gh`) — optional, for PR workflows
 
 Run `strawpot doctor` after install to verify your setup.
@@ -123,11 +123,11 @@ OpenHands, Pi, or your own, assigned per role, mixed in the same
 session. Adding a new runtime means implementing two commands:
 `setup` and `build`.
 
-**Git worktree isolation**
-Every session gets its own git branch in an isolated worktree.
-Multiple sessions run concurrently without conflicts. Crash recovery
-is automatic. Changes merge back via configurable strategies (local
-patch, PR, or auto-detect).
+**Agent-controlled worktree isolation**
+Agents decide when to use isolation via the worktree skill. When
+an agent needs an isolated working copy, it creates a git worktree
+on demand. Changes merge back automatically (local patch or PR).
+No user configuration needed.
 
 **Persistent memory across sessions**
 Three-tier context cards: semantic (always included), retrieval
@@ -154,7 +154,7 @@ code.
 - Not deterministic: same input may produce different artifacts
 - Not autonomous: agents need well-defined roles to be effective
 
-The orchestration, isolation, tracing, and memory systems are solid.
+The orchestration, tracing, and memory systems are solid.
 The AI output quality improves through better roles, skills, and
 community iteration.
 
@@ -172,13 +172,12 @@ User task → StrawPot → Role (ai-ceo)
 
 When you run `strawpot start`:
 
-1. Creates an isolated environment (worktree or project dir)
-2. Starts the Denden gRPC server for agent communication
-3. Retrieves memory context from past sessions
-4. Launches the orchestrator agent (e.g. ai-ceo)
-5. Agents delegate tasks to sub-roles automatically
-6. Required roles and skills are resolved from StrawHub
-7. On exit, records results to memory and cleans up
+1. Starts the Denden gRPC server for agent communication
+2. Retrieves memory context from past sessions
+3. Launches the orchestrator agent (e.g. ai-ceo)
+4. Agents delegate tasks to sub-roles automatically
+5. Required roles and skills are resolved from StrawHub
+6. On exit, records results to memory and cleans up
 
 ## Core Concepts
 
@@ -259,7 +258,6 @@ Project: `strawpot.toml` (project root)
 
 ```toml
 runtime = "strawpot-claude-code"
-isolation = "none"                      # none | worktree
 memory = "dial"                         # memory provider; "" to disable
 
 [denden]

--- a/TODO.md
+++ b/TODO.md
@@ -16,9 +16,8 @@
 
   **Why:** Phase 2 (conversation history file) covers most use cases — full
   output for last 5 turns, recap for older turns, readable on demand. The
-  service adds value mainly for worktree isolation (DB access, no file
-  coordination) and queryable search across long conversations. Not urgent —
-  the history file works well for typical conversation lengths.
+  service adds value mainly for queryable search across long conversations.
+  Not urgent — the history file works well for typical conversation lengths.
 
   **Depends on:** Wrapper protocol supporting tool registration (wrappers must
   expose conversation tools to the agent). See `designs/context/DESIGN.md`

--- a/designs/DESIGN.md
+++ b/designs/DESIGN.md
@@ -31,10 +31,14 @@ strawpot start          ← CLI entry point, CWD = working dir
       └─ Sub-agent B (same worktree, reviewer role)
 ```
 
-All agents in a session share the same working directory. With `isolation=none`
-(default), agents work directly in the project dir. With `isolation=worktree`,
-a git worktree is created per session — agents see each other's changes and
-cleanup is a single `git worktree remove`.
+All agents in a session share the same working directory (the project
+directory). When an agent needs an isolated working copy, it uses the
+worktree skill to create a git worktree on demand.
+
+> **Note:** Session-level `isolation` config was removed in epic #568.
+> Agents now control worktree isolation themselves via the worktree
+> skill. The `Isolator` protocol and `NoneIsolator` remain as internal
+> plumbing (sessions always use `NoneIsolator`).
 
 ---
 
@@ -393,10 +397,13 @@ class Isolator(Protocol):
 
 Implementations:
 - `NoneIsolator` — returns `base_dir` as-is, cleanup is a no-op.
-  Agents work directly in the project directory.
-- `WorktreeIsolator` — creates a worktree per session. Raises `ValueError`
-  if the project is not already a git repo.
-- Future: `DockerIsolator`.
+  Agents work directly in the project directory. This is the only
+  isolator used at session level since session-level isolation was
+  removed (epic #568).
+
+> **Historical note:** `WorktreeIsolator` previously created a
+> worktree per session. This has been replaced by agent-controlled
+> worktree isolation via the worktree skill.
 
 ### Config (`config.py`)
 
@@ -404,7 +411,6 @@ Implementations:
 @dataclass
 class StrawPotConfig:
     runtime: str = "strawpot-claude-code"
-    isolation: str = "none"
     denden_addr: str = "127.0.0.1:9700"
     orchestrator_role: str = "ai-ceo"
     max_depth: int = 3
@@ -496,7 +502,7 @@ Convenience methods (each calls `emit` + `store_artifact` as needed):
 
 | Method | Returns | Stores artifact |
 |--------|---------|-----------------|
-| `session_start(run_id, role, runtime, isolation, task="")` | span_id | task → `task_ref` |
+| `session_start(run_id, role, runtime, task="")` | span_id | task → `task_ref` |
 | `session_end(span_id, merge_action, duration_ms, output="")` | — | output → `output_ref` |
 | `delegate_start(role, parent_span, context, depth=0, session_id="", parent_agent_id=None)` | span_id | context → `context_ref` |
 | `delegate_end(span_id, exit_code, summary, duration_ms, output="", role="", session_id="", agent_id="")` | — | output → `output_ref` |
@@ -532,7 +538,6 @@ The span tree enables call-tree reconstruction:
 ```toml
 # strawpot.toml (project root)
 runtime = "strawpot-claude-code"
-isolation = "none"               # none | worktree | docker
 
 [denden]
 addr = "127.0.0.1:9700"
@@ -601,16 +606,13 @@ enabled = true
      runtime = InteractiveWrapperRuntime(wrapper)            # interactive → tmux session
    else:
      runtime = DirectWrapperRuntime(wrapper)                 # fallback → direct terminal attach
-5. isolator = resolve_isolator(config.isolation)             # none | worktree | docker
+5. isolator = NoneIsolator()  # agents control worktree isolation via skill
 6. session = Session(config, wrapper, runtime, isolator)
 7. session.start():
    a. run_id = "run_" + uuid4()
       → if config.trace: create Tracer(session_dir, run_id), emit session_start
-   b. Create isolated env (or use CWD directly):
-      env = isolator.create(session_id=run_id, base_dir=working_dir)
-      → isolation=none:     env.path = working_dir (no-op)
-      → isolation=worktree: git worktree add <STRAWPOT_HOME>/worktrees/<hash>/<run_id> ...
-      All agents will work in env.path from here on.
+   b. env = isolator.create(session_id=run_id, base_dir=working_dir)
+      → env.path = working_dir (agents work directly in project dir)
    c. Start DenDenServer(addr=config.denden_addr)
       - If port was explicitly provided (--port flag): fail with error if taken
       - Otherwise (default from config): try configured port, if taken bind to
@@ -1183,78 +1185,27 @@ cleanup(env, base_dir):
   pass  # no-op
 ```
 
-Simplest option — good for single-agent sessions, non-coding workflows,
-or when the user manages their own branching.
+Only implementation currently used. Sessions always run in the project
+directory. Agents that need isolation use the worktree skill on demand.
 
-### WorktreeIsolator (`isolation/worktree.py`)
-
-Creates one git worktree per session. Multiple concurrent sessions are
-safe — each gets its own branch.
-
-Worktrees are stored outside the project tree under `STRAWPOT_HOME` to
-avoid interfering with IDEs, file watchers, and gitignore.
-
-```
-create(session_id, base_dir):
-  if not is_git_repo(base_dir): raise ValueError
-
-  path = <STRAWPOT_HOME>/worktrees/<project_hash>/<session_id>
-  branch = strawpot/<session_id>
-  git worktree add <path> -b <branch>
-  return IsolatedEnv(path, branch)
-
-cleanup(env, base_dir):
-  # see Session Cleanup below — action-based merge
-  git worktree remove <path> --force
-  git branch -D <branch>   # only if no PR was created
-```
-
-Pull-before-session and merge behavior are handled by session.py, not here.
-The isolator only manages worktree creation and removal.
-
-### DockerIsolator (future)
-
-Runs agents inside a container. The container gets a copy of the working
-directory (not a bind-mount — true isolation). Multiple concurrent sessions
-are safe — each gets its own container.
-
-Git is initialized inside the container at create time purely for patch
-generation — it never leaks to the host. Changes are exported as a unified
-diff patch, not via `docker cp` (which would copy the `.git` directory).
-
-```
-create(session_id, base_dir):
-  container_id = docker run ... -v <base_dir>:/src:ro  # read-only mount for initial copy
-  # copy base_dir into container working dir
-  docker exec <container> git init && git add -A && git commit -m "initial"
-  return IsolatedEnv(path="/workspace", container_id=container_id)
-
-cleanup(env):
-  # see Session Cleanup below — extract patch, apply to host, remove container
-  patch = docker exec <container> git diff HEAD
-  apply_patch(patch, host_dir)   # uses git apply or patch (see below)
-  docker rm <container>          # .git inside container dies here
-```
+> **Historical note:** `WorktreeIsolator` previously created a
+> session-level worktree. This was removed in epic #568 in favor of
+> agent-controlled worktree isolation via the worktree skill.
 
 ---
 
 ## Session Tracking
 
 `.strawpot/sessions/<run_id>/` holds one directory per active session,
-with `session.json` inside. Multiple concurrent sessions are allowed for
-all isolation modes. For `none`, concurrent sessions write to the same
-directory — overlapping changes are the user's responsibility.
+with `session.json` inside. Multiple concurrent sessions are allowed —
+concurrent sessions write to the same directory, so overlapping changes
+are the user's responsibility.
 
 ---
 
 ## Session Cleanup
 
-When a session ends (Ctrl+C, agent quit, or crash recovery), cleanup
-depends on the isolation mode.
-
-### `isolation = none`
-
-Nothing to do. Changes are already in the project directory.
+When a session ends (Ctrl+C, agent quit, or crash recovery):
 
 ```
 session.stop():
@@ -1263,92 +1214,10 @@ session.stop():
   3. Remove session directory
 ```
 
-### `isolation = worktree`
-
-Cleanup is action-based — no configuration needed. StrawPot detects
-what the agent actually did:
-
-```
-session.stop():
-  1. Kill remaining sub-agents
-  2. Stop denden server
-  3. Check: did the agent create a PR for this branch?
-     → YES (PR exists): clean up worktree, keep remote branch for PR
-     → NO (no PR): generate patch, apply as unstaged changes to base dir
-       - git diff <base_branch>..strawpot/<run_id>
-       - git apply --check <patch>
-         → no conflicts: apply, remove worktree + delete branch
-         → conflicts: show conflicting files, prompt user (see below)
-  4. Remove session directory
-```
-
-### `isolation = docker` (future)
-
-The container has git initialized inside it at `create()` time purely for
-diff tracking. The container's `.git` never touches the host — it dies
-with `docker rm`. Cleanup follows the same action-based approach as
-worktree isolation:
-
-```
-session.stop():
-  1. Kill remaining sub-agents (inside container)
-  2. Stop denden server
-  3. Check: did the agent create a PR?
-     → YES (PR exists): docker rm <container>, done
-     → NO (no PR): generate patch, apply as unstaged changes to host dir
-       - docker exec <container> git diff HEAD
-       - Apply patch to host dir (see Patch Application below)
-         → no conflicts: apply, docker rm <container>
-         → conflicts: show conflicting files, prompt user (see below)
-  4. Remove session directory
-```
-
-### Patch Application
-
-StrawPot picks the right tool based on the host directory:
-
-```
-if is_git_repo(host_dir):
-    use git apply          # better 3-way merge support
-else:
-    use patch              # POSIX standard, no git needed, no side effects
-```
-
-The `patch` fallback means docker isolation works on non-git host
-directories without creating a `.git` on the host.
-
-### Conflict Resolution
-
-When no PR was created, both `worktree` and `docker` use the same
-conflict resolution flow for patch-apply. (If a PR exists, there are
-no local conflicts — they're handled through the PR review process.)
-
-Conflicts are detected before applying — if the patch doesn't apply
-cleanly, strawpot lists the conflicting files and prompts:
-
-```
-Conflict: 2 files changed on both sides since session started.
-  src/auth.py
-  src/config.py
-
-  [a] Apply all — override conflicts with session's changes
-  [s] Skip conflicts — apply only non-conflicting changes
-  [d] Discard all — drop all session changes
-```
-
-| Option | git host (`git apply`) | non-git host (`patch`) |
-|---|---|---|
-| Detect conflicts | `git apply --check` | `patch --dry-run` |
-| Apply all (override) | `git apply --3way` | `patch --force` |
-| Skip conflicts | `git apply --reject`, drop `.rej` | `patch`, skip failed hunks |
-| Discard all | don't apply | don't apply |
-
-After any choice, the worktree is removed and the branch is deleted
-(worktree), or the container is removed (docker).
-
-StrawPot does not provide manual merge resolution. The three options
-cover the common cases; for anything more nuanced the user can use
-`isolation=none` and manage merges themselves.
+Changes are already in the project directory — no merge step needed at
+session level. If an agent used the worktree skill during the session,
+the skill handles its own worktree cleanup (merging changes back or
+preserving the branch for a PR).
 
 ### Crash Recovery
 
@@ -1385,12 +1254,8 @@ the same session directory:
 {
   "run_id": "run_abc123",
   "working_dir": "/home/user/project",
-  "isolation": "worktree",
   "runtime": "strawpot-claude-code",
   "denden_addr": "127.0.0.1:9700",
-  "worktree": "~/.strawpot/worktrees/<project_hash>/run_abc123",
-  "worktree_branch": "strawpot/run_abc123",
-  "base_branch": "main",
   "started_at": "2026-02-27T10:00:00Z",
   "pid": 54321,
   "agents": {
@@ -1433,7 +1298,7 @@ One file per session: `.strawpot/sessions/<run_id>/session.jsonl`
 Each line is a JSON object:
 
 ```json
-{"ts": "2026-02-27T10:00:00Z", "level": "info", "event": "session_started", "run_id": "run_abc123", "msg": "Session started", "data": {"isolation": "worktree", "runtime": "strawpot-claude-code"}}
+{"ts": "2026-02-27T10:00:00Z", "level": "info", "event": "session_started", "run_id": "run_abc123", "msg": "Session started", "data": {"runtime": "strawpot-claude-code"}}
 {"ts": "2026-02-27T10:00:01Z", "level": "info", "event": "agent_spawned", "run_id": "run_abc123", "agent_id": "agent_xyz", "msg": "Spawned orchestrator", "data": {"role": "orchestrator"}}
 {"ts": "2026-02-27T10:01:00Z", "level": "info", "event": "delegate_request", "run_id": "run_abc123", "agent_id": "agent_xyz", "msg": "Delegation requested", "data": {"role": "implementer", "task": "implement auth"}}
 {"ts": "2026-02-27T10:05:00Z", "level": "error", "event": "agent_timeout", "run_id": "run_abc123", "agent_id": "agent_abc", "msg": "Agent timed out after 300s"}
@@ -1443,7 +1308,7 @@ Each line is a JSON object:
 
 | Event | Level | Description |
 |---|---|---|
-| `session_started` | info | Session created, isolation env ready |
+| `session_started` | info | Session created and ready |
 | `session_stopped` | info | Clean shutdown completed |
 | `denden_started` | info | gRPC server bound to address |
 | `denden_stopped` | info | gRPC server shut down |
@@ -1546,7 +1411,6 @@ expands this wildcard to all globally installed roles.
 
 ```
 strawpot start  [--role SLUG] [--runtime NAME]
-                [--isolation none|worktree|docker]
                 [--pull auto|always|never|prompt]
                 [--host HOST] [--port PORT]
 strawpot sessions                    # list all running sessions
@@ -1582,7 +1446,7 @@ is prompted for conflict resolution when patch-applying changes.
 
 `sessions` reads all session directories from `.strawpot/sessions/`,
 loads `session.json` from each, checks if each process is still alive (via
-`pid`), and displays a table of running sessions with run_id, isolation mode,
+`pid`), and displays a table of running sessions with run_id,
 runtime, denden port, and uptime. Stale sessions (dead pid) are marked
 accordingly.
 

--- a/designs/context/DESIGN.md
+++ b/designs/context/DESIGN.md
@@ -244,7 +244,7 @@ Write a `.strawpot/conversations/{id}/history.md` file to the project working di
 - Zero context window cost
 - Already gitignored (`.strawpot/` is in `.gitignore`)
 
-**Limitation:** Awkward with worktree isolation — the file must be written in the worktree directory, which is created by the CLI, not the GUI. Requires coordination between the GUI (which builds context) and the CLI (which creates the worktree). This is solvable but adds coupling.
+**Limitation:** If an agent uses the worktree skill, the file must be written in the worktree directory. This is solvable but adds coupling between the GUI (which builds context) and the worktree lifecycle.
 
 **Changes required:**
 
@@ -271,7 +271,7 @@ Denden is the communication/routing layer (gRPC transport, tool dispatch). The c
 
 **Why not the history file:**
 
-- Works with worktree isolation — the service has DB access, no file coordination needed
+- Works when agents use worktree skill — the service has DB access, no file coordination needed
 - Queryable — agent can ask for specific turns or search, not read a wall of text
 - Extensible — `conversation.search()` could use embeddings; `conversation.decisions()` could filter by topic
 

--- a/designs/gui/DESIGN.md
+++ b/designs/gui/DESIGN.md
@@ -184,7 +184,7 @@ Location: `.strawpot/sessions/<run_id>/session.json`
 {
   "run_id": "a1b2c3d4e5f6",
   "working_dir": "/path/to/project",
-  "isolation": "none | worktree",
+
   "runtime": "strawpot-claude-code",
   "denden_addr": "127.0.0.1:9700",
   "started_at": "2026-01-01T12:00:00+00:00",
@@ -225,7 +225,7 @@ Event types and their `data` fields:
 
 | Event | Data fields |
 |-------|-------------|
-| `session_start` | `run_id`, `role`, `runtime`, `isolation` |
+| `session_start` | `run_id`, `role`, `runtime` |
 | `session_end` | `merge_action`, `duration_ms` |
 | `delegate_start` | `role`, `context_ref`, `parent_span` |
 | `delegate_end` | `exit_code`, `summary`, `duration_ms` |
@@ -259,7 +259,7 @@ Project: `<project>/strawpot.toml` (overrides global)
 | Field | Type | Default |
 |-------|------|---------|
 | `runtime` | str | `"strawpot-claude-code"` |
-| `isolation` | str | `"none"` |
+
 | `denden_addr` | str | `"127.0.0.1:9700"` |
 | `orchestrator_role` | str | `"ai-ceo"` |
 | `max_depth` | int | `3` |
@@ -300,8 +300,8 @@ Home page showing everything at a glance.
 
 ### 2. Project Management
 
-**Project list** — all registered projects with directory path, runtime,
-isolation mode.
+**Project list** — all registered projects with directory path and
+runtime.
 
 **Project detail page:**
 
@@ -343,7 +343,7 @@ chat panel where agents can ask the user questions via `ask_user`.
 - Context file attachment (@ button to attach project files)
 - Role selector from installed roles (datalist with validation)
 - Collapsible advanced options:
-  - Runtime and isolation overrides
+  - Runtime override
   - Custom system prompt textarea (appended to role instructions)
 - Loading state during launch, success/error toasts on completion
 - Navigation to the new session on success
@@ -371,7 +371,7 @@ duration, stop button) is always visible above the tabs.
 
 | Tab | Contents |
 |-----|----------|
-| **Overview** | Task description, summary (on completion), detail grid (status, role, runtime, isolation, started/ended, exit code) |
+| **Overview** | Task description, summary (on completion), detail grid (status, role, runtime, started/ended, exit code) |
 | **Agent Tree** | Real-time delegation tree (see [Real-Time Agent Tree](#real-time-agent-tree)) — the primary tab for active sessions |
 | **Logs** | Agent selector + terminal-style log viewer (see [Agent Log Streaming](#agent-log-streaming)) |
 | **Trace Events** | Span timeline from `trace.jsonl` with durations and clickable artifact refs |
@@ -955,7 +955,6 @@ CREATE TABLE sessions (
     project_id  INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
     role        TEXT NOT NULL,
     runtime     TEXT NOT NULL,
-    isolation   TEXT NOT NULL,
     status      TEXT NOT NULL DEFAULT 'starting',  -- starting | running | completed | failed | archived
     started_at  TEXT NOT NULL,
     ended_at    TEXT,
@@ -993,7 +992,7 @@ data source.
 **Session index sync:** On GUI startup, scan all registered project
 session directories and upsert rows into the `sessions` table. For
 each session directory, read `session.json` for core fields (`run_id`,
-`role`, `runtime`, `isolation`, `started_at`, `session_dir`) and parse
+`role`, `runtime`, `started_at`, `session_dir`) and parse
 `trace.jsonl` for completion fields (`exit_code`, `summary`,
 `duration_ms`, `ended_at` from `session_end` / `delegate_end` events).
 During runtime, session rows are created on launch and updated via

--- a/designs/imu/DESIGN.md
+++ b/designs/imu/DESIGN.md
@@ -63,11 +63,11 @@ from the CLI, sessions go under the current directory's
 `.strawpot/sessions/`. When launched from the GUI, sessions go to
 `~/.strawpot/sessions/` (working directory: `~`).
 
-### No Isolation
+### No Worktree Isolation
 
-Bot Imu always runs with `isolation: none`. It needs to read and write real
-config files, invoke real CLI commands, and manage real cron schedules.
-Worktree isolation would defeat the purpose.
+Bot Imu's agents should not use the worktree skill. They need to read
+and write real config files, invoke real CLI commands, and manage real
+cron schedules. Worktree isolation would defeat the purpose.
 
 ---
 
@@ -363,9 +363,6 @@ metadata:
 # Default agent runtime
 runtime = "strawpot-claude-code"
 
-# Isolation mode: "none" or "worktree"
-isolation = "none"
-
 # Orchestrator settings
 orchestrator_role = "orchestrator"
 permission_mode = "default"
@@ -650,7 +647,7 @@ ls <project>/.strawpot/sessions/
 cat <project>/.strawpot/sessions/<run_id>/session.json | python3 -m json.tool
 ```
 
-Key fields: `run_id`, `working_dir`, `role`, `runtime`, `isolation`,
+Key fields: `run_id`, `working_dir`, `role`, `runtime`,
 `started_at`, `pid`, `task`, `agents` (map of agent_id → agent info).
 
 ## Read Trace Events

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -23,10 +23,6 @@ Settings are merged in order (later overrides earlier):
 # Options: strawpot-claude-code, codex, openhands, or any custom agent name
 runtime = "strawpot-claude-code"
 
-# Isolation strategy
-# Options: none, worktree, docker
-isolation = "none"
-
 # ── Denden gRPC Server ──────────────────────────────────
 [denden]
 addr = "127.0.0.1:9700"

--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -17,8 +17,6 @@ User
  ▼
 strawpot start              ← CLI entry point
  │
- ├─ Isolate (optional)      ← none | worktree | docker
- │
  ├─ Denden gRPC server      ← listens on 127.0.0.1:9700
  │
  └─ Orchestrator agent       ← Claude Code / Codex / OpenHands
@@ -29,7 +27,7 @@ strawpot start              ← CLI entry point
       1. Policy check (role allowed? depth limit?)
       2. Resolve role + skills from StrawHub
       3. Retrieve memory context from provider
-      4. Spawn sub-agent in session worktree
+      4. Spawn sub-agent in project directory
       5. Wait for completion, record to memory
       6. Return result to caller
       │
@@ -39,7 +37,10 @@ strawpot start              ← CLI entry point
       └─ Sub-agent B (reviewer role)
 ```
 
-All agents in a session share the same working directory. With worktree isolation, a git worktree is created per session — agents see each other's changes and cleanup is a single merge operation.
+All agents in a session share the same project directory. When an
+agent needs an isolated working copy (e.g., for a multi-file
+refactor), it uses the [worktree skill](/concepts/isolation) to
+create a git worktree on demand.
 
 ## Package Structure
 
@@ -96,7 +97,9 @@ class AgentRuntime(Protocol):
 
 ### Isolator
 
-Creates one isolated environment per session:
+Internal protocol for environment setup. Sessions run directly
+in the project directory (`NoneIsolator`). Agents that need
+isolation use the [worktree skill](/concepts/isolation) instead.
 
 ```python
 class Isolator(Protocol):

--- a/docs/concepts/isolation.mdx
+++ b/docs/concepts/isolation.mdx
@@ -1,14 +1,63 @@
 ---
 title: Isolation
-description: Environment strategies for agent sessions
+description: How agents use worktree isolation on demand
 ---
 
-StrawPot agents work directly in your project directory. All agents in a session — orchestrator and sub-agents — share the same working directory.
+StrawPot agents work directly in your project directory. All
+agents in a session — orchestrator and sub-agents — share the
+same working directory.
 
-## Agent-Controlled Isolation
+## Agent-Controlled Worktree Isolation
 
-For tasks that need isolated working copies (e.g., multi-file refactors, risky changes), agents can use the [worktree skill](/skills/worktree) to create and manage git worktrees on demand. This gives agents fine-grained control over when and how isolation is used, rather than applying it to the entire session.
+Isolation is not a session-level setting. Instead, agents decide
+when to use isolation based on the task at hand.
+
+For tasks that need isolated working copies (e.g., multi-file
+refactors, risky changes), agents use the
+[worktree skill](/skills/worktree) to create and manage git
+worktrees on demand. The worktree skill:
+
+- Creates a temporary git worktree with its own branch
+- Lets the agent work without affecting the main working
+  directory
+- Merges changes back (or opens a PR) when the agent is done
+- Cleans up the worktree automatically
+
+This gives agents fine-grained control over when and how
+isolation is used, rather than applying it blanket to every
+session. Most tasks run directly in the project directory;
+only tasks that benefit from isolation use it.
+
+### Example
+
+An agent with the worktree skill attached can create an
+isolated environment mid-task:
+
+```
+Agent decides to refactor auth module
+  → enters worktree (new branch: strawpot/refactor-auth)
+  → makes changes in isolation
+  → opens PR from the worktree branch
+  → exits worktree (cleanup automatic)
+```
+
+No user configuration is required. The agent's role determines
+whether the worktree skill is available.
+
+## Previous Behavior
+
+Earlier versions of StrawPot supported a session-level
+`isolation` setting (`none`, `worktree`) in `strawpot.toml` and
+a `--isolation` CLI flag. This has been removed. Agents now
+control isolation themselves via the worktree skill, which is
+more flexible — a single session can use isolation for some
+tasks and not others.
+
+If your `strawpot.toml` still contains an `isolation` key, it
+is ignored. You can safely remove it.
 
 ## Docker Isolation
 
-Container-based isolation is planned but not yet implemented. It will provide full environment isolation including system dependencies, network, and filesystem.
+Container-based isolation is planned but not yet implemented. It
+will provide full environment isolation including system
+dependencies, network, and filesystem.

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -3,7 +3,8 @@ title: Sessions
 description: Session lifecycle, crash recovery, and worktree merge behavior
 ---
 
-A session is the unit of work in StrawPot. It encapsulates an isolated environment, a Denden server, and all spawned agents.
+A session is the unit of work in StrawPot. It encapsulates a
+working environment, a Denden server, and all spawned agents.
 
 ## Lifecycle
 
@@ -12,19 +13,20 @@ When you run `strawpot start`:
 1. **Load config** — Merge global, project, and CLI flag settings
 2. **Resolve agent** — Find the agent runtime (project-local → global), auto-install if needed
 3. **Validate** — Check required tools and environment variables
-4. **Create isolation** — Set up worktree or use project directory directly
-5. **Start Denden** — Launch gRPC server on `127.0.0.1:9700`
-6. **Resolve memory provider** — Load the configured provider (default: `dial`), auto-install if needed
-7. **Resolve orchestrator role** — Fetch from StrawHub, stage dependencies
-8. **Spawn orchestrator** — Launch the agent with role, skills, and memory context in tmux (or direct terminal)
-9. **Block** — Wait for the orchestrator to exit
-10. **Cleanup** — Kill sub-agents, stop Denden, merge changes, remove worktree
+4. **Start Denden** — Launch gRPC server on `127.0.0.1:9700`
+5. **Resolve memory provider** — Load the configured provider (default: `dial`), auto-install if needed
+6. **Resolve orchestrator role** — Fetch from StrawHub, stage dependencies
+7. **Spawn orchestrator** — Launch the agent with role, skills, and memory context in tmux (or direct terminal)
+8. **Block** — Wait for the orchestrator to exit
+9. **Cleanup** — Kill sub-agents, stop Denden
 
 Session state is tracked in `.strawpot/sessions/<session_id>/session.json`.
 
 ## Worktree Merge Behavior
 
-When a worktree session ends, StrawPot detects what the agent actually did and acts accordingly — no configuration needed:
+When an agent uses the [worktree skill](/concepts/isolation) to
+create an isolated working copy, StrawPot detects what the agent
+actually did and acts accordingly — no configuration needed:
 
 | Agent action | What happens at cleanup |
 |-------------|------------------------|
@@ -141,7 +143,7 @@ This separation keeps the event stream small and scannable while preserving full
 
 | Event | When | Key data |
 |-------|------|----------|
-| `session_start` | Session begins | role, runtime, isolation, task_ref |
+| `session_start` | Session begins | role, runtime, task_ref |
 | `session_end` | Session stops | merge_action, duration_ms, output_ref, files_changed |
 | `delegate_start` | Delegation begins | role, depth, context_ref, session_id, parent_agent_id |
 | `delegate_end` | Delegation completes | exit_code, summary, duration_ms, output_ref, role, session_id, agent_id |

--- a/docs/gui/quickstart.mdx
+++ b/docs/gui/quickstart.mdx
@@ -26,10 +26,7 @@ strawpot gui --port 9000
 2. Click **Add Project**
 3. Browse to a directory on your machine
 4. The project name is auto-detected from the directory name
-5. Choose an **Isolation** strategy (`none` or `worktree`) — defaults to your global config value
-6. Click **Create**
-
-If you select `worktree` isolation and the directory is not a git repository, you'll be prompted to initialize one with `git init`.
+5. Click **Create**
 
 The dashboard scans the project's `.strawpot/sessions/` directory to import any existing session history.
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -91,7 +91,6 @@ Create a project-level config file:
 ```toml
 # strawpot.toml (project root)
 runtime = "strawpot-claude-code"
-isolation = "worktree"
 
 [orchestrator]
 role = "team-lead"
@@ -118,7 +117,7 @@ When the orchestrator agent needs help, it delegates sub-tasks via Denden:
 4. **Agent spawn** — A sub-agent is launched with the role's instructions, skills, and memory context
 5. **Result** — The sub-agent's output is recorded to memory and returned to the caller
 
-All agents work in the same directory (worktree or project dir), so they can see each other's changes.
+All agents work in the same project directory, so they can see each other's changes. When an agent needs an isolated working copy, it uses the [worktree skill](/concepts/isolation) on demand.
 
 ## Web Dashboard
 

--- a/docs/realtime-session-feedback-design-2026-03-24.md
+++ b/docs/realtime-session-feedback-design-2026-03-24.md
@@ -1,0 +1,452 @@
+# Real-time Session Feedback for StrawPot CLI
+
+**Date:** 2026-03-24
+**Issue:** [#483](https://github.com/strawpot/strawpot/issues/483) (Gap 2)
+**Author:** product-advisor
+**Status:** Draft
+**Strategic Review:** Passed (2026-03-24)
+
+---
+
+## Problem Statement
+
+When a user runs `strawpot start --task "..."`, they see **nothing** until the entire session completes. Sessions take 5-20+ minutes (delegations to multiple roles, code generation, reviews). The user stares at a blank terminal with no progress, no status, no sense of what is happening.
+
+The strawpot.com landing page shows an idealized progressive-checkmark experience that does not exist in the real product. This is the single highest-impact gap between the demo and reality.
+
+## Demand Evidence
+
+- Issue #483 consolidates #481 and #482 -- identified through a systematic audit of the demo-product gap
+- The strawpot.com website prominently features the checkmark output as a selling point
+- Any new user running `strawpot start --task` for the first time will experience 5+ minutes of silence, which reads as "broken"
+
+## Status Quo
+
+- **CLI task mode:** `Session.start()` calls `self.runtime.wait(handle)` and blocks with zero terminal output until the orchestrator exits (session.py L544-545)
+- **CLI interactive mode:** User sees agent output because stdin/stdout are attached -- less painful but still no structured progress
+- **GUI:** Has SSE infrastructure (`event_bus.py`, `sse.py`) and file watching (`watchfiles` on session directories), but no delegation-level progress events are surfaced
+- **Trace system:** `trace.py` writes rich JSONL events (`delegate_start`, `delegate_end`, `agent_spawn`, `agent_end`, `ask_user_*`, `memory_*`) to `<session_dir>/trace.jsonl` -- **the data for feedback already exists, it is just not rendered**
+
+## Target User & Narrowest Wedge
+
+**Target:** Any StrawPot user running headless task sessions (`--task` flag). This includes:
+- Developers using StrawPot for automated code tasks
+- Scheduled/cron sessions via the GUI scheduler
+- CI/CD integrations
+
+**Narrowest wedge:** Progressive checkmark output to stderr during `strawpot start --task` sessions, driven by delegation lifecycle events the Session class already handles.
+
+## Constraints
+
+1. Must work in headless/agent mode (no interactive prompts, no hang risk)
+2. Must work in both CLI and GUI contexts with the same underlying mechanism
+3. Stage names must be dynamic (reflect actual roles used), not hardcoded
+4. Must degrade gracefully (if rendering fails, session continues)
+5. Output goes to stderr (stdout reserved for agent output in task mode)
+6. No changes to the denden gRPC protocol in v1
+
+## Premises
+
+1. **The trace system already captures every signal needed.** `delegate_start`, `delegate_end`, `agent_spawn`, and `agent_end` events contain role, task, timing, and exit code. No new data collection is required.
+2. **Session._handle_delegate is the natural hook point.** It processes every delegation request and already knows role slug, task text, start time, and completion status.
+3. **The primary pain is task mode.** Interactive mode shows agent output; task mode shows nothing. The fix should prioritize task mode but benefit both.
+4. **Rendering is a separate concern from event emission.** The Session should emit structured events; renderers (CLI terminal, GUI SSE, file trace) should be pluggable consumers.
+5. **denden protocol changes are out of scope.** Agent-initiated progress events (agents reporting their own sub-steps) would be valuable but is an ocean -- v1 uses session-level signals only.
+
+## Approaches Considered
+
+### Approach A: Trace File Tailer (Minimal Viable)
+
+**Summary:** Add a background thread in task mode that tails `trace.jsonl` using `watchfiles`, parses events, and renders checkmark lines to stderr.
+
+**How it works:**
+1. Before `runtime.wait(handle)`, spawn a daemon thread that watches `trace.jsonl`
+2. On each new line, parse the JSONL event and render if it's a `delegate_start` or `delegate_end`
+3. Thread exits when the session ends
+
+**Effort:** S (human: 2 days / AI: 30 min)
+**Risk:** Low
+
+| Pros | Cons |
+|---|---|
+| Smallest diff -- ~80 lines, all in cli.py or a new renderer module | Slight latency: file write + fsnotify + read (typically <100ms but varies by OS) |
+| No changes to Session internals | Requires `trace=true` (currently default, but could be disabled) |
+| Works today with existing trace infrastructure | Duplicates parsing logic that the GUI already has |
+| Easy to test -- just check file output | Cannot surface events that aren't traced (future: ask_user prompts in progress) |
+
+**Existing code reused:** `trace.py` (producer), `watchfiles` (already a dependency for GUI)
+
+---
+
+### Approach B: Session Event Callback (Recommended)
+
+**Summary:** Add a pluggable event callback to the `Session` class. On delegation start/end and other lifecycle events, the Session calls registered listeners. The CLI registers a terminal renderer; the GUI registers an SSE publisher.
+
+**How it works:**
+1. Define a `ProgressEvent` dataclass with `kind`, `role`, `detail`, `timestamp`, `duration_ms`, `status`, `depth`
+2. Add `on_event: Callable[[ProgressEvent], None] | None` to `Session.__init__`
+3. Add a central `_emit_event()` method with try/except guard for graceful degradation
+4. In `_handle_delegate`, emit events at delegation start and end (all 7 exit paths covered)
+5. In `start()`, emit session-level events (session started, orchestrator spawned, cleanup)
+6. CLI task mode passes a `TerminalProgressRenderer` that prints checkmarks to stderr
+7. GUI passes an adapter that publishes to the `EventBus`
+
+**Effort:** M (human: 1 week / AI: 1 hour)
+**Risk:** Low
+
+| Pros | Cons |
+|---|---|
+| Real-time -- no file I/O latency, events fire inline | Touches Session internals (but minimally -- one callback call per event) |
+| Works regardless of trace config | ~200 lines across 3 files (session.py, new renderer, cli.py) vs ~80 for Approach A |
+| Clean separation: Session emits, renderers consume | Callback runs on the delegation handler thread -- renderer must be fast and non-blocking |
+| GUI can use the same events for a live timeline | |
+| Natural extension point for future event types | |
+| Testable: mock the callback, assert events emitted | |
+
+**Existing code reused:** `EventBus` pattern from GUI (same pub/sub concept), `TraceEvent` field names, `ask_user_handler` callback pattern
+
+---
+
+### Approach C: denden Protocol Extension (Ideal Architecture)
+
+**Summary:** Extend the denden gRPC protocol with a `Progress` message type. Agents can emit progress events (e.g., "reading codebase", "writing tests", "creating PR") that flow through the orchestrator to the CLI/GUI. Session-level events from Approach B are also included.
+
+**How it works:**
+1. Add `Progress` message to `denden.proto`: `{ stage: string, detail: string, percent: float }`
+2. Add `on_progress` handler to `DenDenServer`
+3. Agents call `denden send '{"progress":{"stage":"Writing tests","detail":"12/15 complete"}}'`
+4. Session surfaces these alongside its own delegation lifecycle events
+5. CLI renders a rich progress display (stages + sub-steps)
+
+**Effort:** XL (human: 3 weeks / AI: 4 hours)
+**Risk:** High
+
+| Pros | Cons |
+|---|---|
+| Most informative -- agents report their own progress | Protocol change requires updating denden, all wrappers, and the denden skill docs |
+| Enables sub-step visibility ("writing file 3/7") | Agents must opt in -- existing agents produce no progress events until updated |
+| Future-proof architecture | Significantly larger scope -- protocol, server, client, renderers, docs |
+| | Risk of noisy/inconsistent progress from different agents |
+
+**Existing code reused:** `DenDenServer` handler pattern, `denden.proto` extension point
+
+---
+
+## Recommended Approach
+
+**Approach B: Session Event Callback**, with Approach A's trace-file mechanism as a fallback for the GUI.
+
+**Rationale:**
+
+1. **Completeness at low cost.** Per the completeness principle, the delta between A (~80 lines) and B (~200 lines) is trivial with AI agents. B gives a cleaner architecture, real-time delivery, and GUI compatibility -- the extra lines are free.
+
+2. **Right abstraction boundary.** The Session already handles every delegation. Adding a callback is the natural extension -- it doesn't require trace to be enabled, doesn't add file I/O latency, and creates a clean contract between event producer (Session) and consumer (renderer).
+
+3. **Approach C is an ocean.** Valuable but unbounded -- protocol changes ripple through denden, all agent wrappers, skill documentation, and require every agent to opt in. We should build B now and layer C on top later if needed.
+
+4. **Phased delivery.** B ships useful progress output immediately. The same event callback can later feed Approach C's richer events without rewriting.
+
+## Detailed Architecture
+
+### ProgressEvent Dataclass
+
+Named `ProgressEvent` (not `SessionEvent`) to avoid collision with the GUI's existing `gui.event_bus.SessionEvent` class, which has different fields (`kind`, `run_id`, `project_id`, `data`).
+
+```python
+@dataclass
+class ProgressEvent:
+    kind: str          # "session_start" | "delegate_start" | "delegate_end" | ...
+    role: str          # Role slug (e.g., "implementer", "code-reviewer")
+    detail: str        # Human-readable detail (truncated task text or reason)
+    timestamp: str     # ISO 8601 UTC wall clock (matches tracer convention)
+    duration_ms: int   # 0 for start events, elapsed for end events
+    status: str        # "ok" | "error" | "denied" | "cached" | "" (for start events)
+    depth: int         # Delegation depth (0 = orchestrator)
+```
+
+**Timestamp convention:** Uses wall clock ISO 8601 UTC (`datetime.now(timezone.utc).isoformat()`), matching the `TraceEvent.ts` field convention. Durations are computed as deltas between start/end event pairs. This keeps `ProgressEvent` consistent with the trace system and avoids dual-timestamp complexity.
+
+### Central Event Emission Method
+
+All event emission goes through a single `_emit_event()` method on Session. This is the **only** place the `on_event` callback is invoked, providing a single point for error handling, logging, and future behavior (e.g., disable after N failures).
+
+```python
+def _emit_event(self, event: ProgressEvent) -> None:
+    """Emit a progress event to the registered callback.
+
+    Swallows all exceptions -- a failing renderer must never
+    crash the session.
+    """
+    if self._on_event is None:
+        return
+    try:
+        self._on_event(event)
+    except Exception:
+        logger.debug("Event callback failed", exc_info=True)
+```
+
+### _handle_delegate Exit Path Mapping
+
+`_handle_delegate` has 7 distinct exit paths. Each must emit the correct events:
+
+```
+_handle_delegate()
+|
++-- 1. Max delegations exceeded (L1069)
+|   emit: delegate_denied(status="denied", detail="DENY_DELEGATIONS_LIMIT")
+|
++-- 2. Cache hit, fast path (L1096)
+|   emit: delegate_cached(status="cached")
+|
++-- 3. Cache hit, after lock (L1140)
+|   emit: delegate_cached(status="cached")
+|
++-- 4. Success (L1202)
+|   emit: delegate_start(status="") ... [delegation runs] ... delegate_end(status="ok")
+|
++-- 5. Non-zero exit (L1185)
+|   emit: delegate_start(status="") ... [delegation runs] ... delegate_end(status="error")
+|
++-- 6. PolicyDenied (L1206)
+|   emit: delegate_start(status="") ... delegate_denied(status="denied")
+|
++-- 7. Exception (L1217)
+    emit: delegate_start(status="") ... delegate_end(status="error")
+```
+
+**Key placement rule:** For paths 4-7, `delegate_start` is emitted **after** cache checks pass (after L1167), not at the top of the method. This ensures cache hits don't produce spurious start events.
+
+### Event Kinds
+
+| Event | Where emitted | Key data |
+|---|---|---|
+| `session_start` | `Session.start()` after session setup | role=orchestrator_role |
+| `delegate_start` | `_handle_delegate()` after cache checks, before `handle_delegate()` call | role, task summary |
+| `delegate_end` | `_handle_delegate()` after result (paths 4, 5, 7) | role, duration, status |
+| `delegate_denied` | `_handle_delegate()` on max limit (path 1) or PolicyDenied (path 6) | role, reason |
+| `delegate_cached` | `_handle_delegate()` on cache hit (paths 2, 3) | role |
+| `ask_user_start` | `_handle_ask_user()` before handler call | role, question summary |
+| `ask_user_end` | `_handle_ask_user()` after response | role, duration |
+| `session_end` | `Session.stop()` | duration, exit_code, files_changed count |
+
+### Thread Safety
+
+`_handle_delegate` runs on the denden gRPC server's thread pool. Multiple delegations can run concurrently (proven by the per-key cache locks at L1126-1134). The renderer must be thread-safe.
+
+**Strategy:** The `TerminalProgressRenderer` owns a `threading.Lock()`. All stderr writes are serialized through this lock. The lock is internal to the renderer -- `Session._emit_event()` does not need its own lock because it only calls the callback (a single function call is thread-safe).
+
+### BrokenPipeError Handling
+
+When stderr is piped or redirected (`2>/dev/null`, `2>&1 | head`), writing can raise `BrokenPipeError`. The renderer catches this and silently disables further writes:
+
+```python
+class TerminalProgressRenderer:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._disabled = False
+
+    def handle_event(self, event: ProgressEvent) -> None:
+        if self._disabled:
+            return
+        with self._lock:
+            try:
+                self._render(event)
+            except (BrokenPipeError, OSError):
+                self._disabled = True
+```
+
+### CLI Terminal Renderer Output
+
+```
+$ strawpot start --task "Add dark mode toggle"
+
+  Session started (orchestrator: ai-ceo)
+
+  > Delegating to product-advisor...
+  [checkmark] product-advisor completed (12s)
+
+  > Delegating to implementer...
+    > Delegating to code-reviewer... (depth 2)
+    [checkmark] code-reviewer completed (34s)
+  [checkmark] implementer completed (2m 47s)
+
+  > Delegating to pr-reviewer...
+  [checkmark] pr-reviewer completed (1m 12s)
+
+  [checkmark] Session complete (5m 32s) - 7 files changed
+```
+
+**Rendering rules:**
+- Output to stderr (stdout reserved for final agent output)
+- Indent nested delegations by depth (2 spaces per level)
+- Show `>` arrow for in-progress, checkmark for success, X for failure
+- Truncate task text to first 60 chars for the "Delegating to..." line
+- Format durations human-readably (seconds, minutes)
+- Use Unicode checkmark/cross with color when terminal supports it, ASCII fallback otherwise
+- Cached delegations show with "(cached)" suffix
+- Terminal title updated to show current active role (e.g., `\033]0;StrawPot: implementer (2m)\007`)
+
+### JSON Progress Mode
+
+For CI/CD and machine consumption, `--progress json` outputs one JSON object per line to stderr instead of human-readable checkmarks:
+
+```
+$ strawpot start --task "..." --progress json
+
+{"kind":"session_start","role":"ai-ceo","detail":"","timestamp":"2026-03-24T10:00:00Z","duration_ms":0,"status":"","depth":0}
+{"kind":"delegate_start","role":"implementer","detail":"Add dark mode toggle...","timestamp":"2026-03-24T10:00:01Z","duration_ms":0,"status":"","depth":1}
+{"kind":"delegate_end","role":"implementer","detail":"","timestamp":"2026-03-24T10:02:48Z","duration_ms":167000,"status":"ok","depth":1}
+{"kind":"session_end","role":"ai-ceo","detail":"7 files changed","timestamp":"2026-03-24T10:05:32Z","duration_ms":332000,"status":"ok","depth":0}
+```
+
+This reuses the same `ProgressEvent` data -- the renderer just serializes differently.
+
+### Architecture Diagram
+
+```
++--------------------------------------------------------------+
+|                          cli.py                               |
+|                                                               |
+|  start() command                                              |
+|    |                                                          |
+|    +-- if task mode:                                          |
+|    |     if --progress json: renderer = JsonProgressRenderer()|
+|    |     else:               renderer = TerminalProgressRend()|
+|    |                                                          |
+|    +-- Session(on_event=renderer.handle_event)                |
+|                                                               |
++--------------------------------------------------------------+
+                              |
+                              v
++--------------------------------------------------------------+
+|                        session.py                             |
+|                                                               |
+|  Session.__init__(on_event: Callable[[ProgressEvent], None])  |
+|                                                               |
+|  _emit_event(event) --- try/except wrapper ------+           |
+|       |                                           |           |
+|       +-- start()          -> session_start       |           |
+|       +-- _handle_delegate -> delegate_*          |           |
+|       +-- _handle_ask_user -> ask_user_*          |           |
+|       +-- stop()           -> session_end         |           |
+|                                                   |           |
+|  Also calls self._tracer.* (unchanged)            |           |
+|                                                               |
++--------------------------------------------------------------+
+                              |
+                    on_event(ProgressEvent)
+                              |
+              +---------------+---------------+
+              v                               v
++-------------------------+   +------------------------------+
+| TerminalProgressRenderer|   | EventBusAdapter (GUI)        |
+|                          |   |                              |
+| - threading.Lock         |   | Maps ProgressEvent ->        |
+| - sys.stderr.write()    |   | gui.SessionEvent              |
+| - BrokenPipeError guard |   | Publishes to EventBus        |
+| - Unicode/ASCII detect  |   |                              |
+| - _disabled flag         |   |                              |
++-------------------------+   +------------------------------+
+```
+
+## Open Questions
+
+1. **Should we show ask_user events in progress output?** In headless mode, ask_user gets auto-responded. Showing "Waiting for user input..." then immediately "Response received" adds noise. Recommendation: show only if duration > 2s (implies actual human interaction via GUI bridge).
+
+2. **Should cached delegations appear?** Cache hits are instant but still represent completed work. Recommendation: show with a "(cached)" suffix -- it's informative and helps users understand why re-runs are faster.
+
+3. **Verbose mode?** Should `--verbose` show task text snippets alongside role names? Recommendation: yes, add a `--progress-verbose` or respect existing `-v` flag to show truncated task text.
+
+4. **GUI integration priority?** The GUI already has SSE and event_bus. Should we wire up the ProgressEvent adapter in v1 or defer? Recommendation: wire it up -- it's ~20 lines to bridge ProgressEvent to the existing EventBus, and the GUI frontend can consume it when ready.
+
+## Success Criteria
+
+- [ ] Running `strawpot start --task "..."` produces progressive output showing each delegation stage as it starts and completes
+- [ ] Each line identifies the role that is active or completed
+- [ ] Durations are shown for completed stages
+- [ ] Nested delegations are visually indented
+- [ ] Final summary line shows total duration and files changed count
+- [ ] Output goes to stderr (stdout contains only final agent output)
+- [ ] Works in headless mode with no interactive prompts
+- [ ] Degrades gracefully: `_emit_event()` catches all exceptions; renderer catches BrokenPipeError
+- [ ] Stage names are dynamic (derived from actual delegation roles, not hardcoded)
+- [ ] GUI EventBus receives the same events (adapter wired up)
+- [ ] `--progress json` mode outputs machine-readable JSONL to stderr
+- [ ] Terminal title updates to show current active role
+
+## Dependencies
+
+- `strawpot` CLI (session.py, cli.py) -- primary changes
+- `strawpot-gui` (event_bus adapter) -- small addition
+- No changes to denden, agent wrappers, or the gRPC protocol
+
+## Phased Implementation Plan
+
+### Phase 1: Core event callback + CLI renderer (ships first)
+- Define `ProgressEvent` dataclass (new file: `cli/src/strawpot/progress.py`)
+- Add `on_event` callback and `_emit_event()` to `Session.__init__` / session.py
+- Emit events from all 7 `_handle_delegate` exit paths, `_handle_ask_user`, `start()`, `stop()`
+- Implement `TerminalProgressRenderer` with checkmark output to stderr (thread-safe, BrokenPipeError-safe)
+- Implement `JsonProgressRenderer` for `--progress json` mode
+- Add `--progress` flag to `cli.py` `start()` command (`auto` | `json` | `off`; default `auto` = enabled for task mode)
+- Terminal title updates for active role
+- Wire up in `cli.py` `start()` command
+- Wire up GUI `EventBusAdapter` (~20 lines)
+- Tests (see test plan below)
+
+### Phase 2: Polish (follow-up)
+- Color support with terminal capability detection
+- `--progress-verbose` flag for task text display
+- Spinner animation for long-running delegations (if terminal supports it)
+
+### Phase 3: Future -- Agent-initiated progress (Approach C)
+- Extend denden protocol with `Progress` message
+- Update denden skill documentation
+- Agents opt in to progress reporting
+- Merge agent progress with session lifecycle events in renderer
+
+## Test Plan
+
+### Unit tests: TerminalProgressRenderer
+1. Renders `delegate_start` with correct indentation by depth
+2. Renders `delegate_end` with duration formatting (seconds, minutes)
+3. Renders `delegate_denied` with X mark
+4. Renders `delegate_cached` with "(cached)" suffix
+5. Renders `session_start` / `session_end` with summary
+6. Handles Unicode checkmark/cross and ASCII fallback
+7. Thread safety: concurrent events don't garble output (multiple threads writing)
+8. BrokenPipeError disables renderer without crash
+9. OSError disables renderer without crash
+
+### Unit tests: JsonProgressRenderer
+1. Outputs valid JSON per line
+2. Contains all ProgressEvent fields
+
+### Unit tests: Session event emission
+1. `_handle_delegate` success path emits start + end(ok)
+2. `_handle_delegate` cache hit (fast path) emits cached event only
+3. `_handle_delegate` cache hit (after lock) emits cached event only
+4. `_handle_delegate` max delegations denied emits denied event
+5. `_handle_delegate` PolicyDenied emits start + denied
+6. `_handle_delegate` exception emits start + end(error)
+7. `_handle_delegate` non-zero exit emits start + end(error)
+8. `_handle_ask_user` emits ask_user_start + ask_user_end
+9. `Session.start()` emits session_start
+10. `Session.stop()` emits session_end
+11. Callback=None produces no errors (no-op)
+12. Callback raises -> session continues (graceful degradation via _emit_event)
+13. Depth values match what tracer receives
+
+### Integration test
+1. Full session with mock agent -> verify complete event sequence matches expected order
+
+## The Assignment
+
+Ship Phase 1. Define `ProgressEvent`, add the callback to `Session`, implement both renderers, wire it up in `cli.py` and the GUI adapter. This is a bounded lake -- ~200 lines across 4 files, all within the strawpot CLI package plus ~20 lines for the GUI adapter.
+
+## What I Noticed
+
+- The trace system (`trace.py`) is remarkably well-designed -- content-addressed artifact storage, span-based event model, full delegation call tree. The architecture already anticipates observability; the gap is purely that these events don't reach the terminal.
+- The Session class handles delegations, ask_user, memory, and caching all through clean handler methods. Adding an event callback is a natural extension of this pattern -- identical to the existing `ask_user_handler` callback.
+- The GUI's `EventBus` is exactly the right abstraction for the GUI side -- but the existing `SessionEvent` class has different fields, so the new class is named `ProgressEvent` to avoid collision.
+- The `_handle_delegate` method has 7 distinct exit paths (max limit, 2 cache paths, success, non-zero exit, PolicyDenied, exception). Each is mapped to specific events in this design.


### PR DESCRIPTION
## Summary

- Remove all references to session-level `isolation` configuration from docs, design docs, and README
- Document the new agent-controlled worktree skill model in `docs/concepts/isolation.mdx`
- Add migration guidance for users with old `isolation` config keys
- Update 13 files across user-facing docs, design docs, and README

Part of epic #568. Follows code changes in PRs #580, #582, #584.

Closes #578

## Test plan

- [ ] Verify no docs reference `isolation = "worktree"` or `--isolation` as a current feature
- [ ] Verify `docs/concepts/isolation.mdx` explains the worktree skill model
- [ ] Verify config examples in quickstart and configuration docs have no `isolation` key
- [ ] Verify design docs have appropriate historical notes where isolation code still exists internally

🤖 Generated with [Claude Code](https://claude.com/claude-code)