### PR TITLE
Remove PR approval gate from CLAUDE.md workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,7 @@
 
 ## After completing any code change
 
-1. Show me the full `git diff` for review
-2. Wait for my explicit approval before proceeding
-3. Once approved:
-   - Rebase from `main` before committing (`git fetch origin && git rebase origin/main`)
-   - **If the current branch has an open PR**, push to that branch to update the existing PR.
-   - **If the current branch's PR is already merged** (or there is no PR), pull the latest `main` (`git checkout main && git pull origin main`), then create a fresh branch from `main` and open a new PR.
-   - Never reuse a branch whose PR has been merged. Each merged PR keeps its own branch.
+1. Rebase from `main` before committing (`git fetch origin && git rebase origin/main`)
+2. **If the current branch has an open PR**, push to that branch to update the existing PR.
+3. **If the current branch's PR is already merged** (or there is no PR), pull the latest `main` (`git checkout main && git pull origin main`), then create a fresh branch from `main` and open a new PR.
+4. Never reuse a branch whose PR has been merged. Each merged PR keeps its own branch.


### PR DESCRIPTION
## Summary
- Removes the manual PR approval gate from the CLAUDE.md workflow
- Agents now proceed directly to rebase/commit/PR after completing code changes, without waiting for explicit approval of the diff
- The 4-step workflow (rebase → push to open PR or create new branch → open PR → never reuse merged branches) is preserved, just without the approval gate

## Test plan
- [ ] Verify CLAUDE.md renders correctly in each repo
- [ ] Confirm agents follow the updated workflow without waiting for approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)