### PR TITLE
Fix CLI build failure caused by gui-v* tags confusing setuptools_scm

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -65,6 +65,7 @@ where = ["src"]
 [tool.setuptools_scm]
 root = ".."
 tag_regex = "^v(?P<version>[\\d.]+)$"
+git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "v*"]
 
 [build-system]
 requires = ["setuptools", "setuptools-scm>=8"]


### PR DESCRIPTION
## Summary

- The dial repo CI fails when pip installing the strawpot CLI because `git describe` picks the nearest tag, which can be a `gui-v*` tag instead of a `v*` tag
- `setuptools_scm`'s `tag_regex` only filters **after** `git describe` has already selected the nearest tag, so the wrong tag is already chosen by that point
- Adds `git_describe_command` with `--match v*` to `[tool.setuptools_scm]` in `cli/pyproject.toml`, which filters tags at the git level before setuptools_scm ever sees them

## Test plan

- [ ] Verify `pip install` of the CLI succeeds in a repo where `gui-v*` tags are nearer than `v*` tags
- [ ] Confirm dial repo CI passes with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)