### PR TITLE
chore: remove Discord community/invite links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: Question or Discussion
-    url: https://discord.gg/6RMpzuKrRd
-    about: Ask questions, share ideas, or get help on Discord

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,6 @@ Open a [GitHub Issue](https://github.com/strawpot/strawpot/issues) with:
 Good: "I want to run the same schedule in multiple projects with different configs."
 Less helpful: "Add a `project_id` column to the `scheduled_tasks` table."
 
-### Share an Idea or Ask a Question
-
-Join the [Discord](https://discord.gg/6RMpzuKrRd) for discussion, feedback,
-and help getting started.
-
 ## What Happens Next
 
 1. You submit an issue describing a bug or feature

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ StrawPot lets agents figure out how to solve the task.
 
 <p align="center">
   <a href="https://github.com/strawpot/strawpot/actions/workflows/release.yml"><img src="https://img.shields.io/github/actions/workflow/status/strawpot/strawpot/release.yml?branch=main&style=for-the-badge&label=PyPI" alt="PyPI Release"></a>
-  <a href="https://discord.gg/6RMpzuKrRd"><img src="https://img.shields.io/discord/1476285531464929505?label=Discord&logo=discord&logoColor=white&color=5865F2&style=for-the-badge" alt="Discord"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
 </p>
 
@@ -328,8 +327,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Community
 
-- [Discord](https://discord.gg/6RMpzuKrRd): questions, feedback,
-  and discussion
 - [GitHub Issues](https://github.com/strawpot/strawpot/issues):
   bug reports and feature requests
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -79,7 +79,6 @@
   "footer": {
     "socials": {
       "github": "https://github.com/strawpot/strawpot",
-      "discord": "https://discord.gg/6RMpzuKrRd",
       "website": "https://strawpot.com"
     }
   }


### PR DESCRIPTION
## Summary
- Remove Discord badge from README.md header
- Remove Discord community link from README.md Community section
- Remove "Share an Idea or Ask a Question" Discord section from CONTRIBUTING.md
- Remove Discord contact link from `.github/ISSUE_TEMPLATE/config.yml`
- Remove Discord social link from `docs/docs.json` footer

Discord product integration code (adapter, notify-discord skill, tests, CLI, GUI, design docs) is intentionally left untouched — only community invite links (discord.gg URLs) were removed.

## Test plan
- [x] Verified only 4 files changed with link removals
- [ ] Confirm docs site builds without the removed `discord` key in docs.json
- [ ] Confirm issue template config still valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)