### PR TITLE
fix: correct agent count and show sub-agent details in activity display

### DIFF
--- a/gui/frontend/src/lib/agent-activity.test.ts
+++ b/gui/frontend/src/lib/agent-activity.test.ts
@@ -33,38 +33,39 @@ describe("getAgentActivityLabel", () => {
     expect(getAgentActivityLabel(nodes, "root")).toBe("Reading foo.ts");
   });
 
-  it("prefers own activity over children activity", () => {
+  it("shows children aggregate even when parent has own activity", () => {
     const nodes = [
       makeNode({ agent_id: "root", current_activity: "Thinking" }),
-      makeNode({ agent_id: "child", parent: "root", current_activity: "Reading bar.ts" }),
+      makeNode({ agent_id: "child", parent: "root", role: "cr", current_activity: "Reading bar.ts" }),
     ];
-    expect(getAgentActivityLabel(nodes, "root")).toBe("Thinking");
+    // Children take priority over parent's own activity
+    expect(getAgentActivityLabel(nodes, "root")).toBe("2 agents running");
   });
 
-  it("shows count header for single running child", () => {
+  it("shows count header for single running child (includes parent)", () => {
     const nodes = [
       makeNode({ agent_id: "root" }),
       makeNode({ agent_id: "child", parent: "root", role: "code-reviewer", current_activity: "Reading src/api.ts" }),
     ];
-    expect(getAgentActivityLabel(nodes, "root")).toBe("1 agent running");
+    expect(getAgentActivityLabel(nodes, "root")).toBe("2 agents running");
   });
 
-  it("shows count header for single running child without activity", () => {
+  it("shows count header for single running child without activity (includes parent)", () => {
     const nodes = [
       makeNode({ agent_id: "root" }),
       makeNode({ agent_id: "child", parent: "root", role: "qa-engineer" }),
     ];
-    expect(getAgentActivityLabel(nodes, "root")).toBe("1 agent running");
+    expect(getAgentActivityLabel(nodes, "root")).toBe("2 agents running");
   });
 
-  it("shows aggregate count for multiple running children", () => {
+  it("shows aggregate count for multiple running children (includes parent)", () => {
     const nodes = [
       makeNode({ agent_id: "root" }),
       makeNode({ agent_id: "c1", parent: "root", role: "code-reviewer" }),
       makeNode({ agent_id: "c2", parent: "root", role: "qa-engineer" }),
       makeNode({ agent_id: "c3", parent: "root", role: "comment-analyzer" }),
     ];
-    expect(getAgentActivityLabel(nodes, "root")).toBe("3 agents running");
+    expect(getAgentActivityLabel(nodes, "root")).toBe("4 agents running");
   });
 
   it("shows aggregate count without highlighted inline activity", () => {
@@ -74,7 +75,7 @@ describe("getAgentActivityLabel", () => {
       makeNode({ agent_id: "c2", parent: "root", role: "qa-engineer" }),
     ];
     // Header is just the count — activity is in childActivity, not header
-    expect(getAgentActivityLabel(nodes, "root")).toBe("2 agents running");
+    expect(getAgentActivityLabel(nodes, "root")).toBe("3 agents running");
   });
 
   it("ignores completed children", () => {
@@ -83,7 +84,7 @@ describe("getAgentActivityLabel", () => {
       makeNode({ agent_id: "c1", parent: "root", role: "code-reviewer", status: "completed" }),
       makeNode({ agent_id: "c2", parent: "root", role: "qa-engineer", current_activity: "Running tests" }),
     ];
-    expect(getAgentActivityLabel(nodes, "root")).toBe("1 agent running");
+    expect(getAgentActivityLabel(nodes, "root")).toBe("2 agents running");
   });
 
   it("returns null when no children and no own activity", () => {
@@ -126,14 +127,15 @@ describe("getAgentActivityDetail", () => {
     });
   });
 
-  it("prefers own activity — no child activity when parent is active", () => {
+  it("shows children aggregate even when parent has own activity", () => {
     const nodes = [
       makeNode({ agent_id: "root", current_activity: "Thinking" }),
       makeNode({ agent_id: "child", parent: "root", role: "cr", current_activity: "Reading" }),
     ];
     const detail = getAgentActivityDetail(nodes, "root");
-    expect(detail?.header).toBe("Thinking");
-    expect(detail?.childActivity).toBeNull();
+    // Running children take priority over parent's own activity
+    expect(detail?.header).toBe("2 agents running");
+    expect(detail?.childActivity).toBe("cr: Reading");
   });
 
   it("returns count header + most-recent child activity for one running child", () => {
@@ -142,18 +144,18 @@ describe("getAgentActivityDetail", () => {
       makeNode({ agent_id: "child", parent: "root", role: "code-reviewer", current_activity: "Reading src/api.ts" }),
     ];
     const detail = getAgentActivityDetail(nodes, "root");
-    expect(detail?.header).toBe("1 agent running");
+    expect(detail?.header).toBe("2 agents running");
     expect(detail?.childActivity).toBe("code-reviewer: Reading src/api.ts");
   });
 
-  it("returns Working… child activity for child without activity", () => {
+  it("returns role-prefixed Working… for child without activity", () => {
     const nodes = [
       makeNode({ agent_id: "root" }),
       makeNode({ agent_id: "child", parent: "root", role: "qa-engineer" }),
     ];
     const detail = getAgentActivityDetail(nodes, "root");
-    expect(detail?.header).toBe("1 agent running");
-    expect(detail?.childActivity).toBe("Working…");
+    expect(detail?.header).toBe("2 agents running");
+    expect(detail?.childActivity).toBe("qa-engineer: Working…");
   });
 
   it("returns most-recent child activity for multiple running children", () => {
@@ -164,19 +166,19 @@ describe("getAgentActivityDetail", () => {
       makeNode({ agent_id: "c3", parent: "root", role: "comment-analyzer", current_activity: "Analyzing PR" }),
     ];
     const detail = getAgentActivityDetail(nodes, "root");
-    expect(detail?.header).toBe("3 agents running");
+    expect(detail?.header).toBe("4 agents running");
     expect(detail?.childActivity).toBe("comment-analyzer: Analyzing PR");
   });
 
-  it("returns Working… when no children have activity", () => {
+  it("returns role-prefixed Working… when no children have activity", () => {
     const nodes = [
       makeNode({ agent_id: "root" }),
       makeNode({ agent_id: "c1", parent: "root", role: "code-reviewer" }),
       makeNode({ agent_id: "c2", parent: "root", role: "qa-engineer" }),
     ];
     const detail = getAgentActivityDetail(nodes, "root");
-    expect(detail?.header).toBe("2 agents running");
-    expect(detail?.childActivity).toBe("Working…");
+    expect(detail?.header).toBe("3 agents running");
+    expect(detail?.childActivity).toBe("qa-engineer: Working…");
   });
 
   it("returns null when no children and no own activity", () => {
@@ -209,12 +211,12 @@ describe("getSessionActivityLabel", () => {
     expect(getSessionActivityLabel([])).toBeNull();
   });
 
-  it("delegates to root node — shows count for single child", () => {
+  it("delegates to root node — shows count for single child (includes parent)", () => {
     const nodes = [
       makeNode({ agent_id: "root" }),
       makeNode({ agent_id: "c1", parent: "root", role: "reviewer", current_activity: "Reviewing" }),
     ];
-    expect(getSessionActivityLabel(nodes)).toBe("1 agent running");
+    expect(getSessionActivityLabel(nodes)).toBe("2 agents running");
   });
 
   it("handles root with own activity", () => {
@@ -224,13 +226,13 @@ describe("getSessionActivityLabel", () => {
     expect(getSessionActivityLabel(nodes)).toBe("Writing code");
   });
 
-  it("handles root with multiple children", () => {
+  it("handles root with multiple children (includes parent)", () => {
     const nodes = [
       makeNode({ agent_id: "root" }),
       makeNode({ agent_id: "c1", parent: "root", role: "cr" }),
       makeNode({ agent_id: "c2", parent: "root", role: "qa" }),
     ];
-    expect(getSessionActivityLabel(nodes)).toBe("2 agents running");
+    expect(getSessionActivityLabel(nodes)).toBe("3 agents running");
   });
 
   it("falls back when root is completed but children still running", () => {
@@ -282,14 +284,14 @@ describe("getSessionActivityDetail", () => {
     expect(getSessionActivityDetail([])).toBeNull();
   });
 
-  it("returns most-recent child activity for root with children", () => {
+  it("returns most-recent child activity for root with children (includes parent)", () => {
     const nodes = [
       makeNode({ agent_id: "root" }),
       makeNode({ agent_id: "c1", parent: "root", role: "code-reviewer", current_activity: "Reviewing" }),
       makeNode({ agent_id: "c2", parent: "root", role: "qa-engineer", current_activity: "Testing" }),
     ];
     const detail = getSessionActivityDetail(nodes);
-    expect(detail?.header).toBe("2 agents running");
+    expect(detail?.header).toBe("3 agents running");
     expect(detail?.childActivity).toBe("qa-engineer: Testing");
   });
 
@@ -321,14 +323,14 @@ describe("getSessionActivityDetail", () => {
     expect(detail?.childActivity).toBe("qa: Testing");
   });
 
-  it("returns Working… when flat fallback has no activity", () => {
+  it("returns role-prefixed Working… when flat fallback has no activity", () => {
     const nodes = [
       makeNode({ agent_id: "root", status: "completed" }),
       makeNode({ agent_id: "c1", parent: "root", role: "qa" }),
     ];
     const detail = getSessionActivityDetail(nodes);
     expect(detail?.header).toBe("1 agent running");
-    expect(detail?.childActivity).toBe("Working…");
+    expect(detail?.childActivity).toBe("qa: Working…");
   });
 
   it("returns null when all nodes are terminal", () => {

--- a/gui/frontend/src/lib/agent-activity.ts
+++ b/gui/frontend/src/lib/agent-activity.ts
@@ -18,13 +18,29 @@ function formatRunningHeader(count: number): string {
   return `${count} agent${count === 1 ? "" : "s"} running`;
 }
 
-/** Build detail from a set of running nodes: count header + most-recent child activity. */
-function buildRunningDetail(runningNodes: TreeNode[]): AgentActivityDetail {
+/**
+ * Build detail from a set of running child nodes.
+ *
+ * @param runningNodes — the running *child* nodes (used for activity lookup).
+ * @param totalCount   — total running agents to display in the header
+ *                        (includes the parent).  Defaults to runningNodes.length
+ *                        for the flat-fallback path where there is no parent.
+ */
+function buildRunningDetail(
+  runningNodes: TreeNode[],
+  totalCount?: number,
+): AgentActivityDetail {
+  const count = totalCount ?? runningNodes.length;
   const withActivity = runningNodes.filter((n) => n.current_activity);
   const mostRecent = withActivity[withActivity.length - 1];
+  const lastChild = runningNodes[runningNodes.length - 1];
   return {
-    header: formatRunningHeader(runningNodes.length),
-    childActivity: mostRecent ? formatNodeActivity(mostRecent) : "Working…",
+    header: formatRunningHeader(count),
+    childActivity: mostRecent
+      ? formatNodeActivity(mostRecent)
+      : lastChild
+        ? `${lastChild.role}: Working…`
+        : "Working…",
   };
 }
 
@@ -45,9 +61,11 @@ export function getAgentActivityLabel(
 /**
  * Compute structured activity detail for an agent node.
  *
- * - If the node has its own `current_activity`, returns it as header with no child activity.
  * - If the node has running child agents, returns an aggregate header
  *   ("3 agents running") plus the most-recently-updated child's activity.
+ *   The count includes the parent itself (parent + children).
+ * - If the node has its own `current_activity` but no running children,
+ *   returns it as header with no child activity.
  * - Returns `null` when there's nothing meaningful to display.
  */
 export function getAgentActivityDetail(
@@ -57,17 +75,22 @@ export function getAgentActivityDetail(
   const node = nodes.find((n) => n.agent_id === agentId);
   if (!node) return null;
 
-  if (node.current_activity) {
-    return { header: node.current_activity, childActivity: null };
-  }
-
+  // Running children take priority — show aggregate with child detail.
   const runningChildren = nodes.filter(
     (n) => n.parent === agentId && n.status === "running",
   );
 
-  if (runningChildren.length === 0) return null;
+  if (runningChildren.length > 0) {
+    // +1 to include the parent node itself in the total count.
+    return buildRunningDetail(runningChildren, runningChildren.length + 1);
+  }
 
-  return buildRunningDetail(runningChildren);
+  // No running children — fall back to own activity.
+  if (node.current_activity) {
+    return { header: node.current_activity, childActivity: null };
+  }
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Wrong count**: Agent count now includes the parent node itself (`runningChildren.length + 1`), so orchestrator + 1 subagent correctly shows "2 agents running" instead of "1 agent running"
- **Missing sub-agent details**: Running children now take priority over the parent's own `current_activity`, ensuring the aggregate header and child activity line always appear when sub-agents are active (previously the parent's own activity would suppress child info entirely)
- **Better fallback**: The "Working…" fallback now includes the child's role name (e.g., "implementer: Working…") so sub-agents are always identified

## Root cause
Both bugs were in `gui/frontend/src/lib/agent-activity.ts`:
1. `getAgentActivityDetail` counted only `runningChildren.length` (line 70), excluding the parent from the total
2. The parent's own `current_activity` check (line 60-61) fired before the children check, suppressing child activity display whenever the parent had any activity set (e.g., during delegation tool calls)

## Test plan
- [x] All 37 agent-activity tests updated and passing
- [x] Full frontend suite (54 tests) passing
- [x] TypeScript type-check clean
- [ ] Manual verification: start a session with orchestrator + sub-agent, confirm "2 agents running" + sub-agent role/activity appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)