### PR TITLE
Show role-prefixed activity for root-only agents

### DIFF
--- a/gui/frontend/src/lib/agent-activity.test.ts
+++ b/gui/frontend/src/lib/agent-activity.test.ts
@@ -28,9 +28,14 @@ describe("getAgentActivityLabel", () => {
     expect(getAgentActivityLabel([], "nope")).toBeNull();
   });
 
-  it("returns own current_activity when set", () => {
+  it("returns role-prefixed current_activity when set", () => {
     const nodes = [makeNode({ agent_id: "root", current_activity: "Reading foo.ts" })];
-    expect(getAgentActivityLabel(nodes, "root")).toBe("Reading foo.ts");
+    expect(getAgentActivityLabel(nodes, "root")).toBe("test-role: Reading foo.ts");
+  });
+
+  it("returns role-prefixed activity with custom role", () => {
+    const nodes = [makeNode({ agent_id: "root", role: "implementer", current_activity: "Writing code" })];
+    expect(getAgentActivityLabel(nodes, "root")).toBe("implementer: Writing code");
   });
 
   it("shows children aggregate even when parent has own activity", () => {
@@ -118,11 +123,20 @@ describe("getAgentActivityDetail", () => {
     expect(getAgentActivityDetail([], "nope")).toBeNull();
   });
 
-  it("returns own activity with no child activity", () => {
+  it("returns role-prefixed own activity with no child activity", () => {
     const nodes = [makeNode({ agent_id: "root", current_activity: "Reading foo.ts" })];
     const detail = getAgentActivityDetail(nodes, "root");
     expect(detail).toEqual({
-      header: "Reading foo.ts",
+      header: "test-role: Reading foo.ts",
+      childActivity: null,
+    });
+  });
+
+  it("returns role-prefixed own activity with custom role", () => {
+    const nodes = [makeNode({ agent_id: "root", role: "implementer", current_activity: "Writing code" })];
+    const detail = getAgentActivityDetail(nodes, "root");
+    expect(detail).toEqual({
+      header: "implementer: Writing code",
       childActivity: null,
     });
   });
@@ -219,11 +233,11 @@ describe("getSessionActivityLabel", () => {
     expect(getSessionActivityLabel(nodes)).toBe("2 agents running");
   });
 
-  it("handles root with own activity", () => {
+  it("handles root with own activity — shows role prefix", () => {
     const nodes = [
       makeNode({ agent_id: "root", role: "implementer", current_activity: "Writing code" }),
     ];
-    expect(getSessionActivityLabel(nodes)).toBe("Writing code");
+    expect(getSessionActivityLabel(nodes)).toBe("implementer: Writing code");
   });
 
   it("handles root with multiple children (includes parent)", () => {
@@ -295,12 +309,12 @@ describe("getSessionActivityDetail", () => {
     expect(detail?.childActivity).toBe("qa-engineer: Testing");
   });
 
-  it("returns no child activity for root with own activity", () => {
+  it("returns role-prefixed activity for root with own activity", () => {
     const nodes = [
-      makeNode({ agent_id: "root", current_activity: "Writing code" }),
+      makeNode({ agent_id: "root", role: "implementer", current_activity: "Writing code" }),
     ];
     const detail = getSessionActivityDetail(nodes);
-    expect(detail).toEqual({ header: "Writing code", childActivity: null });
+    expect(detail).toEqual({ header: "implementer: Writing code", childActivity: null });
   });
 
   it("returns no child activity for multiple running roots", () => {

--- a/gui/frontend/src/lib/agent-activity.ts
+++ b/gui/frontend/src/lib/agent-activity.ts
@@ -65,7 +65,7 @@ export function getAgentActivityLabel(
  *   ("3 agents running") plus the most-recently-updated child's activity.
  *   The count includes the parent itself (parent + children).
  * - If the node has its own `current_activity` but no running children,
- *   returns it as header with no child activity.
+ *   returns "role: activity" as header with no child activity.
  * - Returns `null` when there's nothing meaningful to display.
  */
 export function getAgentActivityDetail(
@@ -85,9 +85,9 @@ export function getAgentActivityDetail(
     return buildRunningDetail(runningChildren, runningChildren.length + 1);
   }
 
-  // No running children — fall back to own activity.
+  // No running children — fall back to own activity, prefixed with role.
   if (node.current_activity) {
-    return { header: node.current_activity, childActivity: null };
+    return { header: formatNodeActivity(node), childActivity: null };
   }
 
   return null;


### PR DESCRIPTION
## Summary
- When only the root agent is running (no sub-agents), the activity display now shows role-prefixed text (e.g. "implementer: Writing code") instead of raw activity text ("Writing code")
- Uses the existing `formatNodeActivity` helper that was already used for child activities — this was the one remaining code path that didn't prefix with role
- 1-line source change + 4 updated test expectations + 2 new tests (39 total, all passing)

## Test plan
- [x] All 39 existing + new tests pass (`npx vitest run src/lib/agent-activity.test.ts`)
- [x] Root-only agent with `current_activity` displays "role: activity" format
- [x] Sub-agent aggregate display unchanged (count header + child detail)
- [x] Custom role names propagate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)