### PR TITLE
fix: root agent stays running after session stops

### DIFF
--- a/gui/frontend/src/hooks/useSessionWS.test.ts
+++ b/gui/frontend/src/hooks/useSessionWS.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Regression tests for useSessionWS — specifically the stream_complete
+ * handler that must transition running/cancelling nodes to terminal state.
+ *
+ * Uses a minimal fake WebSocket to drive the hook through its lifecycle.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSessionWS } from "./useSessionWS";
+import type { TreeData, TreeNode } from "@/api/types";
+
+/* ---------- Fake WebSocket ---------- */
+
+type WSHandler = (event: { data: string }) => void;
+
+let fakeInstances: FakeWebSocket[] = [];
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readyState = FakeWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: WSHandler | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  sent: string[] = [];
+
+  constructor(_url: string) {
+    fakeInstances.push(this);
+    // Simulate async open
+    setTimeout(() => {
+      this.readyState = FakeWebSocket.OPEN;
+      this.onopen?.();
+    }, 0);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  /** Test helper: simulate receiving a message from the server. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _receive(msg: any) {
+    this.onmessage?.({ data: JSON.stringify(msg) });
+  }
+}
+
+/* ---------- Helpers ---------- */
+
+function makeNode(overrides: Partial<TreeNode> & { agent_id: string }): TreeNode {
+  return {
+    role: "worker",
+    runtime: "claude",
+    status: "running",
+    exit_code: null,
+    started_at: null,
+    duration_ms: null,
+    parent: null,
+    current_activity: null,
+    ...overrides,
+  };
+}
+
+function makeTreeData(nodes: TreeNode[]): TreeData & { type: string } {
+  return {
+    type: "tree_snapshot",
+    nodes,
+    pending_delegations: [],
+    denied_delegations: [],
+  };
+}
+
+/* ---------- Setup / Teardown ---------- */
+
+beforeEach(() => {
+  fakeInstances = [];
+  vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/* ---------- Tests ---------- */
+
+describe("useSessionWS stream_complete handling", () => {
+  it("transitions running nodes to completed on stream_complete", async () => {
+    const { result } = renderHook(() => useSessionWS("run-1", true));
+
+    // Wait for WS connection
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    const ws = fakeInstances[0];
+    expect(ws).toBeDefined();
+
+    // Server sends tree snapshot with running nodes
+    const tree = makeTreeData([
+      makeNode({ agent_id: "root", role: "ceo", status: "running", current_activity: "thinking" }),
+      makeNode({ agent_id: "child-1", role: "worker", status: "running", parent: "root" }),
+      makeNode({ agent_id: "child-2", role: "reviewer", status: "completed", parent: "root" }),
+    ]);
+
+    act(() => ws._receive(tree));
+
+    // Verify initial state — running nodes present
+    expect(result.current.treeData).not.toBeNull();
+    expect(result.current.treeData!.nodes.filter((n) => n.status === "running")).toHaveLength(2);
+
+    // Server sends stream_complete
+    act(() => ws._receive({ type: "stream_complete" }));
+
+    // All previously-running nodes should now be completed
+    const nodes = result.current.treeData!.nodes;
+    expect(nodes.find((n) => n.agent_id === "root")!.status).toBe("completed");
+    expect(nodes.find((n) => n.agent_id === "root")!.current_activity).toBeNull();
+    expect(nodes.find((n) => n.agent_id === "child-1")!.status).toBe("completed");
+    expect(nodes.find((n) => n.agent_id === "child-1")!.current_activity).toBeNull();
+    // Already-completed node stays completed
+    expect(nodes.find((n) => n.agent_id === "child-2")!.status).toBe("completed");
+
+    // No running nodes remain
+    expect(nodes.filter((n) => n.status === "running")).toHaveLength(0);
+  });
+
+  it("transitions cancelling nodes to cancelled on stream_complete", async () => {
+    const { result } = renderHook(() => useSessionWS("run-2", true));
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    const ws = fakeInstances[0];
+
+    const tree = makeTreeData([
+      makeNode({ agent_id: "root", role: "ceo", status: "cancelling" }),
+      makeNode({ agent_id: "child-1", role: "worker", status: "running", parent: "root" }),
+    ]);
+
+    act(() => ws._receive(tree));
+    act(() => ws._receive({ type: "stream_complete" }));
+
+    const nodes = result.current.treeData!.nodes;
+    expect(nodes.find((n) => n.agent_id === "root")!.status).toBe("cancelled");
+    expect(nodes.find((n) => n.agent_id === "child-1")!.status).toBe("completed");
+  });
+
+  it("clears pending_delegations on stream_complete", async () => {
+    const { result } = renderHook(() => useSessionWS("run-3", true));
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    const ws = fakeInstances[0];
+
+    const tree: TreeData & { type: string } = {
+      type: "tree_snapshot",
+      nodes: [makeNode({ agent_id: "root", role: "ceo", status: "running" })],
+      pending_delegations: [
+        { span_id: "span-1", role: "worker", requested_by: "root" } as never,
+      ],
+      denied_delegations: [],
+    };
+
+    act(() => ws._receive(tree));
+    expect(result.current.treeData!.pending_delegations).toHaveLength(1);
+
+    act(() => ws._receive({ type: "stream_complete" }));
+    expect(result.current.treeData!.pending_delegations).toHaveLength(0);
+  });
+
+  it("leaves treeData unchanged if all nodes are already terminal", async () => {
+    const { result } = renderHook(() => useSessionWS("run-4", true));
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    const ws = fakeInstances[0];
+
+    const tree = makeTreeData([
+      makeNode({ agent_id: "root", role: "ceo", status: "completed" }),
+      makeNode({ agent_id: "child-1", role: "worker", status: "failed", parent: "root" }),
+    ]);
+
+    act(() => ws._receive(tree));
+    const before = result.current.treeData;
+
+    act(() => ws._receive({ type: "stream_complete" }));
+    // Same reference — no unnecessary re-render
+    expect(result.current.treeData).toBe(before);
+  });
+
+  it("handles stream_complete when no treeData has been received", async () => {
+    const { result } = renderHook(() => useSessionWS("run-5", true));
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    const ws = fakeInstances[0];
+
+    // stream_complete before any tree snapshot — should not crash
+    act(() => ws._receive({ type: "stream_complete" }));
+    expect(result.current.treeData).toBeNull();
+    expect(result.current.connected).toBe(false);
+  });
+});

--- a/gui/frontend/src/hooks/useSessionWS.ts
+++ b/gui/frontend/src/hooks/useSessionWS.ts
@@ -223,6 +223,28 @@ export function useSessionWS(
           case "stream_complete":
             streamDoneRef.current = true;
             setPendingAskUsers([]);
+            // Transition any still-running nodes to terminal state so the
+            // tree UI immediately reflects the session being done.
+            setTreeData((prev) => {
+              if (!prev) return prev;
+              const hasRunning = prev.nodes.some(
+                (n) => n.status === "running" || n.status === "cancelling",
+              );
+              if (!hasRunning) return prev;
+              return {
+                ...prev,
+                nodes: prev.nodes.map((n) => {
+                  if (n.status === "running") {
+                    return { ...n, status: "completed" as const, current_activity: null };
+                  }
+                  if (n.status === "cancelling") {
+                    return { ...n, status: "cancelled" as const, current_activity: null };
+                  }
+                  return n;
+                }),
+                pending_delegations: [],
+              };
+            });
             ws.close();
             wsRef.current = null;
             setConnected(false);


### PR DESCRIPTION
## Summary

- **Bug:** When a session is stopped, the root agent still shows as "running" in the agent tree UI and the stop (X) button remains visible
- **Root cause:** The `stream_complete` WebSocket handler in `useSessionWS.ts` closed the connection but never updated `treeData`, leaving stale "running" nodes in React state
- **Fix:** Added `setTreeData()` call in the `stream_complete` handler that transitions `running` → `completed`, `cancelling` → `cancelled`, clears `current_activity`, and empties `pending_delegations`

## Test plan

- [x] 5 regression tests added in `useSessionWS.test.ts`
  - Running nodes transition to completed on stream_complete
  - Cancelling nodes transition to cancelled on stream_complete
  - pending_delegations cleared on stream_complete
  - No-op when all nodes already terminal (referential equality preserved)
  - No-op when treeData is null
- [x] 61/61 tests pass
- [x] Clean TypeScript build, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)