### PR TITLE
feat: wire up tool_start/tool_end tracer for real-time agent activity

### DIFF
--- a/cli/src/strawpot/activity.py
+++ b/cli/src/strawpot/activity.py
@@ -1,0 +1,97 @@
+"""Parse real-time activity from agent log output.
+
+Reads the tail of agent ``.log`` files and extracts human-readable
+activity descriptions (e.g. "Reading src/app.ts", "Running tests").
+Used by the activity watcher thread to emit ``tool_start`` /
+``tool_end`` trace events so the GUI can display live agent status.
+"""
+
+import os
+import re
+
+# ANSI escape sequence pattern
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+# Braille spinner characters used by Claude Code and similar CLIs
+_SPINNER_CHARS = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏•·…● "
+
+# Patterns that map log output to structured (tool, summary) pairs.
+# Order matters — first match wins.
+_TOOL_PATTERNS: list[tuple[re.Pattern, str]] = [
+    # Claude Code tool patterns (spinner + tool description)
+    (re.compile(r"(?i)reading\s+(.+?)\.{0,3}$"), "Read"),
+    (re.compile(r"(?i)editing\s+(.+?)\.{0,3}$"), "Edit"),
+    (re.compile(r"(?i)writing\s+(?:to\s+)?(.+?)\.{0,3}$"), "Write"),
+    (re.compile(r"(?i)searching\s+(.+?)\.{0,3}$"), "Search"),
+    (re.compile(r"(?i)running\s+(?:bash\s+)?(?:command:?\s*)?(.+?)\.{0,3}$"), "Bash"),
+    (re.compile(r"(?i)executing\s+(.+?)\.{0,3}$"), "Bash"),
+    (re.compile(r"(?i)(?:launching|spawning)\s+(?:agent\s+)?(.+?)\.{0,3}$"), "Agent"),
+    (re.compile(r"(?i)thinking\.{0,3}$"), "Think"),
+    (re.compile(r"(?i)planning\.{0,3}$"), "Think"),
+]
+
+
+def parse_activity(line: str) -> tuple[str, str] | None:
+    """Extract ``(tool, summary)`` from a single log line.
+
+    Returns ``None`` when no recognisable activity is found.
+
+    The *tool* is a short identifier (``"Read"``, ``"Edit"``, etc.)
+    and *summary* is the cleaned human-readable description suitable
+    for display in the GUI.
+    """
+    if not line:
+        return None
+
+    # Strip ANSI escape codes
+    clean = _ANSI_RE.sub("", line).strip()
+
+    # Strip leading spinner characters
+    stripped = clean.lstrip(_SPINNER_CHARS).strip()
+    if not stripped:
+        return None
+
+    # Try structured patterns first
+    for pattern, tool in _TOOL_PATTERNS:
+        m = pattern.search(stripped)
+        if m:
+            summary = stripped
+            # Truncate long summaries
+            if len(summary) > 120:
+                summary = summary[:117] + "..."
+            return tool, summary
+
+    # Fallback: lines ending with "..." or "…" look like progress
+    # indicators — treat as generic activity.
+    if len(stripped) <= 120 and (
+        stripped.endswith("...") or stripped.endswith("…")
+    ):
+        return "Tool", stripped
+
+    return None
+
+
+def read_last_activity_line(log_path: str) -> str | None:
+    """Read the last non-empty line from an agent log file.
+
+    Reads up to the last 4 KB to find the final line efficiently.
+    Returns ``None`` if the file is empty or unreadable.
+    """
+    try:
+        with open(log_path, "rb") as f:
+            f.seek(0, 2)
+            size = f.tell()
+            if size == 0:
+                return None
+            chunk_size = min(4096, size)
+            f.seek(size - chunk_size)
+            data = f.read(chunk_size).decode("utf-8", errors="replace")
+            lines = data.strip().splitlines()
+            return lines[-1].strip() if lines else None
+    except OSError:
+        return None
+
+
+def get_agent_log_path(session_dir: str, agent_id: str) -> str:
+    """Return the path to an agent's ``.log`` file."""
+    return os.path.join(session_dir, "agents", agent_id, ".log")

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -453,6 +453,10 @@ class Session:
             # 6a. Start cancel signal watcher
             self._start_cancel_watcher()
 
+            # 6b. Start activity watcher (emits tool_start/tool_end
+            #     trace events by monitoring agent log files).
+            self._start_activity_watcher()
+
             # 7. Install signal handler before blocking attach
             signal.signal(signal.SIGINT, self._handle_sigint)
 
@@ -719,6 +723,106 @@ class Session:
         finally:
             if signal_path:
                 mark_signal_done(signal_path)
+
+    # ------------------------------------------------------------------
+    # Activity watcher — emits tool_start / tool_end trace events
+    # ------------------------------------------------------------------
+
+    _ACTIVITY_POLL_INTERVAL = 1.0  # seconds
+
+    def _start_activity_watcher(self) -> None:
+        """Start a daemon thread that monitors agent logs for activity."""
+        if self._tracer is None:
+            return  # Tracing disabled — nothing to emit.
+        t = threading.Thread(
+            target=self._activity_watcher_loop,
+            name="activity-watcher",
+            daemon=True,
+        )
+        t.start()
+
+    def _activity_watcher_loop(self) -> None:
+        """Poll agent .log files and emit tool_start/tool_end trace events.
+
+        Precondition: ``self._tracer`` is not None (checked by caller).
+        """
+        from strawpot.activity import (
+            get_agent_log_path,
+            parse_activity,
+            read_last_activity_line,
+        )
+
+        tracer = self._tracer
+        assert tracer is not None  # guaranteed by _start_activity_watcher
+        session_dir = self._session_dir()
+        # Track current activity per agent: agent_id -> (tool, summary)
+        current: dict[str, tuple[str, str]] = {}
+
+        while not self._cancel_watcher_stop.is_set():
+            try:
+                # Snapshot running agents to avoid holding locks.
+                running_agents = [
+                    (aid, self._agent_spans.get(aid, ""))
+                    for aid, info in list(self._agent_info.items())
+                    if info.get("state", AgentState.RUNNING) == AgentState.RUNNING
+                ]
+
+                for agent_id, span_id in running_agents:
+                    log_path = get_agent_log_path(session_dir, agent_id)
+                    last_line = read_last_activity_line(log_path)
+                    parsed = parse_activity(last_line) if last_line else None
+
+                    prev = current.get(agent_id)
+
+                    if parsed and parsed != prev:
+                        # Activity changed — close previous, open new.
+                        if prev is not None:
+                            tracer.tool_end(
+                                span_id=span_id,
+                                agent_id=agent_id,
+                                tool=prev[0],
+                            )
+                        tracer.tool_start(
+                            span_id=span_id,
+                            agent_id=agent_id,
+                            tool=parsed[0],
+                            summary=parsed[1],
+                        )
+                        current[agent_id] = parsed
+
+                    elif parsed is None and prev is not None:
+                        # Activity cleared.
+                        tracer.tool_end(
+                            span_id=span_id,
+                            agent_id=agent_id,
+                            tool=prev[0],
+                        )
+                        del current[agent_id]
+
+                # Emit tool_end for agents that stopped while active.
+                running_ids = {aid for aid, _ in running_agents}
+                for aid in list(current):
+                    if aid not in running_ids:
+                        prev = current.pop(aid)
+                        span_id = self._agent_spans.get(aid, "")
+                        tracer.tool_end(
+                            span_id=span_id, agent_id=aid, tool=prev[0],
+                        )
+
+            except OSError:
+                logger.debug("Activity watcher I/O error", exc_info=True)
+            except Exception:
+                logger.warning("Activity watcher error", exc_info=True)
+
+            self._cancel_watcher_stop.wait(timeout=self._ACTIVITY_POLL_INTERVAL)
+
+        # Drain: emit tool_end for any activities still tracked at shutdown.
+        for aid, prev in current.items():
+            span_id = self._agent_spans.get(aid, "")
+            try:
+                tracer.tool_end(span_id=span_id, agent_id=aid, tool=prev[0])
+            except Exception:
+                logger.debug("Failed to emit final tool_end for %s", aid)
 
     # ------------------------------------------------------------------
     # Denden server

--- a/cli/tests/test_activity.py
+++ b/cli/tests/test_activity.py
@@ -1,0 +1,187 @@
+"""Tests for strawpot.activity — log line activity parser."""
+
+from strawpot.activity import (
+    get_agent_log_path,
+    parse_activity,
+    read_last_activity_line,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_activity
+# ---------------------------------------------------------------------------
+
+
+class TestParseActivity:
+    """Tests for parse_activity()."""
+
+    def test_empty_string_returns_none(self):
+        assert parse_activity("") is None
+
+    def test_none_like_input(self):
+        assert parse_activity("   ") is None
+
+    def test_reading_file(self):
+        result = parse_activity("⠋ Reading src/app.ts...")
+        assert result is not None
+        tool, summary = result
+        assert tool == "Read"
+        assert "Reading src/app.ts" in summary
+
+    def test_editing_file(self):
+        result = parse_activity("⠙ Editing src/component.tsx...")
+        assert result is not None
+        assert result[0] == "Edit"
+        assert "Editing src/component.tsx" in result[1]
+
+    def test_writing_file(self):
+        result = parse_activity("⠹ Writing to src/index.ts...")
+        assert result is not None
+        assert result[0] == "Write"
+
+    def test_writing_without_to(self):
+        result = parse_activity("⠹ Writing src/index.ts...")
+        assert result is not None
+        assert result[0] == "Write"
+
+    def test_running_bash_command(self):
+        result = parse_activity("⠸ Running bash command: npm test...")
+        assert result is not None
+        assert result[0] == "Bash"
+
+    def test_running_command(self):
+        result = parse_activity("⠼ Running npm install...")
+        assert result is not None
+        assert result[0] == "Bash"
+
+    def test_executing_command(self):
+        result = parse_activity("⠴ Executing pytest...")
+        assert result is not None
+        assert result[0] == "Bash"
+
+    def test_searching(self):
+        result = parse_activity("⠦ Searching for files...")
+        assert result is not None
+        assert result[0] == "Search"
+
+    def test_thinking(self):
+        result = parse_activity("⠧ Thinking...")
+        assert result is not None
+        assert result[0] == "Think"
+
+    def test_planning(self):
+        result = parse_activity("⠇ Planning...")
+        assert result is not None
+        assert result[0] == "Think"
+
+    def test_spawning_agent(self):
+        result = parse_activity("⠏ Launching agent code-reviewer...")
+        assert result is not None
+        assert result[0] == "Agent"
+
+    def test_ansi_codes_stripped(self):
+        result = parse_activity("\x1b[32m⠋ Reading file.py...\x1b[0m")
+        assert result is not None
+        assert result[0] == "Read"
+
+    def test_generic_activity_with_ellipsis(self):
+        result = parse_activity("⠋ Analyzing dependencies...")
+        assert result is not None
+        assert result[0] == "Tool"
+        assert "Analyzing dependencies" in result[1]
+
+    def test_generic_activity_with_unicode_ellipsis(self):
+        result = parse_activity("⠋ Processing…")
+        assert result is not None
+        assert result[0] == "Tool"
+
+    def test_plain_text_no_activity(self):
+        # Regular output text should not be parsed as activity
+        result = parse_activity("Here is the implementation of the function:")
+        assert result is None
+
+    def test_long_line_truncated(self):
+        long_path = "a" * 200
+        result = parse_activity(f"⠋ Reading {long_path}...")
+        assert result is not None
+        assert len(result[1]) <= 120
+
+    def test_case_insensitive(self):
+        result = parse_activity("⠋ READING src/app.ts...")
+        assert result is not None
+        assert result[0] == "Read"
+
+    def test_no_spinner_prefix(self):
+        # Activity text without spinner chars should still match
+        result = parse_activity("Reading src/app.ts...")
+        assert result is not None
+        assert result[0] == "Read"
+
+    def test_same_activity_returns_same_tuple(self):
+        # Ensure tuple equality works for dedup checks
+        r1 = parse_activity("⠋ Reading file.py...")
+        r2 = parse_activity("⠋ Reading file.py...")
+        assert r1 == r2
+
+    def test_different_activity_returns_different_tuple(self):
+        r1 = parse_activity("⠋ Reading file.py...")
+        r2 = parse_activity("⠋ Editing file.py...")
+        assert r1 != r2
+
+
+# ---------------------------------------------------------------------------
+# read_last_activity_line
+# ---------------------------------------------------------------------------
+
+
+class TestReadLastActivityLine:
+    """Tests for read_last_activity_line()."""
+
+    def test_empty_file(self, tmp_path):
+        log = tmp_path / "test.log"
+        log.write_text("")
+        assert read_last_activity_line(str(log)) is None
+
+    def test_single_line(self, tmp_path):
+        log = tmp_path / "test.log"
+        log.write_text("⠋ Reading file.py...\n")
+        result = read_last_activity_line(str(log))
+        assert result is not None
+        assert "Reading file.py" in result
+
+    def test_multiple_lines_returns_last(self, tmp_path):
+        log = tmp_path / "test.log"
+        log.write_text("⠋ Reading file.py...\n⠙ Editing file.py...\n")
+        result = read_last_activity_line(str(log))
+        assert result is not None
+        assert "Editing file.py" in result
+
+    def test_trailing_empty_lines_skipped(self, tmp_path):
+        log = tmp_path / "test.log"
+        log.write_text("⠋ Reading file.py...\n\n\n")
+        result = read_last_activity_line(str(log))
+        assert result is not None
+        assert "Reading file.py" in result
+
+    def test_nonexistent_file_returns_none(self):
+        assert read_last_activity_line("/nonexistent/path.log") is None
+
+    def test_large_file_reads_last_line(self, tmp_path):
+        log = tmp_path / "test.log"
+        # Write enough lines to exceed 4KB
+        lines = ["Line " + str(i) + "\n" for i in range(500)]
+        lines.append("⠋ Final activity...\n")
+        log.write_text("".join(lines))
+        result = read_last_activity_line(str(log))
+        assert result == "⠋ Final activity..."
+
+
+# ---------------------------------------------------------------------------
+# get_agent_log_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetAgentLogPath:
+    def test_path_format(self):
+        result = get_agent_log_path("/sessions/run_abc", "agent_123")
+        assert result == "/sessions/run_abc/agents/agent_123/.log"

--- a/cli/tests/test_session.py
+++ b/cli/tests/test_session.py
@@ -3,7 +3,8 @@
 import json
 import os
 import tempfile
-from unittest.mock import MagicMock, patch
+import threading
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -1563,3 +1564,200 @@ class TestMaxNumDelegations:
         # Third call — limit reached, denied
         resp = session._handle_delegate(self._make_denden_request())
         assert "DENY_DELEGATIONS_LIMIT" in str(resp)
+
+
+# ---------------------------------------------------------------------------
+# Activity watcher loop
+# ---------------------------------------------------------------------------
+
+
+class TestActivityWatcherLoop:
+    """Tests for the _activity_watcher_loop orchestration logic.
+
+    These tests exercise the watcher's state machine directly by:
+    - Setting up Session internals (_agent_info, _agent_spans, _tracer)
+    - Writing fake log files
+    - Running a single iteration of the loop (stop event fires after one tick)
+    """
+
+    def _make_session_for_watcher(self, tmp_path):
+        """Create a minimally-configured Session for watcher tests."""
+        session = _make_session(tmp_path)
+        session._tracer = MagicMock()
+        session._cancel_watcher_stop = threading.Event()
+        # Point session dir to tmp_path so log files are discoverable
+        session._session_dir = lambda: str(tmp_path)
+        return session
+
+    def _write_agent_log(self, tmp_path, agent_id, content):
+        """Write a fake agent log file."""
+        log_dir = tmp_path / "agents" / agent_id
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / ".log").write_text(content)
+
+    def _register_agent(self, session, agent_id, span_id="span_1", state="running"):
+        from strawpot.cancel import AgentState
+        session._agent_info[agent_id] = {"state": AgentState(state)}
+        session._agent_spans[agent_id] = span_id
+
+    def _run_iterations(self, session, n=1, between=None):
+        """Run the watcher loop for *n* iterations then stop.
+
+        ``between`` is an optional callback invoked after each iteration
+        (except the last) — use it to change log files or agent state
+        between ticks.
+
+        The loop's ``current`` dict is local, so we must run all
+        iterations in a single call to preserve state tracking.
+        """
+        count = 0
+        original_wait = session._cancel_watcher_stop.wait
+
+        def _tick_wait(**kwargs):
+            nonlocal count
+            count += 1
+            if between and count < n:
+                between(count)
+            if count >= n:
+                session._cancel_watcher_stop.set()
+            return count >= n
+
+        session._cancel_watcher_stop.clear()
+        session._cancel_watcher_stop.wait = _tick_wait
+        session._ACTIVITY_POLL_INTERVAL = 0.01
+        session._activity_watcher_loop()
+        session._cancel_watcher_stop.wait = original_wait
+
+    def test_new_activity_emits_tool_start(self, tmp_path):
+        session = self._make_session_for_watcher(tmp_path)
+        self._register_agent(session, "agent_1", "span_1")
+        self._write_agent_log(tmp_path, "agent_1", "⠋ Reading src/app.ts...\n")
+
+        self._run_iterations(session)
+
+        session._tracer.tool_start.assert_called_once_with(
+            span_id="span_1",
+            agent_id="agent_1",
+            tool="Read",
+            summary="Reading src/app.ts...",
+        )
+        # Drain emits tool_end on shutdown for still-tracked activity.
+        session._tracer.tool_end.assert_called_once_with(
+            span_id="span_1", agent_id="agent_1", tool="Read",
+        )
+
+    def test_activity_change_emits_tool_end_then_tool_start(self, tmp_path):
+        """When activity changes, tool_end fires for old, tool_start for new."""
+        session = self._make_session_for_watcher(tmp_path)
+        self._register_agent(session, "agent_1", "span_1")
+        self._write_agent_log(tmp_path, "agent_1", "⠋ Reading file.py...\n")
+
+        def change_log(_tick):
+            self._write_agent_log(tmp_path, "agent_1", "⠙ Editing file.py...\n")
+
+        self._run_iterations(session, n=2, between=change_log)
+
+        # Iteration 1: tool_start(Read). Iteration 2: tool_end(Read) + tool_start(Edit).
+        # Drain: tool_end(Edit).
+        assert session._tracer.tool_start.call_count == 2
+        assert session._tracer.tool_end.call_count == 2  # Read + Edit (drain)
+        session._tracer.tool_start.assert_called_with(
+            span_id="span_1", agent_id="agent_1",
+            tool="Edit", summary="Editing file.py...",
+        )
+
+    def test_activity_cleared_emits_tool_end(self, tmp_path):
+        """When log no longer contains activity, tool_end fires."""
+        session = self._make_session_for_watcher(tmp_path)
+        self._register_agent(session, "agent_1", "span_1")
+        self._write_agent_log(tmp_path, "agent_1", "⠋ Reading file.py...\n")
+
+        def clear_log(_tick):
+            self._write_agent_log(tmp_path, "agent_1", "Here is the result:\n")
+
+        self._run_iterations(session, n=2, between=clear_log)
+
+        # Iteration 1: tool_start(Read). Iteration 2: tool_end(Read).
+        session._tracer.tool_start.assert_called_once()
+        session._tracer.tool_end.assert_called_once_with(
+            span_id="span_1", agent_id="agent_1", tool="Read",
+        )
+
+    def test_agent_stops_while_active_emits_tool_end(self, tmp_path):
+        """When an agent leaves RUNNING state, its pending activity is closed."""
+        from strawpot.cancel import AgentState
+
+        session = self._make_session_for_watcher(tmp_path)
+        self._register_agent(session, "agent_1", "span_1")
+        self._write_agent_log(tmp_path, "agent_1", "⠋ Reading file.py...\n")
+
+        def stop_agent(_tick):
+            session._agent_info["agent_1"]["state"] = AgentState.COMPLETED
+
+        self._run_iterations(session, n=2, between=stop_agent)
+
+        # Iteration 1: tool_start. Iteration 2: agent no longer running → tool_end.
+        session._tracer.tool_start.assert_called_once()
+        session._tracer.tool_end.assert_called_once_with(
+            span_id="span_1", agent_id="agent_1", tool="Read",
+        )
+
+    def test_no_log_file_does_not_crash(self, tmp_path):
+        """Missing log file produces no tracer calls and no crash."""
+        session = self._make_session_for_watcher(tmp_path)
+        self._register_agent(session, "agent_1", "span_1")
+        # No log file written
+
+        self._run_iterations(session)
+
+        session._tracer.tool_start.assert_not_called()
+        session._tracer.tool_end.assert_not_called()
+
+    def test_same_activity_no_duplicate_events(self, tmp_path):
+        """Same activity across iterations should not re-emit tool_start."""
+        session = self._make_session_for_watcher(tmp_path)
+        self._register_agent(session, "agent_1", "span_1")
+        self._write_agent_log(tmp_path, "agent_1", "⠋ Reading file.py...\n")
+
+        # Run two iterations with the same log content
+        self._run_iterations(session, n=2)
+
+        # tool_start called only once (dedup on second iteration)
+        assert session._tracer.tool_start.call_count == 1
+        # Drain emits tool_end on shutdown.
+        session._tracer.tool_end.assert_called_once_with(
+            span_id="span_1", agent_id="agent_1", tool="Read",
+        )
+
+    def test_exception_in_parse_does_not_kill_loop(self, tmp_path):
+        """Errors during activity parsing are caught; loop continues."""
+        session = self._make_session_for_watcher(tmp_path)
+        self._register_agent(session, "agent_1", "span_1")
+        self._write_agent_log(tmp_path, "agent_1", "⠋ Reading file.py...\n")
+
+        with patch("strawpot.activity.parse_activity", side_effect=RuntimeError("boom")):
+            # Should not raise — exception is caught
+            self._run_iterations(session)
+
+        # No tracer calls since parsing failed
+        session._tracer.tool_start.assert_not_called()
+
+    def test_skips_non_running_agents(self, tmp_path):
+        """Agents in COMPLETED/CANCELLED state are not polled."""
+        from strawpot.cancel import AgentState
+
+        session = self._make_session_for_watcher(tmp_path)
+        self._register_agent(session, "agent_1", "span_1", state="completed")
+        self._write_agent_log(tmp_path, "agent_1", "⠋ Reading file.py...\n")
+
+        self._run_iterations(session)
+
+        session._tracer.tool_start.assert_not_called()
+
+    def test_no_tracer_skips_watcher(self, tmp_path):
+        """_start_activity_watcher is a no-op when tracer is None."""
+        session = _make_session(tmp_path)
+        session._tracer = None
+        # Should return immediately without spawning a thread
+        session._start_activity_watcher()
+        # No crash — that's the assertion

--- a/gui/src/strawpot_gui/routers/ws.py
+++ b/gui/src/strawpot_gui/routers/ws.py
@@ -74,10 +74,22 @@ def _read_last_log_line(log_path: str) -> str | None:
         return None
 
 
+_ACTIVITY_KEYWORDS_RE = _re.compile(
+    r"(?i)^(?:reading|editing|writing|searching|running|executing|"
+    r"thinking|planning|launching|spawning|analyzing|processing|"
+    r"installing|building|testing|compiling|fetching|downloading|"
+    r"uploading|creating|deleting|updating|checking|reviewing|"
+    r"formatting|linting|deploying|committing|pushing|pulling|"
+    r"cloning|merging|rebasing)\b"
+)
+
+
 def _parse_activity_from_log_line(line: str) -> str | None:
     """Extract a human-readable activity description from an agent log line.
 
     Returns ``None`` if the line doesn't contain recognisable activity.
+    Only returns text that looks like a genuine status indicator (starts
+    with a known verb or ends with ``...`` / ``…``), not arbitrary output.
     """
     if not line:
         return None
@@ -86,6 +98,15 @@ def _parse_activity_from_log_line(line: str) -> str | None:
     # Strip leading spinner characters (braille patterns, dots, etc.)
     clean = clean.lstrip("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏•·…● ").strip()
     if not clean:
+        return None
+    # Only accept lines that look like activity indicators:
+    # - start with a known verb, or
+    # - end with "..." / "…" (progress indicator)
+    if not (
+        _ACTIVITY_KEYWORDS_RE.match(clean)
+        or clean.endswith("...")
+        or clean.endswith("…")
+    ):
         return None
     # Truncate to a reasonable display length
     if len(clean) > 120:

--- a/gui/tests/test_session_ws.py
+++ b/gui/tests/test_session_ws.py
@@ -456,17 +456,44 @@ class TestParseActivityFromLogLine:
     def test_truncates_long_lines(self):
         from strawpot_gui.routers.ws import _parse_activity_from_log_line
 
-        long_line = "x" * 200
+        # Use a recognised verb prefix so the line is accepted as activity
+        long_line = "Reading " + "x" * 200
         result = _parse_activity_from_log_line(long_line)
-        assert len(result) == 118  # 117 chars + "…" (single char)
+        assert result is not None
+        assert len(result) <= 120
         assert result.endswith("…")
 
     def test_does_not_truncate_line_at_boundary(self):
         from strawpot_gui.routers.ws import _parse_activity_from_log_line
 
-        line_120 = "x" * 120
-        result = _parse_activity_from_log_line(line_120)
-        assert result == line_120  # exactly 120 — not truncated
+        line = "Running " + "x" * 112  # exactly 120 chars
+        result = _parse_activity_from_log_line(line)
+        assert result == line  # exactly 120 — not truncated
+
+    def test_returns_none_for_unrecognised_text(self):
+        from strawpot_gui.routers.ws import _parse_activity_from_log_line
+
+        # Plain text that doesn't look like activity should be filtered
+        assert _parse_activity_from_log_line("Here is the code:") is None
+        assert _parse_activity_from_log_line("x" * 200) is None
+
+    def test_accepts_verbs_from_all_regex_groups(self):
+        """Verify verbs from each line of the keyword regex are accepted."""
+        from strawpot_gui.routers.ws import _parse_activity_from_log_line
+
+        # Sample verbs from different lines of _ACTIVITY_KEYWORDS_RE
+        assert _parse_activity_from_log_line("Installing packages") == "Installing packages"
+        assert _parse_activity_from_log_line("Deploying to staging") == "Deploying to staging"
+        assert _parse_activity_from_log_line("Rebasing branch") == "Rebasing branch"
+        assert _parse_activity_from_log_line("Fetching data") == "Fetching data"
+        assert _parse_activity_from_log_line("Analyzing code") == "Analyzing code"
+
+    def test_accepts_ellipsis_suffix_without_keyword(self):
+        """Lines ending with ... or … are accepted even without a known verb."""
+        from strawpot_gui.routers.ws import _parse_activity_from_log_line
+
+        assert _parse_activity_from_log_line("Doing something...") == "Doing something..."
+        assert _parse_activity_from_log_line("Working on it…") == "Working on it…"
 
     def test_combined_ansi_and_spinner(self):
         from strawpot_gui.routers.ws import _parse_activity_from_log_line


### PR DESCRIPTION
## Summary
- **New `activity.py` module**: Parses CLI agent log output into structured `(tool, summary)` pairs — handles ANSI escape codes, braille spinners, and common activity patterns (Reading, Editing, Running, etc.)
- **Activity watcher thread in `session.py`**: Daemon thread polls agent `.log` files every 1s, emits `tool_start`/`tool_end` trace events via the tracer, properly drains on shutdown
- **Improved log-based fallback in `ws.py`**: Only accepts recognized activity verbs and ellipsis patterns, filtering out arbitrary output text that previously leaked as stale activity

## Problem
The GUI conversation view showed "Working" for single root-level agents instead of real-time activity (e.g., "Reading src/app.ts..."). Root cause: `tool_start()`/`tool_end()` tracer methods existed but were never called — `current_activity` was never populated with tool usage info.

## How it works
1. Activity watcher monitors agent `.log` files for tool usage patterns
2. Emits `tool_start`/`tool_end` trace events to `trace.jsonl`
3. GUI backend's WebSocket watcher picks up trace changes
4. `TreeState.process_event()` sets `current_activity` on the node
5. Frontend receives `tree_delta` with live activity text

## Test plan
- [x] 29 unit tests for `activity.py` parser (patterns, edge cases, truncation)
- [x] 9 integration tests for activity watcher loop (emit, change, clear, drain, error handling)
- [x] Updated 3 existing `ws.py` parse tests + added 3 new ones for keyword filtering
- [x] All 109 CLI tests pass, all 70 GUI WS/SSE tests pass
- [x] No regressions in full GUI test suite (998 tests)

Related to #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)