### PR TITLE
feat: add prompt history navigation with Up/Down arrow keys

### DIFF
--- a/gui/frontend/src/hooks/usePromptHistory.test.ts
+++ b/gui/frontend/src/hooks/usePromptHistory.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { usePromptHistory } from "./usePromptHistory";
+import type React from "react";
+
+/* ---------- Helpers ---------- */
+
+/** Build a minimal fake KeyboardEvent targeting a fake textarea. */
+function makeKeyEvent(
+  key: string,
+  textareaOverrides: {
+    value?: string;
+    selectionStart?: number;
+    selectionEnd?: number;
+  } = {},
+): React.KeyboardEvent<HTMLTextAreaElement> {
+  const defaultValue = textareaOverrides.value ?? "";
+  const el = {
+    value: defaultValue,
+    selectionStart: textareaOverrides.selectionStart ?? 0,
+    selectionEnd: textareaOverrides.selectionEnd ?? 0,
+  } as HTMLTextAreaElement;
+
+  return {
+    key,
+    currentTarget: el,
+    preventDefault: vi.fn(),
+  } as unknown as React.KeyboardEvent<HTMLTextAreaElement>;
+}
+
+/* ---------- Tests ---------- */
+
+describe("usePromptHistory", () => {
+  let text: string;
+  const setText = vi.fn<(v: string) => void>();
+
+  beforeEach(() => {
+    text = "";
+    setText.mockClear();
+    setText.mockImplementation((v: string) => {
+      text = v;
+    });
+  });
+
+  function renderHistory() {
+    return renderHook(
+      (props: { text: string }) =>
+        usePromptHistory({ text: props.text, setText }),
+      { initialProps: { text } },
+    );
+  }
+
+  describe("addToHistory", () => {
+    it("stores submitted prompts", () => {
+      const { result } = renderHistory();
+
+      act(() => result.current.addToHistory("hello"));
+      act(() => result.current.addToHistory("world"));
+
+      // Navigate up twice to verify both entries exist.
+      const e1 = makeKeyEvent("ArrowUp", { value: "", selectionStart: 0 });
+      act(() => result.current.handleHistoryKeyDown(e1));
+      expect(setText).toHaveBeenLastCalledWith("world");
+
+      const e2 = makeKeyEvent("ArrowUp", { value: "world", selectionStart: 0 });
+      act(() => result.current.handleHistoryKeyDown(e2));
+      expect(setText).toHaveBeenLastCalledWith("hello");
+    });
+
+    it("ignores empty/whitespace prompts", () => {
+      const { result } = renderHistory();
+
+      act(() => result.current.addToHistory(""));
+      act(() => result.current.addToHistory("   "));
+
+      // ArrowUp should do nothing — no history.
+      const e = makeKeyEvent("ArrowUp", { value: "", selectionStart: 0 });
+      act(() => result.current.handleHistoryKeyDown(e));
+      expect(e.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("deduplicates consecutive identical prompts", () => {
+      const { result } = renderHistory();
+
+      act(() => result.current.addToHistory("same"));
+      act(() => result.current.addToHistory("same"));
+      act(() => result.current.addToHistory("same"));
+
+      // One ArrowUp → "same", second ArrowUp should not move further.
+      const e1 = makeKeyEvent("ArrowUp", { value: "", selectionStart: 0 });
+      act(() => result.current.handleHistoryKeyDown(e1));
+      expect(setText).toHaveBeenLastCalledWith("same");
+
+      // Already at oldest — should not call setText again.
+      setText.mockClear();
+      const e2 = makeKeyEvent("ArrowUp", { value: "same", selectionStart: 0 });
+      act(() => result.current.handleHistoryKeyDown(e2));
+      expect(setText).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ArrowUp navigation", () => {
+    it("does nothing when history is empty", () => {
+      const { result } = renderHistory();
+      const e = makeKeyEvent("ArrowUp", { value: "", selectionStart: 0 });
+
+      act(() => result.current.handleHistoryKeyDown(e));
+
+      expect(e.preventDefault).not.toHaveBeenCalled();
+      expect(setText).not.toHaveBeenCalled();
+    });
+
+    it("recalls the most recent prompt on first ArrowUp", () => {
+      const { result } = renderHistory();
+      act(() => result.current.addToHistory("first"));
+      act(() => result.current.addToHistory("second"));
+
+      const e = makeKeyEvent("ArrowUp", { value: "", selectionStart: 0 });
+      act(() => result.current.handleHistoryKeyDown(e));
+
+      expect(e.preventDefault).toHaveBeenCalled();
+      expect(setText).toHaveBeenCalledWith("second");
+    });
+
+    it("navigates to older entries on successive ArrowUp", () => {
+      const { result } = renderHistory();
+      act(() => result.current.addToHistory("a"));
+      act(() => result.current.addToHistory("b"));
+      act(() => result.current.addToHistory("c"));
+
+      // First up → "c"
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "", selectionStart: 0 }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("c");
+
+      // Second up → "b"
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "c", selectionStart: 0 }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("b");
+
+      // Third up → "a"
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "b", selectionStart: 0 }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("a");
+    });
+
+    it("stops at the oldest entry", () => {
+      const { result } = renderHistory();
+      act(() => result.current.addToHistory("only"));
+
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "", selectionStart: 0 }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("only");
+
+      // Another ArrowUp should not call setText again.
+      setText.mockClear();
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "only", selectionStart: 0 }),
+        ),
+      );
+      expect(setText).not.toHaveBeenCalled();
+    });
+
+    it("does NOT intercept when cursor is NOT on the first line", () => {
+      const { result } = renderHistory();
+      act(() => result.current.addToHistory("prev"));
+
+      // Cursor is on line 2 of a multiline value.
+      const e = makeKeyEvent("ArrowUp", {
+        value: "line1\nline2",
+        selectionStart: 8, // middle of "line2"
+      });
+      act(() => result.current.handleHistoryKeyDown(e));
+
+      expect(e.preventDefault).not.toHaveBeenCalled();
+      expect(setText).not.toHaveBeenCalled();
+    });
+
+    it("intercepts when cursor is on the first line of multiline text", () => {
+      const { result } = renderHistory();
+      act(() => result.current.addToHistory("prev"));
+
+      // Cursor at position 3 — within "line1" (before the \n at index 5).
+      const e = makeKeyEvent("ArrowUp", {
+        value: "line1\nline2",
+        selectionStart: 3,
+      });
+      act(() => result.current.handleHistoryKeyDown(e));
+
+      expect(e.preventDefault).toHaveBeenCalled();
+      expect(setText).toHaveBeenCalledWith("prev");
+    });
+  });
+
+  describe("ArrowDown navigation", () => {
+    it("does nothing when not navigating history", () => {
+      const { result } = renderHistory();
+      act(() => result.current.addToHistory("something"));
+
+      const e = makeKeyEvent("ArrowDown", { value: "", selectionStart: 0 });
+      act(() => result.current.handleHistoryKeyDown(e));
+
+      expect(e.preventDefault).not.toHaveBeenCalled();
+      expect(setText).not.toHaveBeenCalled();
+    });
+
+    it("navigates forward and restores draft", () => {
+      text = "my draft";
+      const { result, rerender } = renderHistory();
+
+      act(() => result.current.addToHistory("old"));
+      act(() => result.current.addToHistory("new"));
+
+      // Rerender with current text so the hook sees the draft.
+      rerender({ text: "my draft" });
+
+      // Up → "new" (stashes "my draft")
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "my draft", selectionStart: 0 }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("new");
+
+      // Up → "old"
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "new", selectionStart: 0 }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("old");
+
+      // Down → "new"
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowDown", {
+            value: "old",
+            selectionStart: 3,
+          }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("new");
+
+      // Down → restore draft "my draft"
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowDown", {
+            value: "new",
+            selectionStart: 3,
+          }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("my draft");
+    });
+
+    it("does NOT intercept when cursor is NOT on the last line", () => {
+      const { result } = renderHistory();
+      act(() => result.current.addToHistory("prev"));
+
+      // Navigate into history first.
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "", selectionStart: 0 }),
+        ),
+      );
+
+      // Cursor on first line of multiline — not on last line.
+      const e = makeKeyEvent("ArrowDown", {
+        value: "line1\nline2",
+        selectionStart: 3,
+      });
+      act(() => result.current.handleHistoryKeyDown(e));
+
+      expect(e.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("intercepts when cursor is on the last line of multiline text", () => {
+      const { result } = renderHistory();
+      act(() => result.current.addToHistory("old"));
+      act(() => result.current.addToHistory("new"));
+
+      // Navigate into history first.
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "", selectionStart: 0 }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("new");
+
+      // Cursor on last line of multiline — should intercept.
+      const e = makeKeyEvent("ArrowDown", {
+        value: "line1\nline2",
+        selectionStart: 8, // middle of "line2"
+      });
+      act(() => result.current.handleHistoryKeyDown(e));
+
+      expect(e.preventDefault).toHaveBeenCalled();
+    });
+  });
+
+  describe("boundary edge cases", () => {
+    it("ArrowUp intercepts when cursor is exactly at the newline position", () => {
+      const { result } = renderHistory();
+      act(() => result.current.addToHistory("prev"));
+
+      // selectionStart === index of \n (position 5 in "line1\nline2")
+      const e = makeKeyEvent("ArrowUp", {
+        value: "line1\nline2",
+        selectionStart: 5, // exactly at the \n
+      });
+      act(() => result.current.handleHistoryKeyDown(e));
+
+      // isOnFirstLine returns true when pos <= firstNewline, so pos=5 is first line.
+      expect(e.preventDefault).toHaveBeenCalled();
+      expect(setText).toHaveBeenCalledWith("prev");
+    });
+
+    it("ArrowDown does NOT intercept when cursor is exactly at the last newline", () => {
+      const { result } = renderHistory();
+      act(() => result.current.addToHistory("prev"));
+
+      // Navigate into history first.
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "", selectionStart: 0 }),
+        ),
+      );
+
+      // selectionStart === index of last \n (position 5 in "line1\nline2").
+      // isOnLastLine uses pos > lastNewline (strict), so pos=5 is NOT last line.
+      const e = makeKeyEvent("ArrowDown", {
+        value: "line1\nline2",
+        selectionStart: 5, // exactly at the \n
+      });
+      act(() => result.current.handleHistoryKeyDown(e));
+
+      expect(e.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("preserves non-consecutive duplicate entries", () => {
+      const { result } = renderHistory();
+      act(() => result.current.addToHistory("a"));
+      act(() => result.current.addToHistory("b"));
+      act(() => result.current.addToHistory("a")); // not consecutive dup of "a"
+
+      // Up → "a" (most recent)
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "", selectionStart: 0 }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("a");
+
+      // Up → "b"
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "a", selectionStart: 0 }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("b");
+
+      // Up → "a" (oldest)
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "b", selectionStart: 0 }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("a");
+    });
+  });
+
+  describe("history reset on new submission", () => {
+    it("resets navigation index after addToHistory", () => {
+      const { result } = renderHistory();
+      act(() => result.current.addToHistory("first"));
+
+      // Navigate up.
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "", selectionStart: 0 }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("first");
+
+      // Submit a new prompt — resets navigation.
+      act(() => result.current.addToHistory("second"));
+
+      // ArrowDown should do nothing (not in history navigation).
+      setText.mockClear();
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowDown", { value: "second", selectionStart: 6 }),
+        ),
+      );
+      expect(setText).not.toHaveBeenCalled();
+
+      // ArrowUp should go to "second" (the newest).
+      act(() =>
+        result.current.handleHistoryKeyDown(
+          makeKeyEvent("ArrowUp", { value: "", selectionStart: 0 }),
+        ),
+      );
+      expect(setText).toHaveBeenLastCalledWith("second");
+    });
+  });
+});

--- a/gui/frontend/src/hooks/usePromptHistory.ts
+++ b/gui/frontend/src/hooks/usePromptHistory.ts
@@ -1,0 +1,126 @@
+import { useCallback, useRef } from "react";
+import type React from "react";
+
+/**
+ * Shell-style prompt history navigation for textarea inputs.
+ *
+ * Keeps an in-memory, conversation-scoped list of previously submitted prompts.
+ * Up/Down arrow keys navigate the history when the cursor is at the
+ * text boundary (start for Up, end for Down). Multiline text is handled
+ * naturally — arrow keys only trigger history navigation when already at
+ * the first/last line boundary.
+ */
+
+export interface UsePromptHistoryOptions {
+  /** Current textarea value. */
+  text: string;
+  /** Setter for the textarea value. */
+  setText: (value: string) => void;
+}
+
+export interface UsePromptHistoryReturn {
+  /** Attach to onKeyDown on the textarea. */
+  handleHistoryKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  /** Call with the submitted prompt text (before clearing the input). */
+  addToHistory: (prompt: string) => void;
+}
+
+/**
+ * Returns `true` when the cursor sits on the **first** line of a textarea.
+ *
+ * "First line" means everything before the first `\n` (or the entire text
+ * if there are no newlines).  We check that `selectionStart` falls within
+ * that range (0 … firstNewline-inclusive).
+ */
+function isOnFirstLine(el: HTMLTextAreaElement): boolean {
+  const pos = el.selectionStart;
+  const firstNewline = el.value.indexOf("\n");
+  // No newlines → always on the first (and only) line.
+  if (firstNewline === -1) return true;
+  return pos <= firstNewline;
+}
+
+/**
+ * Returns `true` when the cursor sits on the **last** line of a textarea.
+ */
+function isOnLastLine(el: HTMLTextAreaElement): boolean {
+  const pos = el.selectionStart;
+  const lastNewline = el.value.lastIndexOf("\n");
+  // No newlines → always on the last (and only) line.
+  if (lastNewline === -1) return true;
+  return pos > lastNewline;
+}
+
+export function usePromptHistory({
+  text,
+  setText,
+}: UsePromptHistoryOptions): UsePromptHistoryReturn {
+  // History entries ordered oldest → newest.
+  const historyRef = useRef<string[]>([]);
+  // Index into history: -1 means "not navigating" (showing current draft).
+  const indexRef = useRef(-1);
+  // Stashed current input when user starts navigating up.
+  const draftRef = useRef("");
+  // Ref to current text so handleHistoryKeyDown stays stable across re-renders.
+  const textRef = useRef(text);
+  textRef.current = text;
+
+  const addToHistory = useCallback((prompt: string) => {
+    const trimmed = prompt.trim();
+    if (!trimmed) return;
+    // Avoid consecutive duplicates.
+    const hist = historyRef.current;
+    if (hist.length === 0 || hist[hist.length - 1] !== trimmed) {
+      hist.push(trimmed);
+    }
+    // Reset navigation state.
+    indexRef.current = -1;
+    draftRef.current = "";
+  }, []);
+
+  const handleHistoryKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      const el = e.currentTarget;
+      const hist = historyRef.current;
+
+      if (e.key === "ArrowUp") {
+        // Only intercept when on the first line (cursor hasn't crossed a newline).
+        if (!isOnFirstLine(el)) return;
+        if (hist.length === 0) return;
+
+        e.preventDefault();
+
+        if (indexRef.current === -1) {
+          // Starting navigation — stash current input.
+          draftRef.current = textRef.current;
+          indexRef.current = hist.length - 1;
+        } else if (indexRef.current > 0) {
+          indexRef.current -= 1;
+        } else {
+          // Already at oldest entry — do nothing.
+          return;
+        }
+
+        setText(hist[indexRef.current]);
+      } else if (e.key === "ArrowDown") {
+        // Only intercept when on the last line.
+        if (!isOnLastLine(el)) return;
+        if (indexRef.current === -1) return; // Not navigating history.
+
+        e.preventDefault();
+
+        if (indexRef.current < hist.length - 1) {
+          indexRef.current += 1;
+          setText(hist[indexRef.current]);
+        } else {
+          // Past the newest entry — restore draft.
+          indexRef.current = -1;
+          setText(draftRef.current);
+        }
+      }
+    },
+    [setText],
+  );
+
+  return { handleHistoryKeyDown, addToHistory };
+}

--- a/gui/frontend/src/pages/ConversationView.tsx
+++ b/gui/frontend/src/pages/ConversationView.tsx
@@ -5,6 +5,7 @@ import { useConversationInfinite } from "@/hooks/queries/use-conversations";
 import { useSubmitConversationTask, useRenameConversation, useCancelPendingTask, useCancelQueuedTask } from "@/hooks/mutations/use-conversations";
 import { useStopSession } from "@/hooks/mutations/use-sessions";
 import { useSessionWS } from "@/hooks/useSessionWS";
+import { usePromptHistory } from "@/hooks/usePromptHistory";
 import { useProjectResources } from "@/hooks/queries/use-project-resources";
 import { useProjectFiles, useProjectConfig } from "@/hooks/queries/use-projects";
 import { Badge } from "@/components/ui/badge";
@@ -212,6 +213,8 @@ export default function ConversationView() {
   // Poll while any session is active (same query key — TanStack merges refetchInterval)
   useConversationInfinite(cid, { refetchInterval: hasActiveSession ? 2000 : false });
 
+  const { handleHistoryKeyDown, addToHistory } = usePromptHistory({ text: task, setText: setTask });
+
   const submit = useSubmitConversationTask(cid);
   const stop = useStopSession();
   const cancelPending = useCancelPendingTask(cid);
@@ -337,6 +340,7 @@ export default function ConversationView() {
       cache_max_entries: advCacheMaxEntries.trim() ? Number(advCacheMaxEntries) : undefined,
       cache_ttl_seconds: advCacheTtl.trim() ? Number(advCacheTtl) : undefined,
     };
+    addToHistory(trimmed);
     submit.mutate(body, {
       onSuccess: () => { setTask(""); setSelectedFiles([]); setShowAllFiles(false); setTimeout(() => textareaRef.current?.focus(), 0); },
     });
@@ -352,7 +356,9 @@ export default function ConversationView() {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSubmit(e as unknown as React.FormEvent);
+      return;
     }
+    handleHistoryKeyDown(e);
   }
 
   function startEditTitle() {

--- a/gui/frontend/src/pages/ImuPage.tsx
+++ b/gui/frontend/src/pages/ImuPage.tsx
@@ -7,6 +7,7 @@ import { SourceBadge } from "@/components/SourceBadge";
 import { useStopSession } from "@/hooks/mutations/use-sessions";
 import { useProjectSessions } from "@/hooks/queries/use-sessions";
 import { useSessionWS } from "@/hooks/useSessionWS";
+import { usePromptHistory } from "@/hooks/usePromptHistory";
 import { useResources } from "@/hooks/queries/use-registry";
 import { useProjectFiles } from "@/hooks/queries/use-projects";
 import { api } from "@/api/client";
@@ -256,6 +257,8 @@ function ImuConversationView({ cid }: { cid: number }) {
 
   useConversationInfinite(cid, { refetchInterval: hasActiveSession ? 2000 : false });
 
+  const { handleHistoryKeyDown, addToHistory } = usePromptHistory({ text: task, setText: setTask });
+
   const submit = useSubmitConversationTask(cid);
   const stop = useStopSession();
   const cancelPending = useCancelPendingTask(cid);
@@ -356,6 +359,7 @@ function ImuConversationView({ cid }: { cid: number }) {
     e.preventDefault();
     const trimmed = task.trim();
     if (!trimmed || hasAdvError) return;
+    addToHistory(trimmed);
     submit.mutate(
       {
         task: trimmed,
@@ -384,7 +388,9 @@ function ImuConversationView({ cid }: { cid: number }) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSubmit(e as unknown as React.FormEvent);
+      return;
     }
+    handleHistoryKeyDown(e);
   }
 
   function startEditTitle() {


### PR DESCRIPTION
## Summary
- Add `usePromptHistory` hook with shell-style Up/Down arrow key history navigation for textarea prompts
- Integrate into both `ConversationView` and `ImuPage` — identical 3-line integration pattern
- In-memory, conversation-scoped history with draft stashing, consecutive dedup, and multiline-aware cursor boundary detection

Closes #600

## What changed
- **New `hooks/usePromptHistory.ts`** — Hook returning `handleHistoryKeyDown` and `addToHistory`. Uses `textRef` pattern for stable callback identity. `isOnFirstLine`/`isOnLastLine` helpers detect cursor boundaries.
- **New `hooks/usePromptHistory.test.ts`** — 17 unit tests covering: empty history, navigation up/down, boundary clamping, draft stash/restore, consecutive dedup, non-consecutive dupes, multiline cursor boundary detection, exact-newline-position edge cases, and reset after submission.
- **`pages/ConversationView.tsx`** — Wire hook, call `addToHistory` before submit, delegate arrow keys to `handleHistoryKeyDown` after Enter guard.
- **`pages/ImuPage.tsx`** — Same integration pattern.

## Test plan
- [x] 78/78 tests pass (`npx vitest run`)
- [x] Clean TypeScript build (`npx tsc --noEmit`)
- [x] Up arrow at first line recalls previous prompts
- [x] Down arrow at last line navigates forward, restores draft
- [x] Arrow keys work normally in multiline text (only trigger at boundaries)
- [x] Consecutive duplicate prompts are deduplicated
- [x] History resets navigation state on new submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)