### PR TITLE
Add YAML template loader and Markdown renderer

### DIFF
--- a/cli/src/strawpot/init/loader.py
+++ b/cli/src/strawpot/init/loader.py
@@ -1,0 +1,81 @@
+"""YAML template loader for archetypes and language layers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from strawpot.init.types import ArchetypeQuestion, ArchetypeTemplate, LanguageLayer
+
+_TEMPLATE_DIR = Path(__file__).parent
+_ARCHETYPES_DIR = _TEMPLATE_DIR / "archetypes"
+_LAYERS_DIR = _TEMPLATE_DIR / "layers"
+
+
+def load_archetype(slug: str) -> ArchetypeTemplate:
+    """Load an archetype template from ``archetypes/{slug}/template.yaml``.
+
+    Raises :class:`FileNotFoundError` if the template does not exist.
+    """
+    path = _ARCHETYPES_DIR / slug / "template.yaml"
+    if not path.is_file():
+        raise FileNotFoundError(f"Archetype template not found: {path}")
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    questions = [
+        ArchetypeQuestion(
+            id=q["id"],
+            question=q.get("question", ""),
+            choices=q.get("choices", []),
+            default=q.get("default", ""),
+            affects=q.get("affects", []),
+        )
+        for q in data.get("questions", [])
+    ]
+
+    return ArchetypeTemplate(
+        name=data.get("name", slug),
+        slug=slug,
+        languages=data.get("languages", []),
+        build_systems=data.get("build_systems", []),
+        questions=questions,
+        rules=data.get("rules", {}),
+        cross_component=data.get("cross_component", []),
+    )
+
+
+def load_language_layer(language: str) -> LanguageLayer:
+    """Load a language layer from ``layers/{language}.yaml``.
+
+    Raises :class:`FileNotFoundError` if the layer does not exist.
+    """
+    path = _LAYERS_DIR / f"{language}.yaml"
+    if not path.is_file():
+        raise FileNotFoundError(f"Language layer not found: {path}")
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    return LanguageLayer(
+        language=data.get("language", language),
+        rules=data.get("rules", {}),
+    )
+
+
+def list_archetypes() -> list[str]:
+    """Return available archetype slugs (directories with template.yaml)."""
+    if not _ARCHETYPES_DIR.is_dir():
+        return []
+    return sorted(
+        d.name
+        for d in _ARCHETYPES_DIR.iterdir()
+        if d.is_dir() and (d / "template.yaml").is_file()
+    )
+
+
+def list_languages() -> list[str]:
+    """Return available language layer slugs."""
+    if not _LAYERS_DIR.is_dir():
+        return []
+    return sorted(p.stem for p in _LAYERS_DIR.glob("*.yaml"))

--- a/cli/src/strawpot/init/renderer.py
+++ b/cli/src/strawpot/init/renderer.py
@@ -1,0 +1,231 @@
+"""Markdown renderer — composes template layers into CLAUDE.md content."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+from strawpot.init.engine import EvaluatedRule, evaluate_rules
+from strawpot.init.types import (
+    ArchetypeTemplate,
+    ComponentConfig,
+    GeneratedFile,
+    LanguageLayer,
+    ProjectConfig,
+)
+
+
+def render_inline_metadata(
+    component: ComponentConfig,
+    rule_count: int,
+    *,
+    dirs_at_gen: list[str] | None = None,
+    build_file_hash: str = "",
+) -> str:
+    """Generate the ``<!-- strawpot:meta -->`` inline metadata block."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    dirs = ", ".join(dirs_at_gen) if dirs_at_gen else ""
+
+    lines = [
+        "<!-- strawpot:meta",
+        f"generated: {timestamp}",
+        f"archetype: {component.archetype}",
+        f"language: {component.language}",
+        f"component: {component.name}",
+        f"rule_count: {rule_count}",
+    ]
+    if dirs:
+        lines.append(f"dirs_at_gen: [{dirs}]")
+    if build_file_hash:
+        lines.append(f"build_file_hash: {build_file_hash}")
+    lines.append("-->")
+    return "\n".join(lines)
+
+
+def _build_project_context(
+    component: ComponentConfig,
+    project: ProjectConfig,
+) -> dict:
+    """Build the project_context dict for engine evaluation."""
+    return {
+        "components": [c.name for c in project.components],
+        "component": {
+            "name": component.name,
+            "path": component.path,
+            "language": component.language,
+        },
+        "shared": {
+            "path": next(
+                (c.path for c in project.components if c.name == "shared"),
+                "",
+            ),
+        },
+        "project": {
+            "name": project.project_name,
+        },
+    }
+
+
+def _evaluate_layer(
+    rules_dict: dict,
+    cross_component: list | None,
+    answers: dict,
+    project_context: dict,
+) -> list[EvaluatedRule]:
+    """Evaluate a single template layer (archetype or language)."""
+    template = {"rules": rules_dict}
+    if cross_component:
+        template["cross_component"] = cross_component
+    return evaluate_rules(template, answers, project_context)
+
+
+def render_component_claude_md(
+    component: ComponentConfig,
+    project: ProjectConfig,
+    archetype: ArchetypeTemplate,
+    language_layer: LanguageLayer | None = None,
+) -> GeneratedFile:
+    """Render a CLAUDE.md for a single component.
+
+    Composes 4 layers in order:
+    1. Language layer rules
+    2. Archetype hard rules
+    3. Archetype conditional (soft) rules
+    4. Cross-component rules
+    """
+    ctx = _build_project_context(component, project)
+    answers = dict(component.archetype_answers)
+
+    # Layer 1: Language rules
+    lang_rules: list[EvaluatedRule] = []
+    if language_layer:
+        lang_rules = _evaluate_layer(
+            language_layer.rules, None, answers, ctx,
+        )
+
+    # Layers 2-4: Archetype rules (hard + soft + cross_component)
+    archetype_rules = _evaluate_layer(
+        archetype.rules, archetype.cross_component, answers, ctx,
+    )
+
+    # Partition archetype rules by section
+    hard_rules = [r for r in archetype_rules if r.section == "hard"]
+    soft_rules = [r for r in archetype_rules if r.section == "soft"]
+    cross_rules = [r for r in archetype_rules if r.section == "cross_component"]
+
+    all_rules = lang_rules + archetype_rules
+    rule_count = len(all_rules)
+
+    # Build Markdown
+    sections: list[str] = []
+
+    # Inline metadata
+    sections.append(render_inline_metadata(component, rule_count))
+    sections.append("")
+
+    # Identity
+    sections.append(f"# {component.name}")
+    sections.append("")
+    sections.append(
+        f"This is the **{component.name}** component of {project.project_name}, "
+        f"written in {component.language}."
+    )
+    if component.archetype:
+        sections.append(f"Archetype: {component.archetype}.")
+    sections.append("")
+
+    # Build Commands
+    if component.build_system:
+        sections.append("## Build Commands")
+        sections.append("")
+        sections.append(f"Build system: {component.build_system}")
+        sections.append("")
+        sections.append("```bash")
+        sections.append("# TODO: Add your build commands here")
+        sections.append("```")
+        sections.append("")
+
+    # Language Rules (from language layer)
+    if lang_rules:
+        sections.append("## Language Conventions")
+        sections.append("")
+        for rule in lang_rules:
+            sections.append(f"- {rule.text}")
+        sections.append("")
+
+    # Hard Rules
+    if hard_rules:
+        sections.append("## Hard Rules")
+        sections.append("")
+        sections.append("These rules must always be followed:")
+        sections.append("")
+        for rule in hard_rules:
+            sections.append(f"- {rule.text}")
+        sections.append("")
+
+    # Soft Rules
+    if soft_rules:
+        sections.append("## Soft Rules")
+        sections.append("")
+        sections.append("Follow these conventions unless there's a good reason not to:")
+        sections.append("")
+        for rule in soft_rules:
+            sections.append(f"- {rule.text}")
+        sections.append("")
+
+    # Cross-Component Awareness
+    if cross_rules:
+        sections.append("## Cross-Component Awareness")
+        sections.append("")
+        for rule in cross_rules:
+            sections.append(f"- {rule.text}")
+        sections.append("")
+
+    # Architecture Guide
+    sections.append("## Architecture Guide")
+    sections.append("")
+    sections.append("<!-- TODO: Add architecture-specific guidance for this component -->")
+    sections.append("")
+
+    # Project-Specific Rules
+    sections.append("## Project-Specific Rules")
+    sections.append("")
+    sections.append("<!-- TODO: Add rules specific to your project that templates can't cover -->")
+    sections.append("")
+
+    content = "\n".join(sections)
+    path = f"{component.path}CLAUDE.md" if not component.path.endswith("/") or component.path == "" else f"{component.path}CLAUDE.md"
+    if component.path and not component.path.endswith("/"):
+        path = f"{component.path}/CLAUDE.md"
+
+    return GeneratedFile(path=path, content=content, rule_count=rule_count)
+
+
+def render_root_claude_md(project: ProjectConfig) -> GeneratedFile:
+    """Render a root-level CLAUDE.md with project overview and component listing."""
+    sections: list[str] = []
+
+    sections.append(f"# {project.project_name}")
+    sections.append("")
+    sections.append(f"Project type: {project.project_type}")
+    sections.append("")
+
+    if project.components:
+        sections.append("## Components")
+        sections.append("")
+        for comp in project.components:
+            sections.append(f"- **{comp.name}** (`{comp.path}`) — {comp.language}")
+        sections.append("")
+        sections.append(
+            "Each component has its own `CLAUDE.md` with detailed rules and conventions."
+        )
+        sections.append("")
+
+    sections.append("## Cross-Component Guidelines")
+    sections.append("")
+    sections.append("<!-- TODO: Add project-wide guidelines that span components -->")
+    sections.append("")
+
+    content = "\n".join(sections)
+    return GeneratedFile(path="CLAUDE.md", content=content, rule_count=0)

--- a/cli/src/strawpot/init/types.py
+++ b/cli/src/strawpot/init/types.py
@@ -1,0 +1,67 @@
+"""Data types for the strawpot init template system."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ArchetypeQuestion:
+    """A question defined in an archetype template."""
+
+    id: str
+    question: str
+    choices: list[str] = field(default_factory=list)
+    default: str = ""
+    affects: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ArchetypeTemplate:
+    """Parsed archetype template from YAML."""
+
+    name: str
+    slug: str
+    languages: list[str] = field(default_factory=list)
+    build_systems: list[str] = field(default_factory=list)
+    questions: list[ArchetypeQuestion] = field(default_factory=list)
+    rules: dict[str, list[dict[str, str]]] = field(default_factory=dict)
+    cross_component: list[dict[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class LanguageLayer:
+    """Parsed language layer from YAML."""
+
+    language: str
+    rules: dict[str, list[dict[str, str]]] = field(default_factory=dict)
+
+
+@dataclass
+class ComponentConfig:
+    """Configuration for a single project component."""
+
+    name: str
+    path: str
+    language: str
+    build_system: str = ""
+    archetype: str = ""
+    archetype_answers: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class ProjectConfig:
+    """Full project configuration from the questionnaire."""
+
+    project_name: str
+    project_type: str
+    components: list[ComponentConfig] = field(default_factory=list)
+
+
+@dataclass
+class GeneratedFile:
+    """A file to be written (staged in memory for atomic writes)."""
+
+    path: str  # relative to project root
+    content: str
+    rule_count: int = 0

--- a/cli/tests/test_init_loader.py
+++ b/cli/tests/test_init_loader.py
@@ -1,0 +1,140 @@
+"""Tests for the YAML template loader."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from strawpot.init.loader import (
+    list_archetypes,
+    list_languages,
+    load_archetype,
+    load_language_layer,
+)
+
+
+@pytest.fixture()
+def archetype_dir(tmp_path, monkeypatch):
+    """Set up a temporary archetypes directory with a test template."""
+    archetypes = tmp_path / "archetypes"
+    archetypes.mkdir()
+    monkeypatch.setattr("strawpot.init.loader._ARCHETYPES_DIR", archetypes)
+
+    # Create a minimal archetype
+    game_engine = archetypes / "game-engine"
+    game_engine.mkdir()
+    template = {
+        "name": "Game Engine",
+        "languages": ["C++", "Rust"],
+        "build_systems": ["CMake", "Meson"],
+        "questions": [
+            {
+                "id": "render_api",
+                "question": "Which rendering API?",
+                "choices": ["Vulkan", "OpenGL"],
+                "default": "Vulkan",
+                "affects": ["hard_rules"],
+            },
+        ],
+        "rules": {
+            "hard": [
+                {"condition": "always", "text": "No raw new/delete."},
+                {"condition": "render_api == 'Vulkan'", "text": "Vulkan destruction order."},
+            ],
+            "soft": [
+                {"condition": "always", "text": "PascalCase for types."},
+            ],
+        },
+        "cross_component": [
+            {"condition": "has_component('server')", "text": "Server has authority."},
+        ],
+    }
+    (game_engine / "template.yaml").write_text(
+        yaml.dump(template, default_flow_style=False),
+        encoding="utf-8",
+    )
+    return archetypes
+
+
+@pytest.fixture()
+def layers_dir(tmp_path, monkeypatch):
+    """Set up a temporary layers directory."""
+    layers = tmp_path / "layers"
+    layers.mkdir()
+    monkeypatch.setattr("strawpot.init.loader._LAYERS_DIR", layers)
+
+    layer = {
+        "language": "C++",
+        "rules": {
+            "hard": [
+                {"condition": "always", "text": "Use RAII for resource management."},
+            ],
+            "soft": [
+                {"condition": "always", "text": "Prefer constexpr where possible."},
+            ],
+        },
+    }
+    (layers / "cpp.yaml").write_text(
+        yaml.dump(layer, default_flow_style=False),
+        encoding="utf-8",
+    )
+    return layers
+
+
+class TestLoadArchetype:
+    def test_loads_template(self, archetype_dir):
+        result = load_archetype("game-engine")
+        assert result.name == "Game Engine"
+        assert result.slug == "game-engine"
+        assert "C++" in result.languages
+        assert "CMake" in result.build_systems
+
+    def test_loads_questions(self, archetype_dir):
+        result = load_archetype("game-engine")
+        assert len(result.questions) == 1
+        q = result.questions[0]
+        assert q.id == "render_api"
+        assert q.choices == ["Vulkan", "OpenGL"]
+        assert q.default == "Vulkan"
+
+    def test_loads_rules(self, archetype_dir):
+        result = load_archetype("game-engine")
+        assert len(result.rules["hard"]) == 2
+        assert len(result.rules["soft"]) == 1
+        assert len(result.cross_component) == 1
+
+    def test_not_found_raises(self, archetype_dir):
+        with pytest.raises(FileNotFoundError):
+            load_archetype("nonexistent")
+
+
+class TestLoadLanguageLayer:
+    def test_loads_layer(self, layers_dir):
+        result = load_language_layer("cpp")
+        assert result.language == "C++"
+        assert len(result.rules["hard"]) == 1
+        assert len(result.rules["soft"]) == 1
+
+    def test_not_found_raises(self, layers_dir):
+        with pytest.raises(FileNotFoundError):
+            load_language_layer("nonexistent")
+
+
+class TestListArchetypes:
+    def test_lists_available(self, archetype_dir):
+        result = list_archetypes()
+        assert "game-engine" in result
+
+    def test_empty_when_no_templates(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("strawpot.init.loader._ARCHETYPES_DIR", tmp_path / "empty")
+        assert list_archetypes() == []
+
+
+class TestListLanguages:
+    def test_lists_available(self, layers_dir):
+        result = list_languages()
+        assert "cpp" in result
+
+    def test_empty_when_no_layers(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("strawpot.init.loader._LAYERS_DIR", tmp_path / "empty")
+        assert list_languages() == []

--- a/cli/tests/test_init_renderer.py
+++ b/cli/tests/test_init_renderer.py
@@ -1,0 +1,232 @@
+"""Tests for the Markdown renderer."""
+
+from __future__ import annotations
+
+from strawpot.init.renderer import (
+    render_component_claude_md,
+    render_inline_metadata,
+    render_root_claude_md,
+)
+from strawpot.init.types import (
+    ArchetypeTemplate,
+    ComponentConfig,
+    LanguageLayer,
+    ProjectConfig,
+)
+
+
+def _make_project(**overrides) -> ProjectConfig:
+    defaults = {
+        "project_name": "TestProject",
+        "project_type": "game",
+        "components": [],
+    }
+    defaults.update(overrides)
+    return ProjectConfig(**defaults)
+
+
+def _make_component(**overrides) -> ComponentConfig:
+    defaults = {
+        "name": "engine",
+        "path": "engine/",
+        "language": "C++",
+        "build_system": "CMake",
+        "archetype": "game-engine",
+        "archetype_answers": {},
+    }
+    defaults.update(overrides)
+    return ComponentConfig(**defaults)
+
+
+def _make_archetype(**overrides) -> ArchetypeTemplate:
+    defaults = {
+        "name": "Game Engine",
+        "slug": "game-engine",
+        "languages": ["C++"],
+        "build_systems": ["CMake"],
+        "questions": [],
+        "rules": {
+            "hard": [
+                {"condition": "always", "text": "No raw new/delete."},
+            ],
+            "soft": [
+                {"condition": "always", "text": "PascalCase for types."},
+            ],
+        },
+        "cross_component": [],
+    }
+    defaults.update(overrides)
+    return ArchetypeTemplate(**defaults)
+
+
+def _make_language_layer(**overrides) -> LanguageLayer:
+    defaults = {
+        "language": "C++",
+        "rules": {
+            "hard": [
+                {"condition": "always", "text": "Use RAII."},
+            ],
+        },
+    }
+    defaults.update(overrides)
+    return LanguageLayer(**defaults)
+
+
+class TestRenderInlineMetadata:
+    def test_basic_metadata(self):
+        component = _make_component()
+        result = render_inline_metadata(component, rule_count=5)
+        assert "<!-- strawpot:meta" in result
+        assert "-->" in result
+        assert "archetype: game-engine" in result
+        assert "language: C++" in result
+        assert "component: engine" in result
+        assert "rule_count: 5" in result
+
+    def test_with_dirs_and_hash(self):
+        component = _make_component()
+        result = render_inline_metadata(
+            component, rule_count=3,
+            dirs_at_gen=["src", "include"],
+            build_file_hash="abc123",
+        )
+        assert "dirs_at_gen: [src, include]" in result
+        assert "build_file_hash: abc123" in result
+
+
+class TestRenderComponentClaudeMd:
+    def test_has_all_sections(self):
+        component = _make_component()
+        project = _make_project(components=[component])
+        archetype = _make_archetype()
+
+        result = render_component_claude_md(component, project, archetype)
+        assert "# engine" in result.content
+        assert "## Build Commands" in result.content
+        assert "## Hard Rules" in result.content
+        assert "## Soft Rules" in result.content
+        assert "## Architecture Guide" in result.content
+        assert "## Project-Specific Rules" in result.content
+
+    def test_identity_section(self):
+        component = _make_component()
+        project = _make_project(components=[component])
+        archetype = _make_archetype()
+
+        result = render_component_claude_md(component, project, archetype)
+        assert "**engine** component of TestProject" in result.content
+        assert "C++" in result.content
+
+    def test_includes_hard_rules(self):
+        component = _make_component()
+        project = _make_project(components=[component])
+        archetype = _make_archetype()
+
+        result = render_component_claude_md(component, project, archetype)
+        assert "No raw new/delete." in result.content
+
+    def test_includes_soft_rules(self):
+        component = _make_component()
+        project = _make_project(components=[component])
+        archetype = _make_archetype()
+
+        result = render_component_claude_md(component, project, archetype)
+        assert "PascalCase for types." in result.content
+
+    def test_four_layer_composition(self):
+        """Language + archetype hard + archetype soft + cross_component."""
+        server = _make_component(name="server", path="server/")
+        component = _make_component()
+        project = _make_project(components=[component, server])
+        archetype = _make_archetype(
+            cross_component=[
+                {"condition": "has_component('server')", "text": "Server is authority."},
+            ],
+        )
+        lang_layer = _make_language_layer()
+
+        result = render_component_claude_md(component, project, archetype, lang_layer)
+        # Language layer
+        assert "Use RAII." in result.content
+        assert "## Language Conventions" in result.content
+        # Archetype hard
+        assert "No raw new/delete." in result.content
+        # Archetype soft
+        assert "PascalCase for types." in result.content
+        # Cross-component
+        assert "Server is authority." in result.content
+        assert "## Cross-Component Awareness" in result.content
+
+    def test_inline_metadata_present(self):
+        component = _make_component()
+        project = _make_project(components=[component])
+        archetype = _make_archetype()
+
+        result = render_component_claude_md(component, project, archetype)
+        assert "<!-- strawpot:meta" in result.content
+
+    def test_generated_file_path(self):
+        component = _make_component(path="engine/")
+        project = _make_project(components=[component])
+        archetype = _make_archetype()
+
+        result = render_component_claude_md(component, project, archetype)
+        assert result.path == "engine/CLAUDE.md"
+
+    def test_rule_count(self):
+        component = _make_component()
+        project = _make_project(components=[component])
+        archetype = _make_archetype()
+
+        result = render_component_claude_md(component, project, archetype)
+        # 1 hard + 1 soft = 2 rules
+        assert result.rule_count == 2
+
+    def test_conditional_rules(self):
+        component = _make_component(
+            archetype_answers={"render_api": "Vulkan"},
+        )
+        project = _make_project(components=[component])
+        archetype = _make_archetype(
+            rules={
+                "hard": [
+                    {"condition": "render_api == 'Vulkan'", "text": "Vulkan order."},
+                    {"condition": "render_api == 'OpenGL'", "text": "GL context."},
+                ],
+                "soft": [],
+            },
+        )
+
+        result = render_component_claude_md(component, project, archetype)
+        assert "Vulkan order." in result.content
+        assert "GL context." not in result.content
+
+
+class TestRenderRootClaudeMd:
+    def test_basic_root(self):
+        project = _make_project(
+            components=[
+                _make_component(name="engine", path="engine/", language="C++"),
+                _make_component(name="server", path="server/", language="Rust"),
+            ],
+        )
+        result = render_root_claude_md(project)
+
+        assert result.path == "CLAUDE.md"
+        assert "# TestProject" in result.content
+        assert "game" in result.content
+        assert "**engine**" in result.content
+        assert "**server**" in result.content
+        assert "`engine/`" in result.content
+        assert "C++" in result.content
+        assert "Rust" in result.content
+
+    def test_no_components(self):
+        project = _make_project(components=[])
+        result = render_root_claude_md(project)
+        assert "## Components" not in result.content
+
+    def test_cross_component_section(self):
+        project = _make_project()
+        result = render_root_claude_md(project)
+        assert "## Cross-Component Guidelines" in result.content


### PR DESCRIPTION
## Summary

- Define core data types: `ArchetypeTemplate`, `LanguageLayer`, `ComponentConfig`, `ProjectConfig`, `GeneratedFile`
- Implement YAML template loader with `load_archetype()`, `load_language_layer()`, `list_archetypes()`, `list_languages()`
- Build Markdown renderer that composes 4 layers (language → archetype hard → archetype soft → cross-component) into CLAUDE.md
- Generate inline metadata blocks (`<!-- strawpot:meta -->`) with generation timestamp, archetype, language, and rule count
- Render root CLAUDE.md with project overview and component listing

Closes #615

## Test plan

- [x] Archetype YAML loads into `ArchetypeTemplate` with questions, rules, and cross_component
- [x] Language layer YAML loads into `LanguageLayer`
- [x] `list_archetypes()` and `list_languages()` discover available templates
- [x] Component CLAUDE.md includes all sections: Identity, Build Commands, Language Conventions, Hard Rules, Soft Rules, Cross-Component, Architecture, Project-Specific
- [x] 4-layer composition works: language + archetype hard + archetype soft + cross_component
- [x] Conditional rules filter correctly based on archetype answers
- [x] Root CLAUDE.md lists components with paths and languages
- [x] 1071 total tests pass (zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)