### PR TITLE
Add adaptive questionnaire flow

### DIFF
--- a/cli/src/strawpot/init/questionnaire.py
+++ b/cli/src/strawpot/init/questionnaire.py
@@ -1,1 +1,340 @@
-"""Adaptive questionnaire for strawpot init."""
+"""Adaptive questionnaire for strawpot init.
+
+Walks users through project type selection, component discovery, path/language
+configuration, and archetype-specific questions.  Returns a fully populated
+:class:`ProjectConfig`.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import Counter
+from pathlib import Path
+
+import click
+
+from strawpot.init.loader import list_archetypes, load_archetype
+from strawpot.init.types import ComponentConfig, ProjectConfig
+
+# ---------------------------------------------------------------------------
+# Project type → archetype mapping
+# ---------------------------------------------------------------------------
+
+_PROJECT_TYPES = ["Game", "Web", "Mobile", "CLI", "Monorepo", "Other"]
+
+_DEFAULT_COMPONENTS: dict[str, list[dict[str, str]]] = {
+    "Game": [
+        {"name": "engine", "archetype": "game-engine"},
+        {"name": "server", "archetype": "game-server"},
+        {"name": "client", "archetype": "game-client"},
+        {"name": "shared", "archetype": "generic"},
+    ],
+    "Web": [
+        {"name": "api", "archetype": "web-api"},
+        {"name": "client", "archetype": "generic"},
+        {"name": "shared", "archetype": "generic"},
+    ],
+    "Mobile": [
+        {"name": "app", "archetype": "generic"},
+        {"name": "api", "archetype": "web-api"},
+    ],
+    "CLI": [
+        {"name": "cli", "archetype": "generic"},
+    ],
+}
+
+# Build files that indicate a component root
+_BUILD_FILES = {
+    "CMakeLists.txt",
+    "Cargo.toml",
+    "package.json",
+    "pyproject.toml",
+    "go.mod",
+    "Makefile",
+    "build.gradle",
+    "pom.xml",
+    "meson.build",
+    "premake5.lua",
+}
+
+# File extension → language mapping
+_EXTENSION_MAP: dict[str, str] = {
+    ".cpp": "C++", ".cc": "C++", ".cxx": "C++", ".hpp": "C++", ".h": "C++",
+    ".c": "C",
+    ".rs": "Rust",
+    ".py": "Python",
+    ".ts": "TypeScript", ".tsx": "TypeScript",
+    ".js": "JavaScript", ".jsx": "JavaScript",
+    ".go": "Go",
+    ".java": "Java",
+    ".cs": "C#",
+    ".swift": "Swift",
+    ".kt": "Kotlin",
+    ".rb": "Ruby",
+}
+
+_MAX_SCAN_DEPTH = 3
+_MAX_SUGGESTIONS = 20
+
+
+# ---------------------------------------------------------------------------
+# Auto-detection helpers
+# ---------------------------------------------------------------------------
+
+
+def suggest_component_paths(project_dir: Path) -> dict[str, Path]:
+    """Scan *project_dir* for directories containing build files.
+
+    Returns a mapping of directory names to paths, max depth 3,
+    capped at 20 suggestions.
+    """
+    suggestions: dict[str, Path] = {}
+
+    for root, dirs, files in os.walk(project_dir):
+        depth = Path(root).relative_to(project_dir).parts
+        if len(depth) >= _MAX_SCAN_DEPTH:
+            dirs.clear()
+            continue
+        # Skip hidden/vendor dirs
+        dirs[:] = [d for d in dirs if not d.startswith(".") and d not in {"node_modules", "vendor", "__pycache__", "venv", ".venv"}]
+
+        if _BUILD_FILES & set(files):
+            rel = Path(root).relative_to(project_dir)
+            name = rel.name or project_dir.name
+            suggestions[name] = rel
+            if len(suggestions) >= _MAX_SUGGESTIONS:
+                break
+
+    return suggestions
+
+
+def detect_language(component_path: Path) -> str | None:
+    """Detect the primary language of a component by counting file extensions.
+
+    Returns the language name if ≥80% of source files share a language,
+    otherwise ``None``.
+    """
+    counter: Counter[str] = Counter()
+    for root, dirs, files in os.walk(component_path):
+        dirs[:] = [d for d in dirs if not d.startswith(".") and d not in {"node_modules", "vendor", "__pycache__", "venv", ".venv"}]
+        for f in files:
+            ext = Path(f).suffix.lower()
+            lang = _EXTENSION_MAP.get(ext)
+            if lang:
+                counter[lang] += 1
+
+    if not counter:
+        return None
+
+    total = sum(counter.values())
+    top_lang, top_count = counter.most_common(1)[0]
+    if top_count / total >= 0.8:
+        return top_lang
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Existing CLAUDE.md handling
+# ---------------------------------------------------------------------------
+
+
+def check_existing_claude_md(path: Path) -> str | None:
+    """Check if a CLAUDE.md already exists at *path*.
+
+    Returns ``"skip"``, ``"backup"``, or ``"append"`` based on user choice,
+    or ``None`` if no existing file.
+    """
+    claude_md = path / "CLAUDE.md" if path.is_dir() else path
+    if not claude_md.exists():
+        return None
+
+    click.echo(f"\n{claude_md} already exists.")
+    choice = click.prompt(
+        "  [S]kip / [B]ackup and replace / [A]ppend generated section",
+        type=click.Choice(["S", "B", "A"], case_sensitive=False),
+        default="S",
+    )
+    return {"s": "skip", "b": "backup", "a": "append"}[choice.lower()]
+
+
+# ---------------------------------------------------------------------------
+# Questionnaire flow
+# ---------------------------------------------------------------------------
+
+
+def _ask_select(prompt: str, choices: list[str], default: str | None = None) -> str:
+    """Ask a selection question using questionary (or click fallback)."""
+    try:
+        import questionary
+        result = questionary.select(prompt, choices=choices, default=default).unsafe_ask()
+        if result is None:
+            raise KeyboardInterrupt
+        return result
+    except ImportError:
+        return click.prompt(prompt, type=click.Choice(choices), default=default or choices[0])
+
+
+def _ask_checkbox(prompt: str, choices: list[str]) -> list[str]:
+    """Ask a checkbox question using questionary (or click fallback)."""
+    try:
+        import questionary
+        result = questionary.checkbox(prompt, choices=choices).unsafe_ask()
+        if result is None:
+            raise KeyboardInterrupt
+        return result
+    except ImportError:
+        click.echo(f"{prompt} (comma-separated)")
+        raw = click.prompt("Selection", default=",".join(choices))
+        return [c.strip() for c in raw.split(",") if c.strip() in choices]
+
+
+def _ask_text(prompt: str, default: str = "") -> str:
+    """Ask a text input question."""
+    try:
+        import questionary
+        result = questionary.text(prompt, default=default).unsafe_ask()
+        if result is None:
+            raise KeyboardInterrupt
+        return result
+    except ImportError:
+        return click.prompt(prompt, default=default)
+
+
+def run_questionnaire(
+    project_dir: Path,
+    non_interactive: bool = False,
+) -> ProjectConfig:
+    """Run the adaptive questionnaire and return a :class:`ProjectConfig`.
+
+    Parameters
+    ----------
+    project_dir:
+        The root directory of the project.
+    non_interactive:
+        If True, use defaults without prompting.
+    """
+    project_name = project_dir.name
+
+    # Q1: Project type
+    if non_interactive:
+        project_type = "Other"
+    else:
+        click.echo(click.style("\n🔧 strawpot init — Project Configuration\n", bold=True))
+        project_type = _ask_select(
+            "What type of project is this?",
+            _PROJECT_TYPES,
+            default="Other",
+        )
+
+    # Get suggested component paths
+    suggestions = suggest_component_paths(project_dir)
+
+    # Q2: Component selection
+    default_comps = _DEFAULT_COMPONENTS.get(project_type, [])
+
+    if non_interactive:
+        # Use defaults or single generic component
+        if default_comps:
+            selected_names = [c["name"] for c in default_comps]
+        else:
+            selected_names = [project_name]
+            default_comps = [{"name": project_name, "archetype": "generic"}]
+    elif not default_comps or project_type == "Other":
+        # Generic flow: ask how many components
+        click.echo("\nNo predefined components for this project type.")
+        comp_count = click.prompt("How many components?", type=int, default=1)
+        selected_names = []
+        for i in range(comp_count):
+            name = _ask_text(f"Component {i+1} name", default=f"component-{i+1}")
+            selected_names.append(name)
+        default_comps = [{"name": n, "archetype": "generic"} for n in selected_names]
+    else:
+        available = [c["name"] for c in default_comps]
+        selected_names = _ask_checkbox(
+            "Which components does your project have?",
+            available,
+        )
+        if not selected_names:
+            selected_names = available[:1]
+
+    # Single-component fast path
+    is_single = len(selected_names) == 1
+
+    # Build components
+    components: list[ComponentConfig] = []
+    available_archetypes = set(list_archetypes())
+
+    for comp_def in default_comps:
+        if comp_def["name"] not in selected_names:
+            continue
+
+        name = comp_def["name"]
+        archetype_slug = comp_def.get("archetype", "generic")
+
+        # Q3: Path per component
+        if is_single:
+            comp_path = "."
+        elif non_interactive:
+            comp_path = suggestions.get(name, Path(name))
+            comp_path = str(comp_path)
+        else:
+            suggested = suggestions.get(name)
+            default_path = str(suggested) if suggested else name
+            comp_path = _ask_text(f"Path for '{name}' component", default=default_path)
+
+        # Resolve and validate path
+        full_path = project_dir / comp_path
+        if not full_path.exists() and not non_interactive:
+            click.echo(f"  ⚠ Path '{comp_path}' does not exist. It will be created.")
+
+        # Q4: Language per component
+        detected = None
+        if full_path.exists():
+            detected = detect_language(full_path)
+
+        if non_interactive:
+            language = detected or "Unknown"
+        elif detected:
+            language = _ask_select(
+                f"Language for '{name}'? (detected: {detected})",
+                [detected, "C++", "C", "Rust", "Python", "TypeScript", "Go", "Java", "Other"],
+                default=detected,
+            )
+        else:
+            language = _ask_select(
+                f"Language for '{name}'?",
+                ["C++", "C", "Rust", "Python", "TypeScript", "JavaScript", "Go", "Java", "Other"],
+            )
+
+        # Q5: Archetype-specific questions
+        archetype_answers: dict[str, str] = {}
+        if archetype_slug in available_archetypes:
+            try:
+                archetype = load_archetype(archetype_slug)
+                for q in archetype.questions:
+                    if non_interactive:
+                        answer = q.default or q.choices[0] if q.choices else ""
+                    else:
+                        answer = _ask_select(
+                            f"[{name}] {q.question}",
+                            q.choices,
+                            default=q.default,
+                        )
+                    archetype_answers[q.id] = answer
+            except FileNotFoundError:
+                pass
+
+        components.append(ComponentConfig(
+            name=name,
+            path=comp_path if comp_path != "." else "",
+            language=language,
+            build_system="",
+            archetype=archetype_slug,
+            archetype_answers=archetype_answers,
+        ))
+
+    return ProjectConfig(
+        project_name=project_name,
+        project_type=project_type,
+        components=components,
+    )

--- a/cli/tests/test_init_questionnaire.py
+++ b/cli/tests/test_init_questionnaire.py
@@ -1,0 +1,214 @@
+"""Tests for the adaptive questionnaire."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from strawpot.init.questionnaire import (
+    detect_language,
+    run_questionnaire,
+    suggest_component_paths,
+)
+
+
+# ---------------------------------------------------------------------------
+# suggest_component_paths
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestComponentPaths:
+    def test_finds_cmake(self, tmp_path):
+        (tmp_path / "engine").mkdir()
+        (tmp_path / "engine" / "CMakeLists.txt").touch()
+        result = suggest_component_paths(tmp_path)
+        assert "engine" in result
+
+    def test_finds_cargo(self, tmp_path):
+        (tmp_path / "server").mkdir()
+        (tmp_path / "server" / "Cargo.toml").touch()
+        result = suggest_component_paths(tmp_path)
+        assert "server" in result
+
+    def test_finds_package_json(self, tmp_path):
+        (tmp_path / "client").mkdir()
+        (tmp_path / "client" / "package.json").touch()
+        result = suggest_component_paths(tmp_path)
+        assert "client" in result
+
+    def test_respects_max_depth(self, tmp_path):
+        deep = tmp_path / "a" / "b" / "c" / "d"
+        deep.mkdir(parents=True)
+        (deep / "CMakeLists.txt").touch()
+        result = suggest_component_paths(tmp_path)
+        assert "d" not in result
+
+    def test_skips_hidden_dirs(self, tmp_path):
+        hidden = tmp_path / ".hidden"
+        hidden.mkdir()
+        (hidden / "CMakeLists.txt").touch()
+        result = suggest_component_paths(tmp_path)
+        assert ".hidden" not in result
+
+    def test_empty_project(self, tmp_path):
+        result = suggest_component_paths(tmp_path)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# detect_language
+# ---------------------------------------------------------------------------
+
+
+class TestDetectLanguage:
+    def test_detects_cpp(self, tmp_path):
+        for name in ["main.cpp", "util.cpp", "math.hpp", "render.cc"]:
+            (tmp_path / name).touch()
+        assert detect_language(tmp_path) == "C++"
+
+    def test_detects_python(self, tmp_path):
+        for name in ["app.py", "models.py", "utils.py", "tests.py", "main.py"]:
+            (tmp_path / name).touch()
+        assert detect_language(tmp_path) == "Python"
+
+    def test_detects_rust(self, tmp_path):
+        for name in ["main.rs", "lib.rs", "utils.rs"]:
+            (tmp_path / name).touch()
+        assert detect_language(tmp_path) == "Rust"
+
+    def test_detects_typescript(self, tmp_path):
+        for name in ["app.ts", "index.ts", "utils.ts", "types.ts"]:
+            (tmp_path / name).touch()
+        assert detect_language(tmp_path) == "TypeScript"
+
+    def test_detects_go(self, tmp_path):
+        for name in ["main.go", "server.go", "handler.go"]:
+            (tmp_path / name).touch()
+        assert detect_language(tmp_path) == "Go"
+
+    def test_mixed_returns_none(self, tmp_path):
+        (tmp_path / "main.cpp").touch()
+        (tmp_path / "app.py").touch()
+        (tmp_path / "server.go").touch()
+        assert detect_language(tmp_path) is None
+
+    def test_empty_returns_none(self, tmp_path):
+        assert detect_language(tmp_path) is None
+
+    def test_skips_node_modules(self, tmp_path):
+        (tmp_path / "main.py").touch()
+        nm = tmp_path / "node_modules"
+        nm.mkdir()
+        for i in range(10):
+            (nm / f"dep{i}.js").touch()
+        assert detect_language(tmp_path) == "Python"
+
+
+# ---------------------------------------------------------------------------
+# run_questionnaire — non-interactive mode
+# ---------------------------------------------------------------------------
+
+
+class TestRunQuestionnaireNonInteractive:
+    def test_returns_project_config(self, tmp_path):
+        result = run_questionnaire(tmp_path, non_interactive=True)
+        assert result.project_name == tmp_path.name
+        assert result.project_type == "Other"
+        assert len(result.components) >= 1
+
+    def test_non_interactive_uses_defaults(self, tmp_path):
+        result = run_questionnaire(tmp_path, non_interactive=True)
+        # Should produce at least one component without prompting
+        assert len(result.components) >= 1
+        for comp in result.components:
+            assert comp.name
+
+
+# ---------------------------------------------------------------------------
+# run_questionnaire — interactive mode (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestRunQuestionnaireInteractive:
+    @patch("strawpot.init.questionnaire._ask_select")
+    @patch("strawpot.init.questionnaire._ask_checkbox")
+    @patch("strawpot.init.questionnaire._ask_text")
+    def test_single_component_fast_path(self, mock_text, mock_checkbox, mock_select, tmp_path):
+        """Single component skips selection and path questions."""
+        # Q1: project type → CLI (single component by default)
+        # Q4: language
+        mock_select.side_effect = ["CLI", "Python"]
+        mock_checkbox.return_value = ["cli"]
+
+        result = run_questionnaire(tmp_path)
+        assert result.project_type == "CLI"
+        assert len(result.components) == 1
+        assert result.components[0].name == "cli"
+        # Path should be empty (root) for single component
+        assert result.components[0].path == ""
+
+    @patch("strawpot.init.questionnaire._ask_select")
+    @patch("strawpot.init.questionnaire._ask_checkbox")
+    @patch("strawpot.init.questionnaire._ask_text")
+    def test_multi_component_game(self, mock_text, mock_checkbox, mock_select, tmp_path):
+        """Game project with multiple components."""
+        # Set up archetype so questions are asked
+        mock_select.side_effect = [
+            "Game",           # Q1: project type
+            "C++",            # Q4: language for engine
+            "Vulkan",         # Q5: render_api
+            "Archetype-based",# Q5: ecs_style
+            "Job system",     # Q5: threading
+        ]
+        mock_checkbox.return_value = ["engine"]
+        mock_text.side_effect = ["engine/"]  # Q3: path for engine
+
+        result = run_questionnaire(tmp_path)
+        assert result.project_type == "Game"
+        assert len(result.components) == 1
+        engine = result.components[0]
+        assert engine.name == "engine"
+        assert engine.archetype == "game-engine"
+        assert engine.archetype_answers.get("render_api") == "Vulkan"
+
+    @patch("strawpot.init.questionnaire._ask_select")
+    @patch("strawpot.init.questionnaire._ask_checkbox")
+    @patch("strawpot.init.questionnaire._ask_text")
+    @patch("strawpot.init.questionnaire.click.prompt")
+    def test_other_fallback(self, mock_click_prompt, mock_text, mock_checkbox, mock_select, tmp_path):
+        """'Other' project type uses generic flow."""
+        mock_select.side_effect = ["Other", "Python"]
+        mock_click_prompt.return_value = 1  # 1 component
+        mock_text.side_effect = ["mylib", "lib/"]  # name, path
+
+        result = run_questionnaire(tmp_path)
+        assert result.project_type == "Other"
+        assert len(result.components) == 1
+        assert result.components[0].archetype == "generic"
+
+
+# ---------------------------------------------------------------------------
+# Existing CLAUDE.md detection
+# ---------------------------------------------------------------------------
+
+
+class TestExistingClaudeMd:
+    def test_no_existing_file(self, tmp_path):
+        from strawpot.init.questionnaire import check_existing_claude_md
+        assert check_existing_claude_md(tmp_path) is None
+
+    @patch("strawpot.init.questionnaire.click.prompt", return_value="S")
+    def test_existing_file_skip(self, mock_prompt, tmp_path):
+        from strawpot.init.questionnaire import check_existing_claude_md
+        (tmp_path / "CLAUDE.md").write_text("existing content")
+        result = check_existing_claude_md(tmp_path)
+        assert result == "skip"
+
+    @patch("strawpot.init.questionnaire.click.prompt", return_value="B")
+    def test_existing_file_backup(self, mock_prompt, tmp_path):
+        from strawpot.init.questionnaire import check_existing_claude_md
+        (tmp_path / "CLAUDE.md").write_text("existing content")
+        result = check_existing_claude_md(tmp_path)
+        assert result == "backup"


### PR DESCRIPTION
## Summary

- Implement 5-question adaptive questionnaire: project type → components → paths → languages → archetype details
- Add single-component fast path (skip selection, generate at root)
- Add path auto-suggest by scanning for build files (CMakeLists.txt, Cargo.toml, etc.) at max depth 3
- Add language auto-detect by file extension counting (≥80% threshold)
- Support `--non-interactive` mode with sensible defaults
- Handle existing CLAUDE.md files with Skip/Backup/Append prompt
- Use questionary for rich terminal prompts with click fallback

Closes #617

## Test plan

- [x] Path auto-suggest finds CMakeLists.txt, Cargo.toml, package.json directories
- [x] Language detection works for C++, Python, Rust, TypeScript, Go
- [x] Mixed-language directories return None
- [x] Single-component fast path works correctly
- [x] Multi-component game flow with mocked prompts
- [x] "Other" fallback produces generic components
- [x] Non-interactive mode returns valid ProjectConfig
- [x] Existing CLAUDE.md detection and handling
- [x] 1156 total tests pass (zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)