### PR TITLE
Add drift detection (--check flag) and inline metadata parsing

### DIFF
--- a/cli/src/strawpot/init/cli.py
+++ b/cli/src/strawpot/init/cli.py
@@ -32,8 +32,8 @@ def init(dry_run: bool, check: bool, verbose: bool, non_interactive: bool) -> No
 
     if check:
         from strawpot.init.drift import check_drift
-        check_drift(project_dir, verbose=verbose)
-        return
+        warnings = check_drift(project_dir, verbose=verbose)
+        raise SystemExit(1 if warnings else 0)
 
     # Run questionnaire
     try:

--- a/cli/src/strawpot/init/drift.py
+++ b/cli/src/strawpot/init/drift.py
@@ -1,16 +1,241 @@
-"""Drift detection for generated CLAUDE.md files."""
+"""Drift detection for generated CLAUDE.md files.
+
+Compares inline metadata (``<!-- strawpot:meta -->``) against current project
+state to detect when regeneration may be needed.
+"""
 
 from __future__ import annotations
 
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 
 import click
+import yaml
+
+from strawpot.init.exceptions import BrokenInlineMetadata
 
 
-def check_drift(project_dir: Path, *, verbose: bool = False) -> None:
-    """Check for drift between generated and current CLAUDE.md files.
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
 
-    Stub implementation — full drift detection is in sub-issue #620.
+
+class DriftType(Enum):
+    NEW_DIRECTORY = "new_directory"
+    REMOVED_DIRECTORY = "removed_directory"
+    BUILD_FILE_CHANGED = "build_file_changed"
+    STALE_CONFIG = "stale_config"
+
+
+@dataclass
+class DriftWarning:
+    """A single drift warning for a CLAUDE.md file."""
+
+    component_path: str
+    drift_type: DriftType
+    message: str
+    suggestion: str
+
+
+# ---------------------------------------------------------------------------
+# Inline metadata parsing
+# ---------------------------------------------------------------------------
+
+_META_RE = re.compile(
+    r"<!--\s*strawpot:meta\s*\n(.*?)\n\s*-->",
+    re.DOTALL,
+)
+
+_FRESHNESS_DAYS = 90
+
+# Build files to hash for change detection
+_BUILD_FILES = {
+    "CMakeLists.txt",
+    "Cargo.toml",
+    "package.json",
+    "pyproject.toml",
+    "go.mod",
+    "Makefile",
+    "build.gradle",
+    "pom.xml",
+    "meson.build",
+}
+
+
+def parse_inline_metadata(file_path: Path) -> dict | None:
+    """Extract and parse the ``<!-- strawpot:meta -->`` block from a CLAUDE.md.
+
+    Returns the parsed metadata dict, or ``None`` if no metadata block found.
+    Raises :class:`BrokenInlineMetadata` if the block exists but is malformed.
     """
-    click.echo(click.style("strawpot init --check", bold=True) + " is not yet implemented.")
-    click.echo("Drift detection will be available soon.")
+    if not file_path.exists():
+        return None
+
+    content = file_path.read_text(encoding="utf-8")
+    m = _META_RE.search(content)
+    if not m:
+        return None
+
+    yaml_text = m.group(1)
+    try:
+        data = yaml.safe_load(yaml_text)
+    except yaml.YAMLError as exc:
+        raise BrokenInlineMetadata(
+            f"Malformed metadata in {file_path}: {exc}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise BrokenInlineMetadata(
+            f"Metadata in {file_path} is not a YAML mapping"
+        )
+
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Build file hashing
+# ---------------------------------------------------------------------------
+
+
+def _hash_build_files(component_dir: Path) -> str:
+    """Compute a SHA-256 hash of build files in a directory."""
+    hasher = hashlib.sha256()
+    for name in sorted(_BUILD_FILES):
+        path = component_dir / name
+        if path.is_file():
+            hasher.update(name.encode())
+            hasher.update(path.read_bytes())
+    return hasher.hexdigest()
+
+
+def _list_subdirs(component_dir: Path) -> list[str]:
+    """List immediate subdirectory names (shallow)."""
+    if not component_dir.is_dir():
+        return []
+    return sorted(
+        d.name for d in component_dir.iterdir()
+        if d.is_dir() and not d.name.startswith(".")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drift detection
+# ---------------------------------------------------------------------------
+
+
+def check_drift(
+    project_dir: Path,
+    *,
+    verbose: bool = False,
+) -> list[DriftWarning]:
+    """Check all CLAUDE.md files with metadata for drift.
+
+    Returns a list of warnings. Also prints formatted output.
+    """
+    warnings: list[DriftWarning] = []
+
+    # Find all CLAUDE.md files
+    claude_files = list(project_dir.rglob("CLAUDE.md"))
+    if not claude_files:
+        click.echo("No CLAUDE.md files found.")
+        return warnings
+
+    for claude_path in sorted(claude_files):
+        rel_path = claude_path.relative_to(project_dir)
+
+        meta = None
+        try:
+            meta = parse_inline_metadata(claude_path)
+        except BrokenInlineMetadata as exc:
+            click.echo(
+                click.style(f"  ⚠ {rel_path}", fg="yellow")
+                + f" — broken metadata: {exc}"
+            )
+            continue
+
+        if meta is None:
+            if verbose:
+                click.echo(
+                    f"  {rel_path} has no strawpot metadata. Treat as manually managed."
+                )
+            continue
+
+        component_dir = claude_path.parent
+        component_name = meta.get("component", str(rel_path.parent))
+
+        # Check directory drift
+        dirs_at_gen = meta.get("dirs_at_gen", [])
+        if isinstance(dirs_at_gen, str):
+            dirs_at_gen = [d.strip() for d in dirs_at_gen.strip("[]").split(",") if d.strip()]
+        if dirs_at_gen:
+            current_dirs = _list_subdirs(component_dir)
+            new_dirs = set(current_dirs) - set(dirs_at_gen)
+            removed_dirs = set(dirs_at_gen) - set(current_dirs)
+
+            for d in sorted(new_dirs):
+                w = DriftWarning(
+                    component_path=str(rel_path),
+                    drift_type=DriftType.NEW_DIRECTORY,
+                    message=f"New directory '{d}' added since generation",
+                    suggestion=f"Run 'strawpot init' to regenerate with updated structure",
+                )
+                warnings.append(w)
+
+            for d in sorted(removed_dirs):
+                w = DriftWarning(
+                    component_path=str(rel_path),
+                    drift_type=DriftType.REMOVED_DIRECTORY,
+                    message=f"Directory '{d}' removed since generation",
+                    suggestion=f"Run 'strawpot init' to regenerate with updated structure",
+                )
+                warnings.append(w)
+
+        # Check build file hash drift
+        build_hash_at_gen = meta.get("build_file_hash", "")
+        if build_hash_at_gen:
+            current_hash = _hash_build_files(component_dir)
+            if current_hash != build_hash_at_gen:
+                w = DriftWarning(
+                    component_path=str(rel_path),
+                    drift_type=DriftType.BUILD_FILE_CHANGED,
+                    message="Build files have changed since generation",
+                    suggestion="Run 'strawpot init' to regenerate with updated build configuration",
+                )
+                warnings.append(w)
+
+        # Check freshness
+        generated_at = meta.get("generated")
+        if generated_at:
+            try:
+                if isinstance(generated_at, datetime):
+                    gen_time = generated_at.replace(tzinfo=timezone.utc) if generated_at.tzinfo is None else generated_at
+                else:
+                    gen_time = datetime.fromisoformat(str(generated_at).replace("Z", "+00:00"))
+                age_days = (datetime.now(timezone.utc) - gen_time).days
+                if age_days > _FRESHNESS_DAYS:
+                    w = DriftWarning(
+                        component_path=str(rel_path),
+                        drift_type=DriftType.STALE_CONFIG,
+                        message=f"Generated {age_days} days ago (threshold: {_FRESHNESS_DAYS} days)",
+                        suggestion="Run 'strawpot init' to refresh with latest templates",
+                    )
+                    warnings.append(w)
+            except (ValueError, TypeError):
+                pass
+
+    # Print results
+    if warnings:
+        click.echo(click.style(f"\n⚠ Found {len(warnings)} drift warning(s):\n", fg="yellow", bold=True))
+        for w in warnings:
+            click.echo(f"  ⚠ {w.component_path}: {w.message}")
+            if verbose:
+                click.echo(f"    → {w.suggestion}")
+        click.echo()
+    else:
+        click.echo(click.style("\n✓ No drift detected.\n", fg="green", bold=True))
+
+    return warnings

--- a/cli/tests/test_init_drift.py
+++ b/cli/tests/test_init_drift.py
@@ -1,0 +1,240 @@
+"""Tests for drift detection and inline metadata parsing."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from strawpot.init.drift import (
+    DriftType,
+    DriftWarning,
+    check_drift,
+    parse_inline_metadata,
+    _hash_build_files,
+)
+from strawpot.init.exceptions import BrokenInlineMetadata
+
+
+# ---------------------------------------------------------------------------
+# parse_inline_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestParseInlineMetadata:
+    def test_valid_metadata(self, tmp_path):
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(
+            "# Engine\n\n"
+            "<!-- strawpot:meta\n"
+            "generated: 2026-03-29T12:00:00Z\n"
+            "archetype: game-engine\n"
+            "language: C++\n"
+            "component: engine\n"
+            "rule_count: 23\n"
+            "-->\n\n"
+            "## Hard Rules\n"
+        )
+        meta = parse_inline_metadata(claude_md)
+        assert meta is not None
+        assert meta["archetype"] == "game-engine"
+        assert meta["language"] == "C++"
+        assert meta["rule_count"] == 23
+
+    def test_no_metadata(self, tmp_path):
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("# Engine\n\nNo metadata here.\n")
+        assert parse_inline_metadata(claude_md) is None
+
+    def test_missing_file(self, tmp_path):
+        assert parse_inline_metadata(tmp_path / "nonexistent.md") is None
+
+    def test_broken_yaml_raises(self, tmp_path):
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(
+            "<!-- strawpot:meta\n"
+            "  this: is: broken: yaml: [[\n"
+            "-->\n"
+        )
+        with pytest.raises(BrokenInlineMetadata):
+            parse_inline_metadata(claude_md)
+
+    def test_metadata_not_at_start(self, tmp_path):
+        """Metadata can appear anywhere in the file."""
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(
+            "# Engine\n\nSome content.\n\n"
+            "<!-- strawpot:meta\n"
+            "archetype: game-engine\n"
+            "component: engine\n"
+            "-->\n\n"
+            "More content.\n"
+        )
+        meta = parse_inline_metadata(claude_md)
+        assert meta is not None
+        assert meta["archetype"] == "game-engine"
+
+
+# ---------------------------------------------------------------------------
+# check_drift — directory changes
+# ---------------------------------------------------------------------------
+
+
+class TestDriftDirectories:
+    def test_new_directory_detected(self, tmp_path):
+        comp = tmp_path / "engine"
+        comp.mkdir()
+        (comp / "src").mkdir()
+        claude_md = comp / "CLAUDE.md"
+        claude_md.write_text(
+            "<!-- strawpot:meta\n"
+            "generated: 2026-03-29T12:00:00Z\n"
+            "component: engine\n"
+            "dirs_at_gen: [src]\n"
+            "-->\n"
+        )
+        # Add a new directory
+        (comp / "tests").mkdir()
+
+        warnings = check_drift(tmp_path)
+        dir_warnings = [w for w in warnings if w.drift_type == DriftType.NEW_DIRECTORY]
+        assert len(dir_warnings) == 1
+        assert "tests" in dir_warnings[0].message
+
+    def test_removed_directory_detected(self, tmp_path):
+        comp = tmp_path / "engine"
+        comp.mkdir()
+        claude_md = comp / "CLAUDE.md"
+        claude_md.write_text(
+            "<!-- strawpot:meta\n"
+            "generated: 2026-03-29T12:00:00Z\n"
+            "component: engine\n"
+            "dirs_at_gen: [src, tests]\n"
+            "-->\n"
+        )
+        # Only src exists, tests was removed
+        (comp / "src").mkdir()
+
+        warnings = check_drift(tmp_path)
+        removed = [w for w in warnings if w.drift_type == DriftType.REMOVED_DIRECTORY]
+        assert len(removed) == 1
+        assert "tests" in removed[0].message
+
+    def test_no_drift_when_dirs_match(self, tmp_path):
+        comp = tmp_path / "engine"
+        comp.mkdir()
+        (comp / "src").mkdir()
+        claude_md = comp / "CLAUDE.md"
+        claude_md.write_text(
+            "<!-- strawpot:meta\n"
+            "generated: 2026-03-29T12:00:00Z\n"
+            "component: engine\n"
+            "dirs_at_gen: [src]\n"
+            "-->\n"
+        )
+        warnings = check_drift(tmp_path)
+        dir_warnings = [w for w in warnings if w.drift_type in (DriftType.NEW_DIRECTORY, DriftType.REMOVED_DIRECTORY)]
+        assert len(dir_warnings) == 0
+
+
+# ---------------------------------------------------------------------------
+# check_drift — build file changes
+# ---------------------------------------------------------------------------
+
+
+class TestDriftBuildFiles:
+    def test_build_file_change_detected(self, tmp_path):
+        comp = tmp_path / "engine"
+        comp.mkdir()
+        cmake = comp / "CMakeLists.txt"
+        cmake.write_text("old content")
+        old_hash = _hash_build_files(comp)
+
+        claude_md = comp / "CLAUDE.md"
+        claude_md.write_text(
+            "<!-- strawpot:meta\n"
+            f"generated: 2026-03-29T12:00:00Z\n"
+            f"component: engine\n"
+            f"build_file_hash: {old_hash}\n"
+            "-->\n"
+        )
+        # Modify the build file
+        cmake.write_text("new content")
+
+        warnings = check_drift(tmp_path)
+        build_warnings = [w for w in warnings if w.drift_type == DriftType.BUILD_FILE_CHANGED]
+        assert len(build_warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# check_drift — freshness
+# ---------------------------------------------------------------------------
+
+
+class TestDriftFreshness:
+    def test_stale_config_detected(self, tmp_path):
+        old_time = (datetime.now(timezone.utc) - timedelta(days=100)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(
+            "<!-- strawpot:meta\n"
+            f"generated: {old_time}\n"
+            "component: root\n"
+            "-->\n"
+        )
+        warnings = check_drift(tmp_path)
+        stale = [w for w in warnings if w.drift_type == DriftType.STALE_CONFIG]
+        assert len(stale) == 1
+        assert "days ago" in stale[0].message
+
+    def test_fresh_config_no_warning(self, tmp_path):
+        recent = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(
+            "<!-- strawpot:meta\n"
+            f"generated: {recent}\n"
+            "component: root\n"
+            "-->\n"
+        )
+        warnings = check_drift(tmp_path)
+        stale = [w for w in warnings if w.drift_type == DriftType.STALE_CONFIG]
+        assert len(stale) == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI --check flag
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCli:
+    @patch("strawpot.cli.get_strawpot_home")
+    def test_check_no_drift_exits_zero(self, mock_home, tmp_path):
+        mock_home.return_value = tmp_path
+        (tmp_path / ".first_run_done").touch()
+
+        # No CLAUDE.md files → no drift
+        from click.testing import CliRunner
+        from strawpot.cli import cli
+        result = CliRunner().invoke(cli, ["init", "--check"])
+        assert result.exit_code == 0
+
+    @patch("strawpot.cli.get_strawpot_home")
+    def test_check_with_drift_exits_one(self, mock_home, tmp_path, monkeypatch):
+        mock_home.return_value = tmp_path
+        (tmp_path / ".first_run_done").touch()
+        monkeypatch.chdir(tmp_path)
+
+        # Create a stale CLAUDE.md
+        old_time = (datetime.now(timezone.utc) - timedelta(days=100)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        (tmp_path / "CLAUDE.md").write_text(
+            "<!-- strawpot:meta\n"
+            f"generated: {old_time}\n"
+            "component: root\n"
+            "-->\n"
+        )
+
+        from click.testing import CliRunner
+        from strawpot.cli import cli
+        result = CliRunner().invoke(cli, ["init", "--check"])
+        assert result.exit_code == 1

--- a/cli/tests/test_init_integration.py
+++ b/cli/tests/test_init_integration.py
@@ -216,7 +216,7 @@ class TestWriteFiles:
 class TestCliIntegration:
     @patch("strawpot.cli.get_strawpot_home")
     def test_init_check_flag(self, mock_home, tmp_path):
-        """--check runs drift detection stub."""
+        """--check runs drift detection."""
         mock_home.return_value = tmp_path
         (tmp_path / ".first_run_done").touch()
 
@@ -225,7 +225,7 @@ class TestCliIntegration:
 
         result = CliRunner().invoke(cli, ["init", "--check"])
         assert result.exit_code == 0
-        assert "not yet implemented" in result.output
+        assert "No CLAUDE.md" in result.output or "No drift" in result.output
 
     @patch("strawpot.cli.get_strawpot_home")
     @patch("strawpot.init.questionnaire.run_questionnaire")


### PR DESCRIPTION
## Summary

- Parse `<!-- strawpot:meta -->` inline metadata blocks from CLAUDE.md files
- Detect directory drift: new/removed directories since generation
- Detect build file changes via SHA-256 hash comparison
- Warn on stale configurations (>90 days since generation)
- Wire `--check` flag with CI-friendly exit codes (0 = no drift, 1 = drift)
- Handle files without metadata and broken metadata gracefully

Closes #620

## Test plan

- [x] Valid metadata parsed correctly from CLAUDE.md
- [x] Missing metadata returns None
- [x] Broken YAML metadata raises BrokenInlineMetadata
- [x] Metadata found anywhere in file (not just start)
- [x] New directory detected as drift
- [x] Removed directory detected as drift
- [x] No false positives when dirs match
- [x] Build file hash change detected
- [x] Stale config (>90 days) triggers warning
- [x] Fresh config no warning
- [x] CLI --check exits 0 with no drift, 1 with drift
- [x] 1206 total tests pass (zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)