### PR TITLE
Add discovery hint and template validation CI test

### DIFF
--- a/cli/src/strawpot/cli.py
+++ b/cli/src/strawpot/cli.py
@@ -146,6 +146,29 @@ def cli(ctx):
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
 
+
+# Project-scoped commands that should show the init hint
+_HINT_COMMANDS = {"start", "config", "doctor"}
+
+
+@cli.result_callback()
+@click.pass_context
+def _show_init_hint_callback(ctx, *args, **kwargs):
+    """Show init hint after project-scoped commands if no CLAUDE.md exists."""
+    parent_ctx = ctx.parent
+    if parent_ctx is None:
+        return
+    invoked = parent_ctx.invoked_subcommand
+    if invoked not in _HINT_COMMANDS:
+        return
+    try:
+        from strawpot.init.hint import should_show_init_hint, show_init_hint
+        if should_show_init_hint(Path.cwd()):
+            show_init_hint()
+    except Exception:
+        pass  # Never let hint logic break the CLI
+
+
 # ---------------------------------------------------------------------------
 # Quickstart guide
 # ---------------------------------------------------------------------------

--- a/cli/src/strawpot/init/hint.py
+++ b/cli/src/strawpot/init/hint.py
@@ -1,0 +1,70 @@
+"""Discovery hint — tells users about ``strawpot init`` when no CLAUDE.md exists."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from strawpot.config import get_strawpot_home
+
+
+_HINTS_FILE = "hints.json"
+
+
+def _hints_path() -> Path:
+    return get_strawpot_home() / _HINTS_FILE
+
+
+def _load_hints() -> dict:
+    path = _hints_path()
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_hints(data: dict) -> None:
+    path = _hints_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def should_show_init_hint(project_dir: Path) -> bool:
+    """Return True if the init hint should be shown for this project.
+
+    Conditions:
+    - No CLAUDE.md exists at the project root
+    - Hint hasn't been dismissed for this project path
+    """
+    if (project_dir / "CLAUDE.md").exists():
+        return False
+
+    hints = _load_hints()
+    dismissed = hints.get("dismissed_init", [])
+    return str(project_dir) not in dismissed
+
+
+def show_init_hint() -> None:
+    """Print the discovery hint."""
+    click.echo()
+    click.echo(
+        click.style("Tip:", bold=True)
+        + " Run "
+        + click.style("strawpot init", bold=True)
+        + " to generate agent configuration for this project."
+    )
+
+
+def dismiss_init_hint(project_dir: Path) -> None:
+    """Dismiss the init hint for the given project directory."""
+    hints = _load_hints()
+    dismissed = hints.get("dismissed_init", [])
+    project_str = str(project_dir)
+    if project_str not in dismissed:
+        dismissed.append(project_str)
+    hints["dismissed_init"] = dismissed
+    _save_hints(hints)

--- a/cli/tests/test_init_hint.py
+++ b/cli/tests/test_init_hint.py
@@ -1,0 +1,78 @@
+"""Tests for the discovery hint system."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from strawpot.init.hint import (
+    dismiss_init_hint,
+    should_show_init_hint,
+    show_init_hint,
+)
+
+
+@pytest.fixture()
+def hint_home(tmp_path, monkeypatch):
+    """Patch get_strawpot_home for hint storage."""
+    monkeypatch.setattr("strawpot.init.hint.get_strawpot_home", lambda: tmp_path)
+    return tmp_path
+
+
+class TestShouldShowInitHint:
+    def test_shows_when_no_claude_md(self, hint_home, tmp_path):
+        project = tmp_path / "myproject"
+        project.mkdir()
+        assert should_show_init_hint(project) is True
+
+    def test_hidden_when_claude_md_exists(self, hint_home, tmp_path):
+        project = tmp_path / "myproject"
+        project.mkdir()
+        (project / "CLAUDE.md").write_text("# Project")
+        assert should_show_init_hint(project) is False
+
+    def test_hidden_after_dismissal(self, hint_home, tmp_path):
+        project = tmp_path / "myproject"
+        project.mkdir()
+        dismiss_init_hint(project)
+        assert should_show_init_hint(project) is False
+
+    def test_dismissal_persists(self, hint_home, tmp_path):
+        project = tmp_path / "myproject"
+        project.mkdir()
+        dismiss_init_hint(project)
+
+        # Should still be dismissed on next check
+        assert should_show_init_hint(project) is False
+
+
+class TestShowInitHint:
+    def test_prints_hint(self, capsys):
+        show_init_hint()
+        output = capsys.readouterr().out
+        assert "strawpot init" in output
+        assert "Tip" in output
+
+
+class TestDismissInitHint:
+    def test_creates_hints_file(self, hint_home, tmp_path):
+        project = tmp_path / "myproject"
+        project.mkdir()
+        dismiss_init_hint(project)
+
+        hints_path = hint_home / "hints.json"
+        assert hints_path.exists()
+
+    def test_multiple_projects(self, hint_home, tmp_path):
+        p1 = tmp_path / "project1"
+        p1.mkdir()
+        p2 = tmp_path / "project2"
+        p2.mkdir()
+
+        dismiss_init_hint(p1)
+        dismiss_init_hint(p2)
+
+        assert should_show_init_hint(p1) is False
+        assert should_show_init_hint(p2) is False

--- a/cli/tests/test_init_template_validation.py
+++ b/cli/tests/test_init_template_validation.py
@@ -1,0 +1,130 @@
+"""CI template validation — comprehensive checks for all archetypes and layers.
+
+This test runs on every CI build and validates:
+1. All conditions parse
+2. All condition variables reference real question IDs
+3. All text interpolation variables are in the allowed set
+4. All condition combinations produce valid, non-empty output
+5. All language layer rules have non-empty text
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from strawpot.init.engine import (
+    _VALID_INTERPOLATION_VARS,
+    evaluate_rules,
+    extract_interpolation_vars,
+    extract_variables,
+    parse_condition,
+)
+from strawpot.init.loader import list_archetypes, list_languages, load_archetype, load_language_layer
+
+
+# ---------------------------------------------------------------------------
+# Archetype validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(params=list_archetypes())
+def archetype(request):
+    return load_archetype(request.param)
+
+
+class TestArchetypeValidation:
+    """Validates every archetype template on every CI run."""
+
+    def test_conditions_parse(self, archetype):
+        """Every condition string must be parseable."""
+        for section in ("hard", "soft"):
+            for rule in archetype.rules.get(section, []):
+                parse_condition(rule["condition"])
+        for rule in archetype.cross_component:
+            parse_condition(rule["condition"])
+
+    def test_condition_variables_exist(self, archetype):
+        """Condition variables must reference real question IDs."""
+        question_ids = {q.id for q in archetype.questions}
+        for section in ("hard", "soft"):
+            for rule in archetype.rules.get(section, []):
+                for var in extract_variables(rule["condition"]):
+                    assert var in question_ids, (
+                        f"[{archetype.slug}] Condition variable '{var}' not in "
+                        f"questions: {question_ids}"
+                    )
+
+    def test_interpolation_vars_valid(self, archetype):
+        """All {{var}} references must be in the allowed set."""
+        for section in ("hard", "soft"):
+            for rule in archetype.rules.get(section, []):
+                for var in extract_interpolation_vars(rule["text"]):
+                    assert var in _VALID_INTERPOLATION_VARS, (
+                        f"[{archetype.slug}] Invalid interpolation var '{{{{{var}}}}}'"
+                    )
+        for rule in archetype.cross_component:
+            for var in extract_interpolation_vars(rule["text"]):
+                assert var in _VALID_INTERPOLATION_VARS
+
+    def test_all_rules_have_text(self, archetype):
+        """Every rule must have non-empty text."""
+        for section in ("hard", "soft"):
+            for rule in archetype.rules.get(section, []):
+                assert rule.get("text", "").strip(), (
+                    f"[{archetype.slug}] Empty rule text in {section}"
+                )
+        for rule in archetype.cross_component:
+            assert rule.get("text", "").strip()
+
+    def test_produces_non_empty_output(self, archetype):
+        """A default answer set must produce at least some rules."""
+        answers = {}
+        for q in archetype.questions:
+            answers[q.id] = q.default or (q.choices[0] if q.choices else "")
+
+        ctx = {
+            "components": ["test"],
+            "component": {"name": "test", "path": "test/", "language": "Unknown"},
+            "shared": {"path": ""},
+            "project": {"name": "TestProject"},
+        }
+        result = evaluate_rules(
+            {"rules": archetype.rules, "cross_component": archetype.cross_component},
+            answers,
+            ctx,
+        )
+        assert len(result) > 0, (
+            f"[{archetype.slug}] Default answers produce no rules"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Language layer validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(params=list_languages())
+def language_layer(request):
+    return load_language_layer(request.param)
+
+
+class TestLanguageLayerValidation:
+    """Validates every language layer on every CI run."""
+
+    def test_conditions_parse(self, language_layer):
+        for section in ("hard", "soft"):
+            for rule in language_layer.rules.get(section, []):
+                parse_condition(rule["condition"])
+
+    def test_all_rules_have_text(self, language_layer):
+        for section in ("hard", "soft"):
+            for rule in language_layer.rules.get(section, []):
+                assert rule.get("text", "").strip(), (
+                    f"[{language_layer.language}] Empty rule text"
+                )
+
+    def test_has_rules(self, language_layer):
+        total = sum(len(language_layer.rules.get(s, [])) for s in ("hard", "soft"))
+        assert total > 0, f"[{language_layer.language}] No rules defined"


### PR DESCRIPTION
## Summary

- Add discovery hint: show "Run strawpot init" tip after project-scoped commands (start, config, doctor) when no CLAUDE.md exists
- Track hint dismissals per project in `~/.strawpot/hints.json`
- Wire hint into CLI via `result_callback` — lazy loading, never breaks the CLI
- Add comprehensive template validation CI test for all 5 archetypes and 5 language layers

Closes #621

## Test plan

- [x] Hint shows when no CLAUDE.md and not dismissed
- [x] Hint hidden when CLAUDE.md exists
- [x] Hint hidden after dismissal
- [x] Dismissal persists across checks
- [x] Multiple projects tracked independently
- [x] All 5 archetypes validated: conditions, variables, interpolation, text, output
- [x] All 5 language layers validated: conditions, text, non-empty
- [x] 1253 total tests pass (zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)