### PR TITLE
Remove orchestrator role quick-switch from Global Settings

### DIFF
--- a/gui/frontend/src/components/ConfigForm.test.tsx
+++ b/gui/frontend/src/components/ConfigForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ConfigForm from "./ConfigForm";
 
@@ -36,7 +36,7 @@ beforeEach(() => {
 
 function renderForm(
   valuesOverrides: Record<string, unknown> = {},
-  props: { saving?: boolean; showQuickSwitch?: boolean } = {},
+  props: { saving?: boolean } = {},
 ) {
   const values = makeValues(valuesOverrides);
   return render(
@@ -44,149 +44,58 @@ function renderForm(
       values={values}
       onSave={onSave}
       saving={props.saving}
-      showQuickSwitch={props.showQuickSwitch}
     />,
   );
 }
 
-/** Get the quick-switch container (the one with "Quick switch" label). */
-function getQuickSwitchButtons() {
-  const label = screen.getByText("Quick switch");
-  const container = label.closest("div")!.parentElement!;
-  return within(container).getAllByRole("button");
-}
-
 // --------------------------------------------------------------------------
-// Tests — RoleQuickSwitch visibility
+// Tests — ConfigForm rendering
 // --------------------------------------------------------------------------
 
-describe("ConfigForm — RoleQuickSwitch visibility", () => {
-  it("does not render quick-switch when showQuickSwitch is false (default)", () => {
+describe("ConfigForm", () => {
+  it("renders the form with all sections", () => {
+    renderForm();
+
+    expect(screen.getByText("General")).toBeInTheDocument();
+    expect(screen.getByText("Orchestrator")).toBeInTheDocument();
+    expect(screen.getByText("Policy")).toBeInTheDocument();
+    expect(screen.getByText("Session")).toBeInTheDocument();
+    expect(screen.getByText("Trace")).toBeInTheDocument();
+  });
+
+  it("does not render quick-switch in global settings", () => {
     renderForm();
 
     expect(screen.queryByText("Quick switch")).not.toBeInTheDocument();
   });
 
-  it("does not render quick-switch when showQuickSwitch is explicitly false", () => {
-    renderForm({}, { showQuickSwitch: false });
+  it("renders Role input with initial value", () => {
+    renderForm({ orchestrator: { role: "imu-live" } });
 
-    expect(screen.queryByText("Quick switch")).not.toBeInTheDocument();
-  });
-
-  it("renders quick-switch when showQuickSwitch is true", () => {
-    renderForm({}, { showQuickSwitch: true });
-
-    expect(screen.getByText("Quick switch")).toBeInTheDocument();
-  });
-});
-
-// --------------------------------------------------------------------------
-// Tests — RoleQuickSwitch behavior
-// --------------------------------------------------------------------------
-
-describe("ConfigForm — RoleQuickSwitch", () => {
-  it("renders two quick-switch buttons: imu and imu-live", () => {
-    renderForm({}, { showQuickSwitch: true });
-
-    const buttons = getQuickSwitchButtons();
-    expect(buttons).toHaveLength(2);
-    expect(buttons[0]).toHaveTextContent("imu");
-    expect(buttons[1]).toHaveTextContent("imu-live");
-  });
-
-  it("calls onSave immediately when switching to a different role", async () => {
-    const user = userEvent.setup();
-    renderForm({ orchestrator: { role: "imu" } }, { showQuickSwitch: true });
-
-    const buttons = getQuickSwitchButtons();
-    await user.click(buttons[1]); // click "imu-live"
-
-    expect(onSave).toHaveBeenCalledTimes(1);
-    const savedData = onSave.mock.calls[0][0];
-    expect(savedData.orchestrator.role).toBe("imu-live");
-  });
-
-  it("does not call onSave when clicking the already-selected role", async () => {
-    const user = userEvent.setup();
-    renderForm({ orchestrator: { role: "imu" } }, { showQuickSwitch: true });
-
-    const buttons = getQuickSwitchButtons();
-    await user.click(buttons[0]); // click "imu" — already selected
-
-    expect(onSave).not.toHaveBeenCalled();
-  });
-
-  it("reflects the current role with active styling class", () => {
-    renderForm(
-      { orchestrator: { role: "imu-live" } },
-      { showQuickSwitch: true },
-    );
-
-    const buttons = getQuickSwitchButtons();
-    // Active button gets bg-background class
-    expect(buttons[1].className).toContain("bg-background");
-    // Inactive button gets text-muted-foreground
-    expect(buttons[0].className).toContain("text-muted-foreground");
-    expect(buttons[0].className).not.toContain("bg-background");
-  });
-
-  it("disables quick-switch buttons when saving", () => {
-    renderForm(
-      { orchestrator: { role: "imu" } },
-      { saving: true, showQuickSwitch: true },
-    );
-
-    const buttons = getQuickSwitchButtons();
-    expect(buttons[0]).toBeDisabled();
-    expect(buttons[1]).toBeDisabled();
-  });
-
-  it("shows no active button when orchestrator_role is a non-quick-role value", () => {
-    renderForm(
-      { orchestrator: { role: "custom-role" } },
-      { showQuickSwitch: true },
-    );
-
-    const buttons = getQuickSwitchButtons();
-    // Neither button should have the active styling
-    for (const btn of buttons) {
-      expect(btn.className).not.toContain("bg-background");
-      expect(btn.className).toContain("text-muted-foreground");
-    }
-  });
-
-  it("updates the Role input field value after quick-switch", async () => {
-    const user = userEvent.setup();
-    renderForm({ orchestrator: { role: "imu" } }, { showQuickSwitch: true });
-
-    // Role input should initially show "imu"
-    const roleInput = screen.getByDisplayValue("imu");
-    expect(roleInput).toBeInTheDocument();
-
-    // Switch to imu-live
-    const buttons = getQuickSwitchButtons();
-    await user.click(buttons[1]);
-
-    // Role input should now reflect "imu-live"
     expect(screen.getByDisplayValue("imu-live")).toBeInTheDocument();
   });
 
-  it("preserves other config values when quick-switching roles", async () => {
+  it("calls onSave with nested config on save button click", async () => {
     const user = userEvent.setup();
-    renderForm(
-      {
-        orchestrator: { role: "imu", permission_mode: "plan" },
-        runtime: "my-agent",
-      },
-      { showQuickSwitch: true },
-    );
+    renderForm({
+      orchestrator: { role: "imu", permission_mode: "plan" },
+      runtime: "my-agent",
+    });
 
-    const buttons = getQuickSwitchButtons();
-    await user.click(buttons[1]); // switch to imu-live
+    const saveBtn = screen.getByRole("button", { name: /save configuration/i });
+    await user.click(saveBtn);
 
+    expect(onSave).toHaveBeenCalledTimes(1);
     const savedData = onSave.mock.calls[0][0];
-    expect(savedData.orchestrator.role).toBe("imu-live");
+    expect(savedData.orchestrator.role).toBe("imu");
     expect(savedData.orchestrator.permission_mode).toBe("plan");
     expect(savedData.runtime).toBe("my-agent");
+  });
+
+  it("disables save button when saving", () => {
+    renderForm({}, { saving: true });
+
+    const saveBtn = screen.getByRole("button", { name: /saving/i });
+    expect(saveBtn).toBeDisabled();
   });
 });

--- a/gui/frontend/src/components/ConfigForm.tsx
+++ b/gui/frontend/src/components/ConfigForm.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { useResources } from "@/hooks/queries/use-registry";
 import { useProjectResources } from "@/hooks/queries/use-project-resources";
-import RoleQuickSwitch from "@/components/RoleQuickSwitch";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -20,7 +19,6 @@ interface ConfigFormProps {
   placeholders?: Record<string, unknown>;
   onSave: (data: Record<string, unknown>) => void;
   saving?: boolean;
-  showQuickSwitch?: boolean;
   projectId?: number | null;
 }
 
@@ -125,7 +123,6 @@ export default function ConfigForm({
   placeholders,
   onSave,
   saving,
-  showQuickSwitch = false,
   projectId,
 }: ConfigFormProps) {
   const [state, setState] = useState<FlatState>(toFlat(values));
@@ -230,21 +227,6 @@ export default function ConfigForm({
       <section className="flex flex-col gap-3">
         <h3 className="text-sm font-semibold">Orchestrator</h3>
         <Separator />
-        {showQuickSwitch && (
-          <div className="flex items-center gap-3">
-            <Label className="text-xs text-muted-foreground">Quick switch</Label>
-            <RoleQuickSwitch
-              current={state.orchestrator_role}
-              onSwitch={(role) => {
-                if (role === state.orchestrator_role) return;
-                const updated = { ...state, orchestrator_role: role };
-                setState(updated);
-                onSave(toNested(updated));
-              }}
-              disabled={saving}
-            />
-          </div>
-        )}
         <div className="grid gap-4 sm:grid-cols-2">
           <Field label="Role">
             <Input

--- a/gui/frontend/src/pages/Settings.tsx
+++ b/gui/frontend/src/pages/Settings.tsx
@@ -79,7 +79,6 @@ export default function Settings() {
               placeholders={globalConfig.data?.defaults}
               onSave={handleSaveGlobal}
               saving={saveGlobal.isPending}
-              showQuickSwitch
             />
           )}
         </TabsContent>


### PR DESCRIPTION
## Summary
- Remove `showQuickSwitch` prop, `RoleQuickSwitch` import, and quick-switch rendering from `ConfigForm`
- Remove `showQuickSwitch` prop from `Settings.tsx` Global tab
- Replace quick-switch tests with basic ConfigForm rendering/save/disable tests
- `RoleQuickSwitch.tsx` component retained — still used in `ImuPage`

## Test plan
- [x] Build passes
- [x] 108/108 frontend tests pass
- [ ] Verify Global Settings page no longer shows quick-switch buttons
- [ ] Verify Imu page quick-switch still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)