### PR TITLE
Save ImuPage orchestrator role to DB settings table

### DIFF
--- a/gui/frontend/src/hooks/mutations/use-settings.ts
+++ b/gui/frontend/src/hooks/mutations/use-settings.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import { queryKeys } from "@/lib/query-keys";
+
+/**
+ * Save (create or update) a single setting by key.
+ */
+export function useSaveSetting(key: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (value: string) =>
+      api.put<{ key: string; value: string }>(`/settings/${key}`, { value }),
+    onSuccess: (_res, value) => {
+      qc.setQueryData(queryKeys.settings.detail(key), value);
+      qc.invalidateQueries({ queryKey: queryKeys.settings.all });
+    },
+  });
+}

--- a/gui/frontend/src/hooks/queries/use-settings.ts
+++ b/gui/frontend/src/hooks/queries/use-settings.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import { ApiError } from "@/api/client";
+import { queryKeys } from "@/lib/query-keys";
+
+/**
+ * Fetch a single setting by key. Returns null if the key does not exist (404).
+ */
+export function useSetting(key: string) {
+  return useQuery({
+    queryKey: queryKeys.settings.detail(key),
+    queryFn: async () => {
+      try {
+        const res = await api.get<{ key: string; value: string }>(
+          `/settings/${key}`,
+        );
+        return res.value;
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 404) return null;
+        throw err;
+      }
+    },
+  });
+}

--- a/gui/frontend/src/lib/query-keys.ts
+++ b/gui/frontend/src/lib/query-keys.ts
@@ -24,6 +24,10 @@ export const queryKeys = {
   config: {
     global: ["config", "global"] as const,
   },
+  settings: {
+    all: ["settings"] as const,
+    detail: (key: string) => ["settings", key] as const,
+  },
   registry: {
     list: (type: string) => ["registry", type] as const,
     detail: (type: string, name: string) => ["registry", type, name] as const,

--- a/gui/frontend/src/pages/ImuPage.tsx
+++ b/gui/frontend/src/pages/ImuPage.tsx
@@ -48,8 +48,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { AlertCircle, BotMessageSquare, CheckCircle2, CornerDownLeft, ExternalLink, Loader2, MessageSquare, Paperclip, Pencil, Settings, Square, Trash2, Upload, X, XCircle } from "lucide-react";
 import type { AskUserPending, ChatMessage, ConversationSession, ImuConversation, ProjectFile, TreeData } from "@/api/types";
 import MarkdownContent from "@/components/MarkdownContent";
-import { useGlobalConfig } from "@/hooks/queries/use-config";
-import { useSaveGlobalConfig } from "@/hooks/mutations/use-config";
+import { useSetting } from "@/hooks/queries/use-settings";
+import { useSaveSetting } from "@/hooks/mutations/use-settings";
 import RoleQuickSwitch, { type QuickRole } from "@/components/RoleQuickSwitch";
 import { toast } from "sonner";
 
@@ -243,11 +243,9 @@ function ImuConversationView({ cid }: { cid: number }) {
   const respondedIdsRef = useRef<Set<string>>(new Set());
   useEffect(() => { respondedIdsRef.current.clear(); }, [cid]);
 
-  const globalConfig = useGlobalConfig();
-  const saveGlobalConfig = useSaveGlobalConfig();
-  const configValues = globalConfig.data?.values as Record<string, unknown> | undefined;
-  const configRole = (configValues?.orchestrator as Record<string, unknown> | undefined)?.role as string | undefined;
-  const orchestratorRole: string = configRole || DEFAULT_ROLE;
+  const settingQuery = useSetting("orchestrator_role");
+  const saveSetting = useSaveSetting("orchestrator_role");
+  const orchestratorRole: string = settingQuery.data || DEFAULT_ROLE;
 
   const { data: agents } = useResources("agents");
   const { data: memories } = useResources("memories");
@@ -372,7 +370,7 @@ function ImuConversationView({ cid }: { cid: number }) {
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     const trimmed = task.trim();
-    if (!trimmed || hasAdvError || globalConfig.isLoading) return;
+    if (!trimmed || hasAdvError || settingQuery.isLoading) return;
     if (!trySubmit(trimmed, submit.isPending)) return;
     addToHistory(trimmed);
     submit.mutate(
@@ -740,18 +738,11 @@ function ImuConversationView({ cid }: { cid: number }) {
               current={orchestratorRole}
               onSwitch={(role) => {
                 if (role === orchestratorRole) return;
-                const merged = {
-                  ...configValues,
-                  orchestrator: {
-                    ...((configValues?.orchestrator as Record<string, unknown>) ?? {}),
-                    role,
-                  },
-                };
-                saveGlobalConfig.mutate(merged, {
+                saveSetting.mutate(role, {
                   onError: () => toast.error("Failed to save role"),
                 });
               }}
-              disabled={saveGlobalConfig.isPending || globalConfig.isLoading}
+              disabled={saveSetting.isPending || settingQuery.isLoading}
               size="sm"
             />
             <div className="flex items-center gap-1">
@@ -802,7 +793,7 @@ function ImuConversationView({ cid }: { cid: number }) {
               )}
               <Button
                 type="submit"
-                disabled={!task.trim() || submit.isPending || hasAdvError || globalConfig.isLoading}
+                disabled={!task.trim() || submit.isPending || hasAdvError || settingQuery.isLoading}
                 variant={hasActiveSession ? "outline" : "default"}
                 title={hasActiveSession ? "Queue task (runs after current session)" : undefined}
               >

--- a/gui/src/strawpot_gui/app.py
+++ b/gui/src/strawpot_gui/app.py
@@ -18,7 +18,7 @@ from strawpot_gui.event_bus import event_bus
 from strawpot_gui.scheduler import Scheduler
 
 logger = logging.getLogger(__name__)
-from strawpot_gui.routers import config, conversations, files, fs, health, imu, integrations, logs, project_resources, projects, registry, schedules, sessions, sse, stats, ws
+from strawpot_gui.routers import config, conversations, files, fs, health, imu, integrations, logs, project_resources, projects, registry, schedules, sessions, settings, sse, stats, ws
 
 
 def _ensure_imu_role() -> None:
@@ -189,6 +189,7 @@ def create_app(
     app.include_router(project_resources.router)
     app.include_router(schedules.router)
     app.include_router(stats.router)
+    app.include_router(settings.router)
 
     # Serve built frontend — check installed package path then dev path
     static_dir = Path(__file__).resolve().parent / "static"

--- a/gui/src/strawpot_gui/config_helpers.py
+++ b/gui/src/strawpot_gui/config_helpers.py
@@ -1,8 +1,9 @@
 """Shared config helpers for the GUI backend."""
 
 import logging
+import sqlite3
 
-from strawpot.config import load_config
+from strawpot.config import get_strawpot_home, load_config
 
 logger = logging.getLogger(__name__)
 
@@ -12,17 +13,42 @@ logger = logging.getLogger(__name__)
 _FALLBACK_ROLE = "imu"
 
 
-def default_orchestrator_role() -> str:
-    """Read orchestrator role from global config.
+def _read_setting_from_db(key: str) -> str | None:
+    """Read a single setting from the GUI database, or None if unavailable."""
+    db_path = get_strawpot_home() / "gui.db"
+    if not db_path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(str(db_path), check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT value FROM settings WHERE key = ?", (key,)
+        ).fetchone()
+        conn.close()
+        return row["value"] if row else None
+    except Exception:
+        logger.debug("Could not read setting %r from DB", key, exc_info=True)
+        return None
 
-    Returns the configured ``orchestrator.role`` value.  Falls back to
-    ``"imu"`` only when the config file cannot be read (e.g. TOML parse
-    error, missing file, or permission denied).  An empty-string role in
-    the config is also treated as a fallback case.
+
+def default_orchestrator_role() -> str:
+    """Read orchestrator role with priority: DB → TOML → fallback.
+
+    1. Check ``settings`` table for ``orchestrator_role`` (set by ImuPage).
+    2. Fall back to ``orchestrator.role`` in global ``strawpot.toml``.
+    3. Last resort: ``"imu"``.
     """
+    # 1. DB setting (highest priority — set directly by the user via GUI)
+    db_role = _read_setting_from_db("orchestrator_role")
+    if db_role:
+        return db_role
+
+    # 2. TOML config
     try:
         role = load_config(None).orchestrator_role
-        return role if role else _FALLBACK_ROLE
+        if role:
+            return role
     except Exception:
         logger.warning("Failed to load global config for default role", exc_info=True)
-        return _FALLBACK_ROLE
+
+    return _FALLBACK_ROLE

--- a/gui/src/strawpot_gui/db.py
+++ b/gui/src/strawpot_gui/db.py
@@ -464,6 +464,16 @@ def _migrate(conn: sqlite3.Connection) -> None:
     if "isolation" in cols:
         conn.execute("ALTER TABLE sessions DROP COLUMN isolation")
 
+    # Add settings table for GUI key-value settings (added 2026-03-31).
+    # Used by ImuPage to persist orchestrator_role without touching TOML files.
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS settings (
+            key        TEXT PRIMARY KEY,
+            value      TEXT NOT NULL,
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+    """)
+
 
 @contextmanager
 def get_db(db_path: str):

--- a/gui/src/strawpot_gui/routers/settings.py
+++ b/gui/src/strawpot_gui/routers/settings.py
@@ -1,0 +1,53 @@
+"""Key-value settings endpoints backed by the SQLite settings table."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+
+from strawpot_gui.db import get_db_conn
+
+router = APIRouter(prefix="/api/settings", tags=["settings"])
+
+
+@router.get("")
+def list_settings(conn=Depends(get_db_conn)):
+    """Return all settings as a {key: value} mapping."""
+    rows = conn.execute("SELECT key, value FROM settings").fetchall()
+    return {row["key"]: row["value"] for row in rows}
+
+
+@router.get("/{key}")
+def get_setting(key: str, conn=Depends(get_db_conn)):
+    """Return a single setting by key, or 404."""
+    row = conn.execute(
+        "SELECT value FROM settings WHERE key = ?", (key,)
+    ).fetchone()
+    if not row:
+        raise HTTPException(404, f"Setting '{key}' not found")
+    return {"key": key, "value": row["value"]}
+
+
+@router.put("/{key}")
+def put_setting(key: str, body: dict = Body(...), conn=Depends(get_db_conn)):
+    """Create or update a setting. Body: {"value": "..."}."""
+    value = body.get("value")
+    if value is None:
+        raise HTTPException(422, "Missing 'value' in request body")
+    now = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+        (key, str(value), now),
+    )
+    conn.connection.commit()
+    return {"key": key, "value": str(value)}
+
+
+@router.delete("/{key}")
+def delete_setting(key: str, conn=Depends(get_db_conn)):
+    """Delete a setting by key."""
+    cur = conn.execute("DELETE FROM settings WHERE key = ?", (key,))
+    conn.connection.commit()
+    if cur.rowcount == 0:
+        raise HTTPException(404, f"Setting '{key}' not found")
+    return {"deleted": key}


### PR DESCRIPTION
## Summary
- **New `settings` table** (SQLite key-value store) via DB migration — replaces TOML file rewriting for the ImuPage role toggle
- **New `/api/settings/{key}` endpoints** (GET/PUT/DELETE) for generic GUI settings
- **`config_helpers.default_orchestrator_role()`** now reads DB → TOML → fallback priority
- **ImuPage** uses `useSetting("orchestrator_role")` instead of `useGlobalConfig` — single-key DB write vs. full TOML rewrite

## Test plan
- [x] 108 frontend tests pass
- [x] 602 backend tests pass
- [x] TypeScript compiles clean
- [ ] Manual: toggle imu ↔ imu-live on ImuPage, verify it persists across page reload
- [ ] Manual: verify Global Settings page still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)