### PR TITLE
Allow selecting imu/imu-live role in schedule dialogs

### DIFF
--- a/gui/frontend/src/components/CreateOneTimeScheduleDialog.tsx
+++ b/gui/frontend/src/components/CreateOneTimeScheduleDialog.tsx
@@ -255,19 +255,32 @@ export default function CreateOneTimeScheduleDialog({
 
           <div className="space-y-2">
             <Label htmlFor="ot-role">Role</Label>
-            <Input
-              id="ot-role"
-              value={role}
-              onChange={(e) => setRole(e.target.value)}
-              placeholder={roles[0] ?? "orchestrator"}
-              list="ot-role-list"
-              disabled={isImu}
-            />
-            <datalist id="ot-role-list">
-              {roles.map((r) => (
-                <option key={r} value={r} />
-              ))}
-            </datalist>
+            {isImu ? (
+              <Select value={role || "imu"} onValueChange={setRole}>
+                <SelectTrigger id="ot-role">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="imu">imu</SelectItem>
+                  <SelectItem value="imu-live">imu-live</SelectItem>
+                </SelectContent>
+              </Select>
+            ) : (
+              <>
+                <Input
+                  id="ot-role"
+                  value={role}
+                  onChange={(e) => setRole(e.target.value)}
+                  placeholder={roles[0] ?? "orchestrator"}
+                  list="ot-role-list"
+                />
+                <datalist id="ot-role-list">
+                  {roles.map((r) => (
+                    <option key={r} value={r} />
+                  ))}
+                </datalist>
+              </>
+            )}
             {!isImu && role.trim() && roles.length > 0 && !roles.includes(role.trim()) && (
               <p className="text-xs text-destructive">Role not found in installed roles</p>
             )}
@@ -342,7 +355,7 @@ export default function CreateOneTimeScheduleDialog({
             </Button>
             <Button
               type="submit"
-              disabled={isPending || (!!role.trim() && roles.length > 0 && !roles.includes(role.trim()))}
+              disabled={isPending || (!isImu && !!role.trim() && roles.length > 0 && !roles.includes(role.trim()))}
             >
               {isPending
                 ? "Saving..."

--- a/gui/frontend/src/components/CreateScheduleDialog.tsx
+++ b/gui/frontend/src/components/CreateScheduleDialog.tsx
@@ -279,19 +279,32 @@ export default function CreateScheduleDialog({
 
           <div className="space-y-2">
             <Label htmlFor="sched-role">Role</Label>
-            <Input
-              id="sched-role"
-              value={role}
-              onChange={(e) => setRole(e.target.value)}
-              placeholder={roles[0] ?? "orchestrator"}
-              list="sched-role-list"
-              disabled={isImu}
-            />
-            <datalist id="sched-role-list">
-              {roles.map((r) => (
-                <option key={r} value={r} />
-              ))}
-            </datalist>
+            {isImu ? (
+              <Select value={role || "imu"} onValueChange={setRole}>
+                <SelectTrigger id="sched-role">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="imu">imu</SelectItem>
+                  <SelectItem value="imu-live">imu-live</SelectItem>
+                </SelectContent>
+              </Select>
+            ) : (
+              <>
+                <Input
+                  id="sched-role"
+                  value={role}
+                  onChange={(e) => setRole(e.target.value)}
+                  placeholder={roles[0] ?? "orchestrator"}
+                  list="sched-role-list"
+                />
+                <datalist id="sched-role-list">
+                  {roles.map((r) => (
+                    <option key={r} value={r} />
+                  ))}
+                </datalist>
+              </>
+            )}
             {!isImu && role.trim() && roles.length > 0 && !roles.includes(role.trim()) && (
               <p className="text-xs text-destructive">Role not found in installed roles</p>
             )}
@@ -379,7 +392,7 @@ export default function CreateScheduleDialog({
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={isPending || (!!role.trim() && roles.length > 0 && !roles.includes(role.trim()))}>
+            <Button type="submit" disabled={isPending || (!isImu && !!role.trim() && roles.length > 0 && !roles.includes(role.trim()))}>
               {isPending
                 ? "Saving..."
                 : editing


### PR DESCRIPTION
## Summary
- When Imu project is selected in Recurring or One-Time schedule dialogs, the role field changes from a disabled text input to a **Select dropdown** with `imu` and `imu-live` options
- Other projects retain the existing free-text input with autocomplete from installed roles
- Submit button validation updated to skip role-not-found check when Imu is selected

## Changes
- `CreateScheduleDialog.tsx` — conditional role field (Select for Imu, Input for others)
- `CreateOneTimeScheduleDialog.tsx` — same change

## Test plan
- [ ] Create a recurring schedule with Imu project → verify role dropdown shows imu/imu-live
- [ ] Edit an existing Imu schedule → verify role dropdown pre-selects correct value
- [ ] Create a one-time schedule with Imu → same dropdown behavior
- [ ] Select a non-Imu project → verify free-text input with autocomplete still works
- [ ] TypeScript build passes, 108/108 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)