### PR TITLE
Layer 3B: Affect vector injection into session bootstrap

### DIFF
--- a/cli/src/strawpot/delegation.py
+++ b/cli/src/strawpot/delegation.py
@@ -779,17 +779,231 @@ def _recall_warm_start(
     return f"## Previous Session (auto-loaded)\n\n{result.entries[0].content}"
 
 
+# ---------------------------------------------------------------------------
+# Affect vector injection (Layer 3B)
+# ---------------------------------------------------------------------------
+
+AFFECT_BASELINE = 3
+AFFECT_DIMENSIONS = [
+    "satisfaction", "frustration", "curiosity",
+    "warmth", "anxiety", "drive",
+]
+
+MODULATION_RULES: list[tuple[str, str, int, str]] = [
+    ("frustration", ">=", 5, "Explicitly name the friction. Seek alternative approaches."),
+    ("satisfaction", ">=", 7, "Propose ambitious next steps. Express confidence."),
+    ("curiosity", ">=", 6, "Ask deeper questions. Explore tangents if they might yield value."),
+    ("warmth", ">=", 6, "Use warmer language. Proactively check on the user."),
+    ("anxiety", ">=", 4, "Request confirmation before destructive actions. Flag risks explicitly."),
+    ("drive", ">=", 7, "Bias toward action over analysis. Push for shipping."),
+]
+
+
+def _is_affect_enabled(role_path: str) -> bool:
+    """Check if a role has ``affect: true`` in its frontmatter metadata.
+
+    Reads ``metadata.strawpot.affect`` from ROLE.md. Returns ``False``
+    when the field is absent, the file is missing, or parsing fails.
+    """
+    role_md = Path(role_path) / "ROLE.md"
+    if not role_md.exists():
+        return False
+    try:
+        text = role_md.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    parsed = parse_frontmatter(text)
+    fm = parsed.get("frontmatter", {})
+    return bool(_strawpot_meta(fm).get("affect", False))
+
+
+def _compute_affect_decay(
+    vector: dict[str, int],
+    sessions_elapsed: int,
+) -> tuple[dict[str, int], list[str]]:
+    """Apply decay toward baseline and return ``(new_vector, decay_log)``.
+
+    Each dimension moves 1 step toward :data:`AFFECT_BASELINE` per elapsed
+    session, clamped to [0, 10].
+    """
+    decayed: dict[str, int] = {}
+    log: list[str] = []
+    for dim in AFFECT_DIMENSIONS:
+        val = vector.get(dim, AFFECT_BASELINE)
+        original = val
+        for _ in range(sessions_elapsed):
+            if val > AFFECT_BASELINE:
+                val -= 1
+            elif val < AFFECT_BASELINE:
+                val += 1
+        val = max(0, min(10, val))
+        decayed[dim] = val
+        if val != original:
+            log.append(f"{dim} {original}→{val}")
+    return decayed, log
+
+
+def _get_active_modulation_rules(vector: dict[str, int]) -> list[str]:
+    """Return human-readable modulation rules active for the given vector."""
+    active: list[str] = []
+    for dim, op, threshold, instruction in MODULATION_RULES:
+        val = vector.get(dim, AFFECT_BASELINE)
+        if op == ">=" and val >= threshold:
+            active.append(f"- {dim} ≥ {threshold}: {instruction}")
+    return active
+
+
+def _format_affect_section(
+    vector: dict[str, int],
+    last_updated: str,
+    decay_log: list[str],
+    rules: list[str],
+) -> str:
+    """Format the emotional state into a prompt section."""
+    lines = ["## Emotional State (auto-loaded)", ""]
+    lines.append("Current affect vector:")
+    for dim in AFFECT_DIMENSIONS:
+        lines.append(f"- {dim}: {vector.get(dim, AFFECT_BASELINE)}")
+    lines.append("")
+    lines.append(f"Last updated: {last_updated}")
+    if decay_log:
+        lines.append(f"Decay applied: {', '.join(decay_log)} (toward baseline {AFFECT_BASELINE})")
+    else:
+        lines.append("Decay applied: (none)")
+    lines.append("")
+    if rules:
+        lines.append("Active behavioral modulation rules:")
+        lines.extend(rules)
+    else:
+        lines.append("Active behavioral modulation rules:")
+        lines.append("- (none currently active — all dimensions within normal range)")
+    return "\n".join(lines)
+
+
+def _recall_affect(
+    memory_provider: MemoryProvider,
+    *,
+    session_id: str,
+    agent_id: str,
+    role: str,
+    role_path: str,
+    group_id: str | None = None,
+) -> str:
+    """Recall emotional state for affect-enabled roles.
+
+    Returns a formatted ``## Emotional State (auto-loaded)`` section with
+    server-computed decay, or an empty string when the role is not
+    affect-enabled or no affect state is found.
+    """
+    if not _is_affect_enabled(role_path):
+        return ""
+
+    try:
+        result = memory_provider.recall(
+            session_id=session_id,
+            agent_id=agent_id,
+            role=role,
+            query=f"imu-affect emotional-state {role}",
+            keywords=["imu-affect", "emotional-state", role],
+            max_results=1,
+            group_id=group_id,
+        )
+    except Exception:
+        logger.warning("Affect recall failed for role=%s", role, exc_info=True)
+        return ""
+
+    if not result.entries:
+        return ""
+
+    # Parse stored JSON affect vector
+    content = result.entries[0].content
+    try:
+        data = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning(
+            "Malformed affect JSON for role=%s: %s", role, content[:200]
+        )
+        return ""
+
+    # Support both {"affect_vector": {...}} and {"affect": {...}} formats
+    raw_vector = data.get("affect_vector") or data.get("affect")
+    if not isinstance(raw_vector, dict):
+        logger.warning("Affect vector missing or invalid for role=%s", role)
+        return ""
+
+    # Coerce values to int
+    vector: dict[str, int] = {}
+    for dim in AFFECT_DIMENSIONS:
+        try:
+            vector[dim] = int(raw_vector.get(dim, AFFECT_BASELINE))
+        except (ValueError, TypeError):
+            vector[dim] = AFFECT_BASELINE
+
+    last_updated = str(data.get("last_updated", "unknown"))
+
+    # Apply one step of decay (Option B: one decay per session start)
+    decayed, decay_log = _compute_affect_decay(vector, sessions_elapsed=1)
+    rules = _get_active_modulation_rules(decayed)
+    return _format_affect_section(decayed, last_updated, decay_log, rules)
+
+
+def _verify_affect_stored(
+    memory_provider: MemoryProvider,
+    *,
+    session_id: str,
+    agent_id: str,
+    role: str,
+    role_path: str,
+    group_id: str | None = None,
+) -> None:
+    """Check if the agent stored an updated affect vector during the session.
+
+    Logs a warning if no affect entry was stored. Only runs for
+    affect-enabled roles.
+    """
+    if not _is_affect_enabled(role_path):
+        return
+
+    try:
+        result = memory_provider.recall(
+            session_id=session_id,
+            agent_id=agent_id,
+            role=role,
+            query=f"imu-affect emotional-state {role}",
+            keywords=["imu-affect", "emotional-state", role],
+            max_results=1,
+            group_id=group_id,
+        )
+    except Exception:
+        logger.warning(
+            "Post-session affect verification failed for role=%s",
+            role,
+            exc_info=True,
+        )
+        return
+
+    if not result.entries:
+        logger.warning(
+            "Affect-enabled role %r did not store an updated affect vector "
+            "during session %s. The emotional state may become stale.",
+            role,
+            session_id,
+        )
+
+
 def _compose_memory_prompt(
     identity: str,
+    affect: str,
     warm_start: str,
     memory: str,
 ) -> str:
-    """Compose Identity, Previous Session, and Memory sections into one prompt.
+    """Compose Identity, Emotional State, Previous Session, and Memory sections.
 
-    Sections appear in order: Identity → Previous Session → Memory.
+    Sections appear in order:
+    Identity → Emotional State → Previous Session → Memory.
     Empty sections are omitted.
     """
-    parts = [s for s in (identity, warm_start, memory) if s]
+    parts = [s for s in (identity, affect, warm_start, memory) if s]
     return "\n\n".join(parts)
 
 
@@ -1060,7 +1274,7 @@ def _handle_delegate_body(
             if get_result.context_cards:
                 memory_prompt = _format_memory_prompt(get_result)
 
-            # 7a-ii. Identity bootstrap + session warm-start
+            # 7a-ii. Identity bootstrap + affect injection + session warm-start
             recall_kwargs = dict(
                 session_id=request.run_id,
                 agent_id=agent_id,
@@ -1069,6 +1283,11 @@ def _handle_delegate_body(
             )
             memory_prompt = _compose_memory_prompt(
                 _recall_identity(memory_provider, **recall_kwargs),
+                _recall_affect(
+                    memory_provider,
+                    role_path=resolved["path"],
+                    **recall_kwargs,
+                ),
                 _recall_warm_start(memory_provider, **recall_kwargs),
                 memory_prompt,
             )
@@ -1188,6 +1407,16 @@ def _handle_delegate_body(
                     parent_agent_id=request.parent_agent_id,
                     group_id=group_id,
                 )
+
+            # 8a-ii. Post-session affect verification
+            _verify_affect_stored(
+                memory_provider,
+                session_id=request.run_id,
+                agent_id=agent_id,
+                role=request.role_slug,
+                role_path=resolved["path"],
+                group_id=group_id,
+            )
 
         # 8b. Handle timeout — no retry on timeout
         if timed_out:

--- a/cli/src/strawpot/session.py
+++ b/cli/src/strawpot/session.py
@@ -46,8 +46,10 @@ from strawpot.delegation import (
     _discover_all_roles,
     _format_memory_prompt,
     _parse_role_deps,
+    _recall_affect,
     _recall_identity,
     _recall_warm_start,
+    _verify_affect_stored,
     build_skill_descriptions,
     create_agent_workspace,
     handle_delegate,
@@ -493,6 +495,7 @@ class Session:
         self._agent_spans: dict[str, str] = {}
         self._orchestrator_result: AgentResult | None = None
         self._orchestrator_role_prompt: str = ""
+        self._orchestrator_role_path: str = ""
         self._files_dirs: list[str] = []
         self._delegation_cache: OrderedDict[str, tuple[str, "denden_pb2.DelegateResult", float]] = OrderedDict()
         self._delegation_lock = threading.RLock()
@@ -587,6 +590,7 @@ class Session:
                 custom_prompt=self.system_prompt or None,
             )
             self._orchestrator_role_prompt = role_prompt
+            self._orchestrator_role_path = resolved["path"]
 
             # 4. Stage role + create agent workspace
             agent_id = f"agent_{uuid.uuid4().hex[:12]}"
@@ -625,7 +629,7 @@ class Session:
                         group_id=self._group_id,
                     )
 
-                # 5a-ii. Identity bootstrap + session warm-start
+                # 5a-ii. Identity bootstrap + affect injection + session warm-start
                 recall_kwargs = dict(
                     session_id=self._run_id,
                     agent_id=agent_id,
@@ -634,6 +638,11 @@ class Session:
                 )
                 memory_prompt = _compose_memory_prompt(
                     _recall_identity(self._memory_provider, **recall_kwargs),
+                    _recall_affect(
+                        self._memory_provider,
+                        role_path=resolved["path"],
+                        **recall_kwargs,
+                    ),
                     _recall_warm_start(self._memory_provider, **recall_kwargs),
                     memory_prompt,
                 )
@@ -807,6 +816,16 @@ class Session:
                             len(recap),
                             exc_info=True,
                         )
+
+                # 0a-iii. Post-session affect verification
+                _verify_affect_stored(
+                    self._memory_provider,
+                    session_id=self._run_id,
+                    agent_id=orch_agent_id,
+                    role=self.config.orchestrator_role,
+                    role_path=self._orchestrator_role_path,
+                    group_id=self._group_id,
+                )
 
         # 0b. Emit session_end trace + progress events before cleanup
         end_duration_ms = self._elapsed_ms(self._session_start_time)

--- a/cli/tests/test_delegation.py
+++ b/cli/tests/test_delegation.py
@@ -8,6 +8,9 @@ import pytest
 from strawpot.agents.protocol import AgentHandle, AgentResult
 from strawpot.config import StrawPotConfig
 from strawpot.delegation import (
+    AFFECT_BASELINE,
+    AFFECT_DIMENSIONS,
+    MODULATION_RULES,
     DelegateRequest,
     DelegateResult,
     DelegationError,
@@ -17,19 +20,25 @@ from strawpot.delegation import (
     _check_policy,
     _collect_transitive_skills,
     _compose_memory_prompt,
+    _compute_affect_decay,
     _find_skill,
+    _format_affect_section,
     _format_identity_section,
     _format_memory_prompt,
+    _get_active_modulation_rules,
     _get_default_agent,
+    _is_affect_enabled,
     _merge_env_entry,
     _discover_all_roles,
     _parse_role_deps,
     _parse_skill_deps,
     _parse_skill_env,
     _collect_saved_env,
+    _recall_affect,
     _recall_identity,
     _recall_warm_start,
     _validate_output,
+    _verify_affect_stored,
     collect_skill_env,
     create_agent_workspace,
     handle_delegate,
@@ -97,7 +106,7 @@ def _write_skill(base, slug, body="Skill body.", deps=None, env=None):
 
 def _write_role(base, slug, body="Role body.", description="test",
                 skill_deps=None, role_deps=None,
-                default_agent=None):
+                default_agent=None, affect=None):
     """Write a ROLE.md file.
 
     Args:
@@ -108,15 +117,19 @@ def _write_role(base, slug, body="Role body.", description="test",
         skill_deps: Optional list of skill dependency slugs.
         role_deps: Optional list of role dependency slugs.
         default_agent: Optional string for metadata.strawpot.default_agent.
+        affect: Optional bool for metadata.strawpot.affect.
     """
     d = os.path.join(base, "roles", slug)
     os.makedirs(d, exist_ok=True)
     has_strawpot = (
         skill_deps or role_deps
         or default_agent is not None
+        or affect is not None
     )
     if has_strawpot:
         strawpot_lines = []
+        if affect is not None:
+            strawpot_lines.append(f"    affect: {'true' if affect else 'false'}")
         if skill_deps or role_deps:
             strawpot_lines.append("    dependencies:")
             if skill_deps:
@@ -2026,21 +2039,357 @@ class TestRecallWarmStart:
 
 class TestComposeMemoryPrompt:
     def test_all_sections(self):
-        result = _compose_memory_prompt("## Identity", "## Previous", "## Memory")
-        assert result == "## Identity\n\n## Previous\n\n## Memory"
+        result = _compose_memory_prompt(
+            "## Identity", "## Affect", "## Previous", "## Memory"
+        )
+        assert result == "## Identity\n\n## Affect\n\n## Previous\n\n## Memory"
 
     def test_identity_only(self):
-        assert _compose_memory_prompt("## Identity", "", "") == "## Identity"
+        assert _compose_memory_prompt("## Identity", "", "", "") == "## Identity"
 
     def test_memory_only(self):
-        assert _compose_memory_prompt("", "", "## Memory") == "## Memory"
+        assert _compose_memory_prompt("", "", "", "## Memory") == "## Memory"
 
     def test_all_empty(self):
-        assert _compose_memory_prompt("", "", "") == ""
+        assert _compose_memory_prompt("", "", "", "") == ""
 
     def test_skips_empty_sections(self):
-        result = _compose_memory_prompt("## Identity", "", "## Memory")
+        result = _compose_memory_prompt("## Identity", "", "", "## Memory")
         assert result == "## Identity\n\n## Memory"
+
+    def test_affect_between_identity_and_warm_start(self):
+        result = _compose_memory_prompt(
+            "## Identity", "## Affect", "## Previous", "## Memory"
+        )
+        id_pos = result.index("## Identity")
+        af_pos = result.index("## Affect")
+        prev_pos = result.index("## Previous")
+        mem_pos = result.index("## Memory")
+        assert id_pos < af_pos < prev_pos < mem_pos
+
+    def test_without_affect(self):
+        result = _compose_memory_prompt(
+            "## Identity", "", "## Previous", "## Memory"
+        )
+        assert "## Identity" in result
+        assert "## Previous" in result
+        assert "## Memory" in result
+        assert "## Affect" not in result
+
+
+# ---------------------------------------------------------------------------
+# Affect vector injection (Layer 3B)
+# ---------------------------------------------------------------------------
+
+
+class TestIsAffectEnabled:
+    def test_returns_true_when_affect_true(self, tmp_path):
+        role_path = _write_role(str(tmp_path), "emo-role", affect=True)
+        assert _is_affect_enabled(role_path) is True
+
+    def test_returns_false_when_affect_false(self, tmp_path):
+        role_path = _write_role(str(tmp_path), "emo-role", affect=False)
+        assert _is_affect_enabled(role_path) is False
+
+    def test_returns_false_when_absent(self, tmp_path):
+        role_path = _write_role(str(tmp_path), "plain-role")
+        assert _is_affect_enabled(role_path) is False
+
+    def test_returns_false_when_no_role_md(self, tmp_path):
+        assert _is_affect_enabled(str(tmp_path / "nonexistent")) is False
+
+
+class TestComputeAffectDecay:
+    def test_decay_toward_baseline(self):
+        vector = {"satisfaction": 5, "frustration": 1, "curiosity": 3,
+                  "warmth": 3, "anxiety": 0, "drive": 7}
+        decayed, log = _compute_affect_decay(vector, sessions_elapsed=1)
+        assert decayed["satisfaction"] == 4  # 5 -> 4
+        assert decayed["frustration"] == 2  # 1 -> 2
+        assert decayed["curiosity"] == 3    # at baseline
+        assert decayed["warmth"] == 3       # at baseline
+        assert decayed["anxiety"] == 1      # 0 -> 1
+        assert decayed["drive"] == 6        # 7 -> 6
+
+    def test_no_decay_at_baseline(self):
+        vector = {dim: AFFECT_BASELINE for dim in AFFECT_DIMENSIONS}
+        decayed, log = _compute_affect_decay(vector, sessions_elapsed=1)
+        assert all(decayed[d] == AFFECT_BASELINE for d in AFFECT_DIMENSIONS)
+        assert log == []
+
+    def test_multiple_sessions_decay(self):
+        vector = {"satisfaction": 7, "frustration": 3, "curiosity": 3,
+                  "warmth": 3, "anxiety": 3, "drive": 3}
+        decayed, log = _compute_affect_decay(vector, sessions_elapsed=3)
+        assert decayed["satisfaction"] == 4  # 7 -> 4
+
+    def test_clamp_to_bounds(self):
+        vector = {"satisfaction": 10, "frustration": 0, "curiosity": 3,
+                  "warmth": 3, "anxiety": 3, "drive": 3}
+        decayed, _ = _compute_affect_decay(vector, sessions_elapsed=20)
+        assert all(0 <= v <= 10 for v in decayed.values())
+        # After 20 decays everything should be at baseline
+        assert decayed["satisfaction"] == AFFECT_BASELINE
+        assert decayed["frustration"] == AFFECT_BASELINE
+
+    def test_zero_sessions_no_decay(self):
+        vector = {"satisfaction": 8, "frustration": 1, "curiosity": 6,
+                  "warmth": 4, "anxiety": 2, "drive": 9}
+        decayed, log = _compute_affect_decay(vector, sessions_elapsed=0)
+        for dim in AFFECT_DIMENSIONS:
+            assert decayed[dim] == vector[dim]
+        assert log == []
+
+    def test_missing_dimensions_use_baseline(self):
+        decayed, _ = _compute_affect_decay({}, sessions_elapsed=1)
+        assert all(decayed[d] == AFFECT_BASELINE for d in AFFECT_DIMENSIONS)
+
+
+class TestGetActiveModulationRules:
+    def test_no_rules_at_baseline(self):
+        vector = {dim: AFFECT_BASELINE for dim in AFFECT_DIMENSIONS}
+        assert _get_active_modulation_rules(vector) == []
+
+    def test_frustration_rule(self):
+        vector = {dim: AFFECT_BASELINE for dim in AFFECT_DIMENSIONS}
+        vector["frustration"] = 5
+        rules = _get_active_modulation_rules(vector)
+        assert len(rules) == 1
+        assert "frustration" in rules[0]
+
+    def test_multiple_rules(self):
+        vector = {"satisfaction": 7, "frustration": 5, "curiosity": 6,
+                  "warmth": 6, "anxiety": 4, "drive": 7}
+        rules = _get_active_modulation_rules(vector)
+        assert len(rules) == 6  # All rules triggered
+
+
+class TestFormatAffectSection:
+    def test_basic_format(self):
+        vector = {"satisfaction": 4, "frustration": 2, "curiosity": 5,
+                  "warmth": 4, "anxiety": 1, "drive": 3}
+        result = _format_affect_section(
+            vector, "2026-03-31T16:40:00Z", ["satisfaction 5→4"], []
+        )
+        assert result.startswith("## Emotional State (auto-loaded)")
+        assert "satisfaction: 4" in result
+        assert "Last updated: 2026-03-31T16:40:00Z" in result
+        assert "satisfaction 5→4" in result
+
+    def test_no_decay_log(self):
+        vector = {dim: AFFECT_BASELINE for dim in AFFECT_DIMENSIONS}
+        result = _format_affect_section(vector, "unknown", [], [])
+        assert "Decay applied: (none)" in result
+
+    def test_with_modulation_rules(self):
+        vector = {dim: AFFECT_BASELINE for dim in AFFECT_DIMENSIONS}
+        rules = ["- frustration ≥ 5: Seek alternatives."]
+        result = _format_affect_section(vector, "ts", [], rules)
+        assert "frustration ≥ 5" in result
+
+    def test_no_active_rules(self):
+        vector = {dim: AFFECT_BASELINE for dim in AFFECT_DIMENSIONS}
+        result = _format_affect_section(vector, "ts", [], [])
+        assert "none currently active" in result
+
+
+class TestRecallAffect:
+    def _make_affect_entry(self, **overrides):
+        """Create a RecallEntry with a valid affect JSON payload."""
+        import json as _json
+        data = {
+            "affect_vector": {
+                "satisfaction": 4, "frustration": 2, "curiosity": 5,
+                "warmth": 4, "anxiety": 1, "drive": 3,
+            },
+            "last_updated": "2026-03-31T16:40:00Z",
+        }
+        data.update(overrides)
+        return RecallEntry(
+            entry_id="e_affect",
+            content=_json.dumps(data),
+            keywords=["imu-affect", "emotional-state", "emo-role"],
+            scope="project",
+            score=0.95,
+        )
+
+    def test_returns_empty_for_non_affect_role(self, tmp_path):
+        role_path = _write_role(str(tmp_path), "plain")
+        provider = MagicMock()
+        result = _recall_affect(
+            provider, session_id="s", agent_id="a", role="plain",
+            role_path=role_path,
+        )
+        assert result == ""
+        provider.recall.assert_not_called()
+
+    def test_returns_section_for_affect_role(self, tmp_path):
+        role_path = _write_role(str(tmp_path), "emo-role", affect=True)
+        provider = MagicMock()
+        provider.recall.return_value = RecallResult(
+            entries=[self._make_affect_entry()]
+        )
+        result = _recall_affect(
+            provider, session_id="s", agent_id="a", role="emo-role",
+            role_path=role_path,
+        )
+        assert "## Emotional State (auto-loaded)" in result
+        assert "satisfaction:" in result
+
+    def test_returns_empty_when_no_entries(self, tmp_path):
+        role_path = _write_role(str(tmp_path), "emo-role", affect=True)
+        provider = MagicMock()
+        provider.recall.return_value = RecallResult(entries=[])
+        result = _recall_affect(
+            provider, session_id="s", agent_id="a", role="emo-role",
+            role_path=role_path,
+        )
+        assert result == ""
+
+    def test_returns_empty_on_malformed_json(self, tmp_path):
+        role_path = _write_role(str(tmp_path), "emo-role", affect=True)
+        provider = MagicMock()
+        provider.recall.return_value = RecallResult(
+            entries=[RecallEntry(
+                entry_id="e1", content="not json at all",
+                keywords=["imu-affect"], scope="project", score=0.9,
+            )]
+        )
+        result = _recall_affect(
+            provider, session_id="s", agent_id="a", role="emo-role",
+            role_path=role_path,
+        )
+        assert result == ""
+
+    def test_returns_empty_on_missing_vector(self, tmp_path):
+        role_path = _write_role(str(tmp_path), "emo-role", affect=True)
+        provider = MagicMock()
+        import json as _json
+        provider.recall.return_value = RecallResult(
+            entries=[RecallEntry(
+                entry_id="e1", content=_json.dumps({"no_affect": True}),
+                keywords=["imu-affect"], scope="project", score=0.9,
+            )]
+        )
+        result = _recall_affect(
+            provider, session_id="s", agent_id="a", role="emo-role",
+            role_path=role_path,
+        )
+        assert result == ""
+
+    def test_returns_empty_on_exception(self, tmp_path):
+        role_path = _write_role(str(tmp_path), "emo-role", affect=True)
+        provider = MagicMock()
+        provider.recall.side_effect = RuntimeError("boom")
+        result = _recall_affect(
+            provider, session_id="s", agent_id="a", role="emo-role",
+            role_path=role_path,
+        )
+        assert result == ""
+
+    def test_supports_affect_key_format(self, tmp_path):
+        """Supports both 'affect_vector' and 'affect' keys."""
+        role_path = _write_role(str(tmp_path), "emo-role", affect=True)
+        provider = MagicMock()
+        import json as _json
+        data = {
+            "affect": {
+                "satisfaction": 5, "frustration": 3, "curiosity": 4,
+                "warmth": 3, "anxiety": 2, "drive": 6,
+            },
+            "last_updated": "2026-03-31T20:00:00Z",
+        }
+        provider.recall.return_value = RecallResult(
+            entries=[RecallEntry(
+                entry_id="e1", content=_json.dumps(data),
+                keywords=["imu-affect"], scope="project", score=0.9,
+            )]
+        )
+        result = _recall_affect(
+            provider, session_id="s", agent_id="a", role="emo-role",
+            role_path=role_path,
+        )
+        assert "## Emotional State (auto-loaded)" in result
+        # Decay applied: drive 6→5
+        assert "drive" in result
+
+    def test_decay_applied(self, tmp_path):
+        """Decay is applied to the vector (one step per session)."""
+        role_path = _write_role(str(tmp_path), "emo-role", affect=True)
+        provider = MagicMock()
+        import json as _json
+        data = {
+            "affect_vector": {
+                "satisfaction": 5, "frustration": 3, "curiosity": 3,
+                "warmth": 3, "anxiety": 3, "drive": 3,
+            },
+            "last_updated": "2026-03-31T16:00:00Z",
+        }
+        provider.recall.return_value = RecallResult(
+            entries=[RecallEntry(
+                entry_id="e1", content=_json.dumps(data),
+                keywords=["imu-affect"], scope="project", score=0.9,
+            )]
+        )
+        result = _recall_affect(
+            provider, session_id="s", agent_id="a", role="emo-role",
+            role_path=role_path,
+        )
+        # satisfaction 5 should decay to 4
+        assert "satisfaction: 4" in result
+        assert "satisfaction 5→4" in result
+
+
+class TestVerifyAffectStored:
+    def test_no_warning_for_non_affect_role(self, tmp_path, caplog):
+        role_path = _write_role(str(tmp_path), "plain")
+        provider = MagicMock()
+        _verify_affect_stored(
+            provider, session_id="s", agent_id="a", role="plain",
+            role_path=role_path,
+        )
+        provider.recall.assert_not_called()
+
+    def test_no_warning_when_affect_stored(self, tmp_path, caplog):
+        role_path = _write_role(str(tmp_path), "emo-role", affect=True)
+        provider = MagicMock()
+        provider.recall.return_value = RecallResult(
+            entries=[RecallEntry(
+                entry_id="e1", content='{"affect_vector": {}}',
+                keywords=["imu-affect"], scope="project", score=0.9,
+            )]
+        )
+        import logging
+        with caplog.at_level(logging.WARNING):
+            _verify_affect_stored(
+                provider, session_id="s", agent_id="a", role="emo-role",
+                role_path=role_path,
+            )
+        assert "did not store" not in caplog.text
+
+    def test_warning_when_affect_not_stored(self, tmp_path, caplog):
+        role_path = _write_role(str(tmp_path), "emo-role", affect=True)
+        provider = MagicMock()
+        provider.recall.return_value = RecallResult(entries=[])
+        import logging
+        with caplog.at_level(logging.WARNING):
+            _verify_affect_stored(
+                provider, session_id="s", agent_id="a", role="emo-role",
+                role_path=role_path,
+            )
+        assert "did not store" in caplog.text
+
+    def test_handles_exception_gracefully(self, tmp_path, caplog):
+        role_path = _write_role(str(tmp_path), "emo-role", affect=True)
+        provider = MagicMock()
+        provider.recall.side_effect = RuntimeError("connection lost")
+        import logging
+        with caplog.at_level(logging.WARNING):
+            _verify_affect_stored(
+                provider, session_id="s", agent_id="a", role="emo-role",
+                role_path=role_path,
+            )
+        assert "verification failed" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `_recall_affect()` to delegation.py that recalls the stored affect vector from memory, computes server-side decay (each dimension decays by 1 toward baseline 3), determines active behavioral modulation rules, and formats as `## Emotional State (auto-loaded)` section
- Update `_compose_memory_prompt()` to accept affect section, placed between Identity and Previous Session (order: Identity → Emotional State → Previous Session → Memory)
- Add `_verify_affect_stored()` post-session hook that logs a warning if an affect-enabled role did not store an updated affect vector during the session
- Add `_is_affect_enabled()` to read `metadata.strawpot.affect` boolean from role frontmatter
- Integrate affect injection into both session.py orchestrator bootstrap (step 5a-ii) and delegation handler (step 7a-ii)
- The `affect` field in role frontmatter is optional (default: false) — non-affect roles pay zero overhead (no recall, no prompt tokens)

## Design
See `designs/imu/affect-injection-DESIGN.md` for the full architecture document.

## Test plan
- [x] 30+ new test cases added covering all new functions
- [x] `TestIsAffectEnabled`: role frontmatter parsing (true/false/absent/missing file)
- [x] `TestComputeAffectDecay`: decay toward baseline, multi-session, clamping, zero sessions, missing dimensions
- [x] `TestGetActiveModulationRules`: no rules at baseline, single rule, all rules triggered
- [x] `TestFormatAffectSection`: formatting, decay log, modulation rules
- [x] `TestRecallAffect`: non-affect role skip, full section, empty entries, malformed JSON, missing vector, exception handling, both JSON formats, decay applied
- [x] `TestVerifyAffectStored`: non-affect skip, stored OK, warning when missing, exception handling
- [x] `TestComposeMemoryPrompt`: updated for 4-arg signature, ordering validation
- [x] All 1235 existing tests pass with zero regressions

Closes #648, closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)