### PR TITLE
Security & maintenance dependency updates

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -30,8 +30,6 @@ dependencies = [
     # Security: pin minimum versions for transitive dependencies
     "cryptography>=46.0.6",
     "certifi>=2026.2.25",
-    # Core SDK: keep in sync with ecosystem
-    "anthropic>=0.88.0",
 ]
 
 [project.urls]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -20,13 +20,18 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1",
-    "croniter>=1.0",
+    "croniter>=6.2.2",
     "mcp>=1.0",
     "pyyaml>=6.0",
     "tomli_w>=1.0",
     "strawhub",
     "strawpot-memory",
     "denden-server",
+    # Security: pin minimum versions for transitive dependencies
+    "cryptography>=46.0.6",
+    "certifi>=2026.2.25",
+    # Core SDK: keep in sync with ecosystem
+    "anthropic>=0.88.0",
 ]
 
 [project.urls]
@@ -46,6 +51,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-cov>=6.0",
+    "coverage>=7.13.5",
     "pytest-timeout>=2.0",
     "pyinstaller>=6.0",
 ]

--- a/gui/pyproject.toml
+++ b/gui/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "tomli_w>=1.0",
     "watchfiles>=1.0",
     "python-multipart>=0.0.9",
-    "croniter>=2.0",
+    "croniter>=6.2.2",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- **cryptography** 44.0.1 → 46.0.6 — SECURITY: 2 major versions behind, addresses known CVEs
- **certifi** 2025.1.31 → 2026.2.25 — SECURITY: updated CA certificate bundle
- **anthropic** 0.83.0 → 0.88.0 — core SDK update for agent ecosystem compatibility
- **croniter** 6.0.0 → 6.2.2 — schedule engine bugfixes (direct dep in both cli and gui)
- **coverage** 7.13.4 → 7.13.5 — minor dev tooling update

`cryptography` and `certifi` are added as explicit direct dependencies in `cli/pyproject.toml` to enforce minimum versions for these security-critical transitive packages. `croniter` minimum version updated in both `cli/pyproject.toml` and `gui/pyproject.toml`.

## Test plan
- [x] All 1235 CLI tests pass
- [x] All 574 GUI tests pass (1 pre-existing failure on main excluded)
- [x] Packages installed and verified at target versions
- [x] No breaking API changes detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)